### PR TITLE
Add Jest setup and basic form component tests

### DIFF
--- a/__tests__/form-components.test.tsx
+++ b/__tests__/form-components.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import AppointmentForm from "@/components/forms/appointment-form";
+import GroupForm from "@/components/forms/group-form";
+import TaskForm from "@/components/forms/task-form";
+import TemplateEditor from "@/components/forms/template-editor";
+import CaseFormulationModelForm from "@/components/forms/case-formulation-model-form";
+
+// Mock router to prevent navigation issues
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  useSearchParams: () => new URLSearchParams(""),
+}));
+
+// Mock zod schemas if needed, or external API calls
+
+describe("Form Components", () => {
+  it("renders AppointmentForm without crashing", () => {
+    render(<AppointmentForm />);
+    expect(screen.getByRole("form")).toBeInTheDocument();
+  });
+
+  it("renders GroupForm without crashing", () => {
+    render(<GroupForm />);
+    expect(screen.getByRole("form")).toBeInTheDocument();
+  });
+
+  it("renders TaskForm without crashing", () => {
+    render(<TaskForm />);
+    expect(screen.getByRole("form")).toBeInTheDocument();
+  });
+
+  it("renders TemplateEditor without crashing", () => {
+    render(<TemplateEditor />);
+    expect(screen.getByText(/template/i)).toBeInTheDocument();
+  });
+
+  it("renders CaseFormulationModelForm without crashing", () => {
+    render(<CaseFormulationModelForm />);
+    expect(screen.getByRole("form")).toBeInTheDocument();
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
+};


### PR DESCRIPTION
## Summary
- configure Jest using ts-jest and jsdom
- add a test suite for form components

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a3f2fa0e08324a2059b088f1a13d7