### PR TITLE
Improve AI service error handling

### DIFF
--- a/src/ai/flows/generate-session-insights.ts
+++ b/src/ai/flows/generate-session-insights.ts
@@ -1,5 +1,4 @@
-
-'use server';
+"use server";
 
 /**
  * @fileOverview Generates session insights from session notes using AI.
@@ -9,36 +8,70 @@
  * - GenerateSessionInsightsOutput - The return type for the generateSessionInsights function.
  */
 
-import {ai} from '@/ai/genkit';
-import {z} from 'genkit';
+import { ai } from "@/ai/genkit";
+import { z } from "genkit";
 
-const GenerateSessionInsightsInputSchema = z.object({
-  sessionNotes: z
+export const GenerateSessionInsightsInputSchema = z.object({
+  sessionNotes: z.string().describe("The session notes to analyze."),
+  patientHistorySummary: z
     .string()
-    .describe('The session notes to analyze.'),
-  patientHistorySummary: z.string().optional().describe('A brief summary of the patient relevant history and previous inventory results.'),
+    .optional()
+    .describe(
+      "A brief summary of the patient relevant history and previous inventory results.",
+    ),
 });
-export type GenerateSessionInsightsInput = z.infer<typeof GenerateSessionInsightsInputSchema>;
+export type GenerateSessionInsightsInput = z.infer<
+  typeof GenerateSessionInsightsInputSchema
+>;
 
-const GenerateSessionInsightsOutputSchema = z.object({
-  keywords: z.array(z.string()).describe('Keywords identified in the session notes.'),
-  themes: z.array(z.string()).describe('Themes identified in the session notes.'),
-  symptomEvolution: z.string().describe('Description of symptom evolution based on the notes.'),
-  suggestiveInsights: z.string().describe('Suggestive insights to improve understanding of patient progress.'),
-  therapeuticMilestones: z.array(z.string()).optional().describe('Identified significant therapeutic milestones or breakthroughs in the session.'),
-  inventoryComparisonInsights: z.string().optional().describe('Analysis comparing current session notes with past inventory responses and history to show evolution.'),
-  potentialRiskAlerts: z.array(z.string()).optional().describe('Subtle alerts based on language patterns or metric decline indicating potential risks (e.g., increased anxiety, depressive thoughts).'),
+export const GenerateSessionInsightsOutputSchema = z.object({
+  keywords: z
+    .array(z.string())
+    .describe("Keywords identified in the session notes."),
+  themes: z
+    .array(z.string())
+    .describe("Themes identified in the session notes."),
+  symptomEvolution: z
+    .string()
+    .describe("Description of symptom evolution based on the notes."),
+  suggestiveInsights: z
+    .string()
+    .describe(
+      "Suggestive insights to improve understanding of patient progress.",
+    ),
+  therapeuticMilestones: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Identified significant therapeutic milestones or breakthroughs in the session.",
+    ),
+  inventoryComparisonInsights: z
+    .string()
+    .optional()
+    .describe(
+      "Analysis comparing current session notes with past inventory responses and history to show evolution.",
+    ),
+  potentialRiskAlerts: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Subtle alerts based on language patterns or metric decline indicating potential risks (e.g., increased anxiety, depressive thoughts).",
+    ),
 });
-export type GenerateSessionInsightsOutput = z.infer<typeof GenerateSessionInsightsOutputSchema>;
+export type GenerateSessionInsightsOutput = z.infer<
+  typeof GenerateSessionInsightsOutputSchema
+>;
 
-export async function generateSessionInsights(input: GenerateSessionInsightsInput): Promise<GenerateSessionInsightsOutput> {
+export async function generateSessionInsights(
+  input: GenerateSessionInsightsInput,
+): Promise<GenerateSessionInsightsOutput> {
   return generateSessionInsightsFlow(input);
 }
 
 const prompt = ai.definePrompt({
-  name: 'generateSessionInsightsPrompt',
-  input: {schema: GenerateSessionInsightsInputSchema},
-  output: {schema: GenerateSessionInsightsOutputSchema},
+  name: "generateSessionInsightsPrompt",
+  input: { schema: GenerateSessionInsightsInputSchema },
+  output: { schema: GenerateSessionInsightsOutputSchema },
   prompt: `You are an AI assistant for psychologists. Analyze the following session notes to identify key themes, symptom evolution, provide suggestive insights, and flag important observations.
 
 Session Notes:
@@ -62,13 +95,12 @@ Output should be in JSON format. Return:
 
 const generateSessionInsightsFlow = ai.defineFlow(
   {
-    name: 'generateSessionInsightsFlow',
+    name: "generateSessionInsightsFlow",
     inputSchema: GenerateSessionInsightsInputSchema,
     outputSchema: GenerateSessionInsightsOutputSchema,
   },
-  async input => {
-    const {output} = await prompt(input);
+  async (input) => {
+    const { output } = await prompt(input);
     return output!;
-  }
+  },
 );
-

--- a/src/ai/flows/generate-session-note-template.ts
+++ b/src/ai/flows/generate-session-note-template.ts
@@ -1,4 +1,4 @@
-'use server';
+"use server";
 /**
  * @fileOverview An AI agent for generating session note templates.
  *
@@ -7,29 +7,38 @@
  * - GenerateSessionNoteTemplateOutput - The return type for the generateSessionNoteTemplate function.
  */
 
-import {ai} from '@/ai/genkit';
-import {z} from 'genkit';
+import { ai } from "@/ai/genkit";
+import { z } from "genkit";
 
-const GenerateSessionNoteTemplateInputSchema = z.object({
-  patientName: z.string().describe('The name of the patient.'),
-  sessionSummary: z.string().describe('A summary of the therapy session.'),
-  therapistInstructions: z.string().optional().describe('Optional instructions for the AI to tailor the template.'),
+export const GenerateSessionNoteTemplateInputSchema = z.object({
+  patientName: z.string().describe("The name of the patient."),
+  sessionSummary: z.string().describe("A summary of the therapy session."),
+  therapistInstructions: z
+    .string()
+    .optional()
+    .describe("Optional instructions for the AI to tailor the template."),
 });
-export type GenerateSessionNoteTemplateInput = z.infer<typeof GenerateSessionNoteTemplateInputSchema>;
+export type GenerateSessionNoteTemplateInput = z.infer<
+  typeof GenerateSessionNoteTemplateInputSchema
+>;
 
-const GenerateSessionNoteTemplateOutputSchema = z.object({
-  template: z.string().describe('The generated session note template.'),
+export const GenerateSessionNoteTemplateOutputSchema = z.object({
+  template: z.string().describe("The generated session note template."),
 });
-export type GenerateSessionNoteTemplateOutput = z.infer<typeof GenerateSessionNoteTemplateOutputSchema>;
+export type GenerateSessionNoteTemplateOutput = z.infer<
+  typeof GenerateSessionNoteTemplateOutputSchema
+>;
 
-export async function generateSessionNoteTemplate(input: GenerateSessionNoteTemplateInput): Promise<GenerateSessionNoteTemplateOutput> {
+export async function generateSessionNoteTemplate(
+  input: GenerateSessionNoteTemplateInput,
+): Promise<GenerateSessionNoteTemplateOutput> {
   return generateSessionNoteTemplateFlow(input);
 }
 
 const prompt = ai.definePrompt({
-  name: 'generateSessionNoteTemplatePrompt',
-  input: {schema: GenerateSessionNoteTemplateInputSchema},
-  output: {schema: GenerateSessionNoteTemplateOutputSchema},
+  name: "generateSessionNoteTemplatePrompt",
+  input: { schema: GenerateSessionNoteTemplateInputSchema },
+  output: { schema: GenerateSessionNoteTemplateOutputSchema },
   prompt: `You are an AI assistant that generates session note templates for psychologists.
 
   Given the patient's name and a summary of the session, create a comprehensive session note template.
@@ -45,12 +54,12 @@ const prompt = ai.definePrompt({
 
 const generateSessionNoteTemplateFlow = ai.defineFlow(
   {
-    name: 'generateSessionNoteTemplateFlow',
+    name: "generateSessionNoteTemplateFlow",
     inputSchema: GenerateSessionNoteTemplateInputSchema,
     outputSchema: GenerateSessionNoteTemplateOutputSchema,
   },
-  async input => {
-    const {output} = await prompt(input);
+  async (input) => {
+    const { output } = await prompt(input);
     return output!;
-  }
+  },
 );

--- a/src/app/api/ai/report-draft/route.ts
+++ b/src/app/api/ai/report-draft/route.ts
@@ -1,13 +1,27 @@
-import { NextResponse } from 'next/server';
-import { generateReportDraft } from '@/ai/flows/generate-report-draft-flow';
+import { NextResponse } from "next/server";
+import {
+  generateReportDraft,
+  GenerateReportDraftInputSchema,
+} from "@/ai/flows/generate-report-draft-flow";
+import { ZodError } from "zod";
 
 export async function POST(req: Request) {
   try {
-    const input = await req.json();
+    const body = await req.json();
+    const input = GenerateReportDraftInputSchema.parse(body);
     const result = await generateReportDraft(input);
     return NextResponse.json(result);
   } catch (e) {
-    console.error('Error generating report draft:', e);
-    return NextResponse.json({ error: 'Failed to generate report draft' }, { status: 500 });
+    if (e instanceof ZodError) {
+      return NextResponse.json(
+        { error: "Dados de entrada inválidos" },
+        { status: 400 },
+      );
+    }
+    console.error("Error generating report draft:", e);
+    return NextResponse.json(
+      { error: "Failed to generate report draft" },
+      { status: 500 },
+    );
   }
 }

--- a/src/app/api/ai/session-insights/route.ts
+++ b/src/app/api/ai/session-insights/route.ts
@@ -1,13 +1,27 @@
-import { NextResponse } from 'next/server';
-import { generateSessionInsights } from '@/ai/flows/generate-session-insights';
+import { NextResponse } from "next/server";
+import {
+  generateSessionInsights,
+  GenerateSessionInsightsInputSchema,
+} from "@/ai/flows/generate-session-insights";
+import { ZodError } from "zod";
 
 export async function POST(req: Request) {
   try {
-    const input = await req.json();
+    const body = await req.json();
+    const input = GenerateSessionInsightsInputSchema.parse(body);
     const result = await generateSessionInsights(input);
     return NextResponse.json(result);
   } catch (e) {
-    console.error('Error generating session insights:', e);
-    return NextResponse.json({ error: 'Failed to generate session insights' }, { status: 500 });
+    if (e instanceof ZodError) {
+      return NextResponse.json(
+        { error: "Dados de entrada inválidos" },
+        { status: 400 },
+      );
+    }
+    console.error("Error generating session insights:", e);
+    return NextResponse.json(
+      { error: "Failed to generate session insights" },
+      { status: 500 },
+    );
   }
 }

--- a/src/app/api/ai/session-note-template/route.ts
+++ b/src/app/api/ai/session-note-template/route.ts
@@ -1,13 +1,27 @@
-import { NextResponse } from 'next/server';
-import { generateSessionNoteTemplate } from '@/ai/flows/generate-session-note-template';
+import { NextResponse } from "next/server";
+import {
+  generateSessionNoteTemplate,
+  GenerateSessionNoteTemplateInputSchema,
+} from "@/ai/flows/generate-session-note-template";
+import { ZodError } from "zod";
 
 export async function POST(req: Request) {
   try {
-    const input = await req.json();
+    const body = await req.json();
+    const input = GenerateSessionNoteTemplateInputSchema.parse(body);
     const result = await generateSessionNoteTemplate(input);
     return NextResponse.json(result);
   } catch (e) {
-    console.error('Error generating session note template:', e);
-    return NextResponse.json({ error: 'Failed to generate session note template' }, { status: 500 });
+    if (e instanceof ZodError) {
+      return NextResponse.json(
+        { error: "Dados de entrada inválidos" },
+        { status: 400 },
+      );
+    }
+    console.error("Error generating session note template:", e);
+    return NextResponse.json(
+      { error: "Failed to generate session note template" },
+      { status: 500 },
+    );
   }
 }

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -1,20 +1,36 @@
 "use client";
 
-import type { GenerateSessionInsightsInput, GenerateSessionInsightsOutput } from "@/ai/flows/generate-session-insights";
-import type { GenerateReportDraftInput, GenerateReportDraftOutput } from "@/ai/flows/generate-report-draft-flow";
-import type { GenerateSessionNoteTemplateInput, GenerateSessionNoteTemplateOutput } from "@/ai/flows/generate-session-note-template";
+import type {
+  GenerateSessionInsightsInput,
+  GenerateSessionInsightsOutput,
+} from "@/ai/flows/generate-session-insights";
+import type {
+  GenerateReportDraftInput,
+  GenerateReportDraftOutput,
+} from "@/ai/flows/generate-report-draft-flow";
+import type {
+  GenerateSessionNoteTemplateInput,
+  GenerateSessionNoteTemplateOutput,
+} from "@/ai/flows/generate-session-note-template";
 
 async function requestAI<T>(url: string, body: unknown): Promise<T> {
-  const res = await fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
-  if (!res.ok) {
-    const message = await res.text();
-    throw new Error(message || "Erro na requisição AI");
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const message = await res.text();
+      throw new Error(message || "Erro na requisição AI");
+    }
+    return res.json() as Promise<T>;
+  } catch (e) {
+    console.error("Erro na comunicação com o serviço de IA:", e);
+    throw new Error(
+      "Não foi possível conectar ao serviço de IA. Verifique sua conexão e tente novamente.",
+    );
   }
-  return res.json() as Promise<T>;
 }
 
 export async function generateSessionInsights(


### PR DESCRIPTION
## Summary
- add network error handling in aiService
- export schemas for AI flows
- validate requests in AI route handlers

## Testing
- `npx jest --runInBand` *(fails: Need to install jest)*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_684a4a9b60d88324afdd9d292608526a