### PR TITLE
Add Firestore integration for user approvals

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,0 +1,13 @@
+import { initializeApp, getApps, getApp } from 'firebase/app';
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+};
+
+export const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
+


### PR DESCRIPTION
## Summary
- initialize Firebase client in `src/lib/firebase.ts`
- implement Firestore queries on the user approvals page
- fetch pending users and approve them with Firestore updates

## Testing
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684625bc33dc83249ea01971353aded3