### PR TITLE
Implement patient hub navigation

### DIFF
--- a/src/app/(app)/patients/[id]/page.tsx
+++ b/src/app/(app)/patients/[id]/page.tsx
@@ -12,6 +12,7 @@ import SessionNoteCard from "@/components/patients/session-note-card";
 import ResourceCard from "@/components/resources/resource-card";
 import AssessmentCard from "@/components/assessments/assessment-card";
 import InfoItem from "@/components/patients/info-item";
+import { mockPatients, type MockPatient } from "@/mocks/patients";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -152,9 +153,26 @@ const mockPatientTasks: PatientTask[] = [
 
 
 export default function PatientDetailPage({ params }: { params: { id: string } }) {
-  const patient = mockPatient; 
+  const patient: MockPatient | undefined = useMemo(
+    () => mockPatients.find(p => p.id === params.id),
+    [params.id]
+  );
   const router = useRouter();
   const { toast } = useToast();
+
+  if (!patient) {
+    return (
+      <div className="space-y-6 text-center py-10">
+        <UsersIconLucide className="mx-auto h-16 w-16 text-destructive" />
+        <h1 className="text-3xl font-headline font-bold text-destructive">
+          Paciente não encontrado
+        </h1>
+        <Button variant="outline" asChild>
+          <Link href="/patients">Voltar para Pacientes</Link>
+        </Button>
+      </div>
+    );
+  }
 
   const [sessionNotes, setSessionNotes] = useState(initialSessionNotes);
   const [assessments, setAssessments] = useState(initialAssessments);
@@ -301,6 +319,9 @@ export default function PatientDetailPage({ params }: { params: { id: string } }
 
   return (
     <div className="space-y-6">
+      <Button variant="outline" asChild>
+        <Link href="/patients">← Voltar para Pacientes</Link>
+      </Button>
       <Card className="shadow-sm overflow-hidden">
         <CardHeader className="bg-muted/30 p-6">
           <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4">

--- a/src/app/(app)/patients/page.tsx
+++ b/src/app/(app)/patients/page.tsx
@@ -4,13 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { UserPlus, Search, Filter, Users } from "lucide-react";
 import Link from "next/link";
 import PatientListItem from "@/components/patients/patient-list-item";
-
-const mockPatients = [
-  { id: "1", name: "Alice Wonderland", email: "alice@example.com", lastSession: "2024-07-15", nextAppointment: "2024-07-22", avatarUrl: "https://placehold.co/100x100/D0BFFF/4F3A76?text=AW", dataAiHint: "female avatar" },
-  { id: "2", name: "Bob O Construtor", email: "bob@example.com", lastSession: "2024-07-10", nextAppointment: "2024-07-20", avatarUrl: "https://placehold.co/100x100/70C1B3/FFFFFF?text=BB", dataAiHint: "male avatar" },
-  { id: "3", name: "Charlie Brown", email: "charlie@example.com", lastSession: "2024-07-12", nextAppointment: "2024-07-25", avatarUrl: "https://placehold.co/100x100/D0BFFF/4F3A76?text=CB", dataAiHint: "child avatar" },
-  { id: "4", name: "Diana Prince", email: "diana@example.com", lastSession: "2024-07-18", nextAppointment: null, avatarUrl: "https://placehold.co/100x100/70C1B3/FFFFFF?text=DP", dataAiHint: "female hero" },
-];
+import { mockPatients } from "@/mocks/patients";
 
 export default function PatientsPage() {
   return (

--- a/src/mocks/patients.ts
+++ b/src/mocks/patients.ts
@@ -1,0 +1,7 @@
+export const mockPatients = [
+  { id: "1", name: "Alice Wonderland", email: "alice@example.com", lastSession: "2024-07-15", nextAppointment: "2024-07-22", avatarUrl: "https://placehold.co/100x100/D0BFFF/4F3A76?text=AW", dataAiHint: "female avatar" },
+  { id: "2", name: "Bob O Construtor", email: "bob@example.com", lastSession: "2024-07-10", nextAppointment: "2024-07-20", avatarUrl: "https://placehold.co/100x100/70C1B3/FFFFFF?text=BB", dataAiHint: "male avatar" },
+  { id: "3", name: "Charlie Brown", email: "charlie@example.com", lastSession: "2024-07-12", nextAppointment: "2024-07-25", avatarUrl: "https://placehold.co/100x100/D0BFFF/4F3A76?text=CB", dataAiHint: "child avatar" },
+  { id: "4", name: "Diana Prince", email: "diana@example.com", lastSession: "2024-07-18", nextAppointment: null, avatarUrl: "https://placehold.co/100x100/70C1B3/FFFFFF?text=DP", dataAiHint: "female hero" },
+];
+export type MockPatient = (typeof mockPatients)[number];


### PR DESCRIPTION
## Summary
- move patient mock data to new `src/mocks/patients.ts`
- load mock data on patient listing page
- fetch patient by id in detail page
- handle not found and add back link

## Testing
- `npm run lint` *(fails: Definition for rule '@next/next/link-passhref' was not found)*
- `npm run typecheck` *(fails with multiple TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_684773b3ed908324bb2ca1b5fd18bb04