### PR TITLE
Refine filter types

### DIFF
--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -42,7 +42,16 @@ const appointmentStatuses = [
     {value: "NoShow", label: "Falta"},
     {value: "Rescheduled", label: "Remarcado"},
     {value: "Blocked", label: "Bloqueado"}
-];
+] as const;
+
+type AppointmentStatusFilter = typeof appointmentStatuses[number]["value"];
+
+type ScheduleFilters = {
+  psychologistId: string;
+  status: AppointmentStatusFilter;
+  dateFrom: Date | undefined;
+  dateTo: Date | undefined;
+};
 
 
 export default function SchedulePage() {
@@ -51,14 +60,17 @@ export default function SchedulePage() {
   const [appointmentsData, setAppointmentsData] = useState<AppointmentsByDate>(() => getInitialMockAppointments());
   const { toast } = useToast();
 
-  const [filters, setFilters] = useState({
+  const [filters, setFilters] = useState<ScheduleFilters>({
     psychologistId: "all",
     status: "All",
-    dateFrom: undefined as Date | undefined,
-    dateTo: undefined as Date | undefined,
+    dateFrom: undefined,
+    dateTo: undefined,
   });
 
-  const handleFilterChange = (filterName: keyof typeof filters, value: any) => {
+  const handleFilterChange = <K extends keyof ScheduleFilters>(
+    filterName: K,
+    value: ScheduleFilters[K]
+  ) => {
     setFilters(prev => ({ ...prev, [filterName]: value }));
   };
   

--- a/src/app/(app)/schedule/today/page.tsx
+++ b/src/app/(app)/schedule/today/page.tsx
@@ -44,7 +44,16 @@ const appointmentStatuses = [
     {value: "NoShow", label: "Falta"},
     {value: "Rescheduled", label: "Remarcado"},
     {value: "Blocked", label: "Bloqueado"}
-];
+] as const;
+
+type AppointmentStatusFilter = typeof appointmentStatuses[number]["value"];
+
+type ScheduleFilters = {
+  psychologistId: string;
+  status: AppointmentStatusFilter;
+  dateFrom: Date | undefined;
+  dateTo: Date | undefined;
+};
 
 
 export default function TodaySchedulePage() {
@@ -53,11 +62,11 @@ export default function TodaySchedulePage() {
   const [appointmentsData, setAppointmentsData] = useState<AppointmentsByDate>(() => getInitialMockAppointments());
   const { toast } = useToast();
 
-  const [filters, setFilters] = useState({
+  const [filters, setFilters] = useState<ScheduleFilters>({
     psychologistId: "all",
     status: "All",
-    dateFrom: undefined as Date | undefined,
-    dateTo: undefined as Date | undefined,
+    dateFrom: undefined,
+    dateTo: undefined,
   });
 
   const [tasksForCurrentDate, setTasksForCurrentDate] = useState<Task[]>([]);
@@ -84,7 +93,10 @@ export default function TodaySchedulePage() {
   }, [currentDate, toast]);
 
 
-  const handleFilterChange = (filterName: keyof typeof filters, value: any) => {
+  const handleFilterChange = <K extends keyof ScheduleFilters>(
+    filterName: K,
+    value: ScheduleFilters[K]
+  ) => {
     setFilters(prev => ({ ...prev, [filterName]: value }));
   };
   

--- a/src/app/(app)/tasks/page.tsx
+++ b/src/app/(app)/tasks/page.tsx
@@ -40,16 +40,18 @@ const taskPriorityOptions: {value: TaskPriority | "All", label: string}[] = [
     {value: "Baixa", label: "Baixa"},
 ];
 
+type TaskFilters = {
+  status: TaskStatus | "All";
+  priority: TaskPriority | "All";
+  assignedTo: string;
+  dueDate?: Date;
+};
+
 export default function TasksPage() {
   const [allTasks, setAllTasks] = useState<Task[]>([]);
   const [isLoadingTasks, setIsLoadingTasks] = useState(true);
   const [searchTerm, setSearchTerm] = useState("");
-  const [filters, setFilters] = useState<{
-    status: TaskStatus | "All";
-    priority: TaskPriority | "All";
-    assignedTo: string;
-    dueDate?: Date;
-  }>({
+  const [filters, setFilters] = useState<TaskFilters>({
     status: "All",
     priority: "All",
     assignedTo: "Todos",
@@ -72,7 +74,10 @@ export default function TasksPage() {
     fetchTasks();
   }, []);
 
-  const handleFilterChange = (filterName: keyof typeof filters, value: any) => {
+  const handleFilterChange = <K extends keyof TaskFilters>(
+    filterName: K,
+    value: TaskFilters[K]
+  ) => {
     setFilters(prev => ({ ...prev, [filterName]: value }));
   };
 


### PR DESCRIPTION
## Summary
- tighten type for appointment and task filter handlers

## Testing
- `npm run typecheck` *(fails: cannot find type declarations)*
- `npm run lint` *(fails: missing custom ESLint rules)*

------
https://chatgpt.com/codex/tasks/task_e_684a4dbf299c83249997b808c467efc9