### PR TITLE
Implement schedule conflict check

### DIFF
--- a/src/components/schedule/appointment-calendar.tsx
+++ b/src/components/schedule/appointment-calendar.tsx
@@ -30,31 +30,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useToast } from "@/hooks/use-toast";
-
-
-type AppointmentStatus = 
-  | "Scheduled" 
-  | "Completed" 
-  | "CancelledByPatient" 
-  | "CancelledByClinic" 
-  | "Blocked" 
-  | "Confirmed" 
-  | "NoShow" 
-  | "Rescheduled";
-
-export type Appointment = { 
-  id: string;
-  startTime: string; // HH:mm
-  endTime: string; // HH:mm
-  patient: string; 
-  type: string;
-  psychologistId: string;
-  status: AppointmentStatus;
-  blockReason?: string;
-  notes?: string;
-};
-
-export type AppointmentsByDate = Record<string, Appointment[]>;
+import type { Appointment, AppointmentsByDate, AppointmentStatus } from "@/types/appointment";
 
 const mockPsychologists = [
   { id: "psy1", name: "Dr. Silva" },

--- a/src/services/appointmentService.ts
+++ b/src/services/appointmentService.ts
@@ -1,0 +1,23 @@
+import type { AppointmentsByDate } from '@/types/appointment';
+
+export function hasScheduleConflict(
+  appointments: AppointmentsByDate,
+  dateKey: string,
+  startTime: string,
+  endTime: string,
+  psychologistId: string,
+  isBlockTime: boolean
+): boolean {
+  const existing = appointments[dateKey] || [];
+  return existing.some((appt) => {
+    if (appt.psychologistId !== psychologistId) return false;
+    if (appt.status === 'CancelledByPatient' || appt.status === 'CancelledByClinic') {
+      return false;
+    }
+    if (!isBlockTime && appt.type === 'Blocked Slot') {
+      // Bloqueio impede consulta
+      return startTime < appt.endTime && endTime > appt.startTime;
+    }
+    return startTime < appt.endTime && endTime > appt.startTime;
+  });
+}

--- a/src/services/ics-generator.ts
+++ b/src/services/ics-generator.ts
@@ -1,5 +1,5 @@
 
-import { type Appointment, type AppointmentsByDate } from '@/components/schedule/appointment-calendar';
+import { type Appointment, type AppointmentsByDate } from '@/types/appointment';
 import { format } from 'date-fns';
 import { toDate } from 'date-fns-tz';
 

--- a/src/stores/appointmentStore.ts
+++ b/src/stores/appointmentStore.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand';
+import type { Appointment, AppointmentsByDate } from '@/types/appointment';
+import { getInitialMockAppointments } from '@/components/schedule/appointment-calendar';
+
+interface AppointmentState {
+  appointments: AppointmentsByDate;
+  setAppointments: (appointments: AppointmentsByDate) => void;
+  addAppointment: (dateKey: string, appointment: Appointment) => void;
+}
+
+export const useAppointmentStore = create<AppointmentState>((set) => ({
+  appointments: getInitialMockAppointments(),
+  setAppointments: (appointments) => set({ appointments }),
+  addAppointment: (dateKey, appointment) =>
+    set((state) => {
+      const existing = state.appointments[dateKey] || [];
+      return {
+        appointments: {
+          ...state.appointments,
+          [dateKey]: [...existing, appointment],
+        },
+      };
+    }),
+}));

--- a/src/types/appointment.ts
+++ b/src/types/appointment.ts
@@ -1,0 +1,23 @@
+export type AppointmentStatus =
+  | "Scheduled"
+  | "Completed"
+  | "CancelledByPatient"
+  | "CancelledByClinic"
+  | "Blocked"
+  | "Confirmed"
+  | "NoShow"
+  | "Rescheduled";
+
+export interface Appointment {
+  id: string;
+  startTime: string; // HH:mm
+  endTime: string; // HH:mm
+  patient: string;
+  type: string;
+  psychologistId: string;
+  status: AppointmentStatus;
+  blockReason?: string;
+  notes?: string;
+}
+
+export type AppointmentsByDate = Record<string, Appointment[]>;


### PR DESCRIPTION
## Summary
- introduce `Appointment` types shared across app
- create store and service for appointment data and conflict validation
- add conflict validation in appointment form before saving
- update calendar and ICS generator to use shared types

## Testing
- `npx next lint` *(fails: Need to install 'next')*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68478b567b58832491cf7886844832a9