### PR TITLE
Add firestore rules test using authenticatedContext

### DIFF
--- a/__tests__/firestore-rules.test.ts
+++ b/__tests__/firestore-rules.test.ts
@@ -1,0 +1,28 @@
+import { initializeTestEnvironment, assertSucceeds } from '@firebase/rules-unit-testing';
+import { readFileSync } from 'fs';
+import { Firestore } from 'firebase/firestore';
+
+let testEnv: Awaited<ReturnType<typeof initializeTestEnvironment>>;
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: 'demo-project',
+    firestore: {
+      rules: readFileSync('firestore.rules', 'utf8'),
+    },
+  });
+});
+
+afterAll(async () => {
+  await testEnv.cleanup();
+});
+
+function getAuthedDb(auth: { sub: string; role: string }): Firestore {
+  return testEnv.authenticatedContext(auth.sub, auth).firestore();
+}
+
+test('admin user can read other user profile', async () => {
+  const auth = { sub: 'user-id', role: 'admin' };
+  const db = getAuthedDb(auth);
+  await assertSucceeds(db.doc('users/otherUser').get());
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "zustand": "^4.5.4"
       },
       "devDependencies": {
+        "@firebase/rules-unit-testing": "^4.0.1",
         "@next/eslint-plugin-next": "^15.3.3",
         "@types/node": "^20",
         "@types/react": "^18",
@@ -1247,6 +1248,19 @@
       "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.4.0.tgz",
       "integrity": "sha512-7p3mRE/ldCNYt8fmWMQ/MSGRmXYlJ15Rvs9Rk17t8p0WwZDbeK7eRmoI1tvCPaDzn9Oqh+yD6Lw+sGLsLg4kKg==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/rules-unit-testing": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-4.0.1.tgz",
+      "integrity": "sha512-Vu8iMLP+dO9hCAqUCitWZQdORyM6CxucilRZtleeTZd5bejZmyOiaBPwYm3NOYG6025ac99CEeA+ETmJRxa9zg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "firebase": "^11.0.0"
+      }
     },
     "node_modules/@firebase/storage": {
       "version": "0.13.12",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "zustand": "^4.5.4"
   },
   "devDependencies": {
+    "@firebase/rules-unit-testing": "^4.0.1",
     "@next/eslint-plugin-next": "^15.3.3",
     "@types/node": "^20",
     "@types/react": "^18",


### PR DESCRIPTION
## Summary
- add `@firebase/rules-unit-testing` as dev dependency
- provide a sample Firestore rules test using `testEnv.authenticatedContext(auth.sub, auth)`

## Testing
- `npm run typecheck` *(fails: Cannot find name 'beforeAll' and other type errors)*
- `npm run lint` *(fails: several ESLint rule and parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a41afff388324a19d1a5d9d113095