### PR TITLE
Fix missing import

### DIFF
--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -1,0 +1,2 @@
+'use strict';
+module.exports = require('./eslint-rules');

--- a/src/components/schedule/appointment-calendar.tsx
+++ b/src/components/schedule/appointment-calendar.tsx
@@ -19,6 +19,7 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
+  AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import {
   DropdownMenu,


### PR DESCRIPTION
## Summary
- add `AlertDialogTrigger` import in `appointment-calendar`
- create `eslint-local-rules.js` to load custom ESLint rules

## Testing
- `npm run lint` *(fails: Definition for rule '@next/next/link-passhref' was not found)*
- `npm run typecheck` *(fails to compile TypeScript)*

------
https://chatgpt.com/codex/tasks/task_e_684765ce57a88324a421b9619a18c589