### PR TITLE
Fix lint warnings and typing issues

### DIFF
--- a/src/app/(app)/admin/metrics/page.tsx
+++ b/src/app/(app)/admin/metrics/page.tsx
@@ -1,7 +1,7 @@
 
 "use client";
 
-import { BarChart3, Users, CalendarCheck, Clock, LineChart as LineChartIcon, UsersRound } from "lucide-react";
+import { BarChart3, Users, CalendarCheck, Clock } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import StatsCard from "@/components/dashboard/stats-card";
 import dynamic from "next/dynamic";
@@ -23,13 +23,6 @@ const mockAdminMetrics = {
   avgSessionDuration: 52, // minutes
 };
 
-// Mock data for sessions per week (can reuse structure of SessionsTrendChart)
-const sessionsPerWeekData = [
-  { month: "Semana 1", sessions: 120 },
-  { month: "Semana 2", sessions: 135 },
-  { month: "Semana 3", sessions: 110 },
-  { month: "Semana 4", sessions: 140 },
-];
 
 // Mock data for sessions per psychologist
 const sessionsPerPsychologistData = [

--- a/src/app/(app)/analytics/page.tsx
+++ b/src/app/(app)/analytics/page.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { BarChart3, Users, CalendarCheck, TrendingUp, PieChart as PieChartIcon, UsersRound, Activity as ActivityIcon } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import dynamic from "next/dynamic";

--- a/src/app/(app)/groups/[id]/page.tsx
+++ b/src/app/(app)/groups/[id]/page.tsx
@@ -106,7 +106,7 @@ export default function GroupDetailPage({ params }: { params: { id: string } }) 
                     <AlertDialogHeader>
                     <AlertDialogTitle>Excluir Grupo Permanentemente?</AlertDialogTitle>
                     <AlertDialogDescription>
-                        Esta ação não pode ser desfeita. Todos os dados associados ao grupo "{group.name}" serão removidos. Tem certeza?
+                        Esta ação não pode ser desfeita. Todos os dados associados ao grupo &quot;{group.name}&quot; serão removidos. Tem certeza?
                     </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>

--- a/src/app/(app)/groups/edit/[id]/page.tsx
+++ b/src/app/(app)/groups/edit/[id]/page.tsx
@@ -32,7 +32,7 @@ export default function EditGroupPage() {
           description: `Descrição para ${foundGroup.name}`, // Placeholder
           psychologistId: foundGroup.psychologist === "Dr. Silva" ? "psy1" : "psy2", // Placeholder
           patientIds: [], // Placeholder, needs actual patient IDs related to group
-          dayOfWeek: foundGroup.schedule.split(',')[0].toLowerCase() as any, // Placeholder
+          dayOfWeek: foundGroup.schedule.split(',')[0].toLowerCase() as GroupFormValues["dayOfWeek"], // Placeholder
           startTime: foundGroup.schedule.split(',')[1]?.trim().split(' - ')[0] || "00:00", // Placeholder
           endTime: foundGroup.schedule.split(',')[1]?.trim().split(' - ')[1] || "01:00", // Placeholder
         });

--- a/src/app/(app)/tools/case-formulation-models/page.tsx
+++ b/src/app/(app)/tools/case-formulation-models/page.tsx
@@ -128,7 +128,7 @@ export default function CaseFormulationModelsPage() {
                             <AlertDialogHeader>
                             <AlertDialogTitle>Excluir Modelo?</AlertDialogTitle>
                             <AlertDialogDescription>
-                                Tem certeza que deseja excluir o modelo "{template.name}"? Esta ação não pode ser desfeita.
+                                Tem certeza que deseja excluir o modelo &quot;{template.name}&quot;? Esta ação não pode ser desfeita.
                             </AlertDialogDescription>
                             </AlertDialogHeader>
                             <AlertDialogFooter>

--- a/src/app/(app)/tools/psychopharmacology/page.tsx
+++ b/src/app/(app)/tools/psychopharmacology/page.tsx
@@ -132,7 +132,7 @@ export default function PsychopharmacologyPage() {
           ) : (
              <div className="text-center py-10 text-muted-foreground">
                 <Pill className="mx-auto h-12 w-12" />
-                <p className="mt-2">Nenhum medicamento encontrado para "{searchTerm}".</p>
+                <p className="mt-2">Nenhum medicamento encontrado para &quot;{searchTerm}&quot;.</p>
                 <p className="text-xs">Tente refinar seus termos de busca.</p>
              </div>
            )}

--- a/src/app/(app)/user-approvals/page.tsx
+++ b/src/app/(app)/user-approvals/page.tsx
@@ -45,7 +45,7 @@ export default function UserApprovalsPage() {
 
     const unsubscribe: Unsubscribe = onSnapshot(q, (snapshot) => {
       const users = snapshot.docs.map(docSnap => {
-        const data = docSnap.data() as any;
+        const data = docSnap.data() as Record<string, unknown>;
         return {
           id: docSnap.id,
           name: data.name || "Nome não informado",

--- a/src/components/tasks/task-item.tsx
+++ b/src/components/tasks/task-item.tsx
@@ -135,7 +135,7 @@ function TaskItemComponent({ task }: TaskItemProps) {
                 <AlertDialogHeader>
                 <AlertDialogTitle>Excluir Tarefa?</AlertDialogTitle>
                 <AlertDialogDescription>
-                    Tem certeza que deseja excluir a tarefa "{task.title}"? Esta ação não pode ser desfeita.
+                    Tem certeza que deseja excluir a tarefa &quot;{task.title}&quot;? Esta ação não pode ser desfeita.
                 </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -462,7 +462,8 @@ const SidebarGroupAction = React.forwardRef<
   React.ComponentProps<"button"> & { asChild?: boolean }
 >(({ className, asChild = false, ...props }, ref) => {
   const Comp = asChild ? Slot : "button"
-   const finalProps = asChild ? props : (({ asChild: _asChild, ...restProps }) => restProps)(props as any);
+  const { asChild: _asChild, ...restProps } = props
+  const finalProps = asChild ? props : restProps
 
   return (
     <Comp
@@ -616,10 +617,11 @@ const SidebarMenuAction = React.forwardRef<
   React.ComponentProps<"button"> & {
     asChild?: boolean
     showOnHover?: boolean
-  }
+  } 
 >(({ className, asChild = false, showOnHover = false, ...props }, ref) => {
   const Comp = asChild ? Slot : "button"
-   const finalProps = asChild ? props : (({ asChild: _asChild, ...restProps }) => restProps)(props as any);
+  const { asChild: _asChild, ...restProps } = props
+  const finalProps = asChild ? props : restProps
 
   return (
     <Comp


### PR DESCRIPTION
## Summary
- remove unused imports and variables
- fix `any` casts in sidebar and groups
- escape quotes in various confirmation dialogs
- replace `CardFooter` unused import

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm run typecheck` *(fails: Type errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a45be6dc483248904ac924217ec1d