### PR TITLE
Fix next config type

### DIFF
--- a/src/types/nextjs.d.ts
+++ b/src/types/nextjs.d.ts
@@ -1,0 +1,7 @@
+import 'next'
+
+declare module 'next' {
+  interface ExperimentalConfig {
+    allowedDevOrigins?: string[]
+  }
+}


### PR DESCRIPTION
## Summary
- extend Next.js experimental config types so `allowedDevOrigins` is valid

## Testing
- `npm run typecheck` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684a4dc2f62c832485d65dd8eb871801