### PR TITLE
Fix local eslint rule export

### DIFF
--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -1,8 +1,9 @@
 
 "use strict";
 
+// Export local ESLint rules directly so `eslint-plugin-local-rules`
+// can load them correctly. The plugin expects an object whose keys
+// are rule names and values are rule definitions.
 module.exports = {
-  rules: {
-    'no-aschild-on-a': require('./no-aschild-on-a')
-  }
+  'no-aschild-on-a': require('./no-aschild-on-a'),
 };


### PR DESCRIPTION
## Summary
- fix export shape for custom eslint rules so local plugin works

## Testing
- `npm run lint` *(fails: Definition for rule '@next/next/link-passhref' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a4dc0b654832484d400f90227c248