### PR TITLE
Implement Firestore user approvals and navigation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
 # Firebase Studio
 
-This is a NextJS starter in Firebase Studio.
+This project is a Next.js starter created with Firebase Studio.
 
-To get started, take a look at src/app/page.tsx.
+## Getting Started
+
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+
+2. **Run the development server**
+   ```bash
+   npm run dev
+   ```
+
+3. **Type checking and linting**
+   ```bash
+   npm run typecheck
+   npm run lint
+   ```
+
+For more details about the planned features, see [docs/blueprint.md](docs/blueprint.md).

--- a/src/app/(app)/patients/[id]/page.tsx
+++ b/src/app/(app)/patients/[id]/page.tsx
@@ -11,6 +11,7 @@ import PatientTimeline from "@/components/patients/patient-timeline";
 import SessionNoteCard from "@/components/patients/session-note-card";
 import ResourceCard from "@/components/resources/resource-card";
 import AssessmentCard from "@/components/assessments/assessment-card";
+import { useRouter } from "next/navigation";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -58,8 +59,9 @@ const mockResources = [
 
 
 export default function PatientDetailPage({ params }: { params: { id: string } }) {
-  const patient = mockPatient; 
+  const patient = mockPatient;
   const { toast } = useToast();
+  const router = useRouter();
 
   const getInitials = (name: string) => {
     const names = name.split(' ');
@@ -82,7 +84,7 @@ export default function PatientDetailPage({ params }: { params: { id: string } }
       description: `${patient.name} foi excluído(a) permanentemente.`,
       variant: "destructive",
     });
-    // TODO: router.push("/patients"); ou similar após exclusão real
+    router.push("/patients");
   };
 
   const formattedDob = patient.dob ? format(new Date(patient.dob), "P", { locale: ptBR }) : "N/A";

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,0 +1,22 @@
+import { initializeApp, getApps, getApp } from "firebase/app";
+import { getFirestore } from "firebase/firestore";
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+};
+
+function createFirebaseApp() {
+  if (!getApps().length) {
+    return initializeApp(firebaseConfig);
+  }
+  return getApp();
+}
+
+const app = createFirebaseApp();
+export const db = getFirestore(app);
+


### PR DESCRIPTION
## Summary
- hook up Firebase Firestore
- load and approve users in the approvals page
- redirect back to `/patients` after deleting a patient
- expand README with setup instructions

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run typecheck` *(fails: multiple TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68462323829883248693d5c18b52da98