### PR TITLE
Add prontuario generation via Google Apps Script

### DIFF
--- a/src/app/(app)/patients/[id]/page.tsx
+++ b/src/app/(app)/patients/[id]/page.tsx
@@ -45,6 +45,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
 import dynamic from "next/dynamic";
+import { gerarProntuario } from "@/services/prontuarioService";
 
 const PatientProgressChart = dynamic(() => import("@/components/patients/patient-progress-chart"), {
   loading: () => (
@@ -305,6 +306,30 @@ export default function PatientDetailPage({ params }: { params: { id: string } }
       setIsLoadingGeneralInsights(false);
     }
   }, [sessionNotes, toast]);
+
+  const handleGenerateProntuario = useCallback(async () => {
+    if (sessionNotes.length === 0) {
+      toast({
+        title: "Sem Anotações",
+        description: "Adicione anotações para gerar o prontuário.",
+        variant: "default",
+      });
+      return;
+    }
+    try {
+      await gerarProntuario(patient.id, sessionNotes);
+      toast({
+        title: "Prontuário Gerado",
+        description: "Documento criado via Google Apps Script.",
+      });
+    } catch (e: any) {
+      toast({
+        title: "Erro ao Gerar Prontuário",
+        description: e.message || "Não foi possível gerar o prontuário.",
+        variant: "destructive",
+      });
+    }
+  }, [sessionNotes, patient.id, toast]);
 
 
   const formattedDob = useMemo(() => patient.dob ? format(new Date(patient.dob), "P", { locale: ptBR }) : "N/A", [patient.dob]);
@@ -600,9 +625,14 @@ export default function PatientDetailPage({ params }: { params: { id: string } }
             <CardTitle className="font-headline flex items-center"><MessageSquare className="mr-2 h-5 w-5 text-primary"/> Anotações de Sessão</CardTitle>
             <CardDescription>Registro cronológico das sessões de terapia.</CardDescription>
           </div>
-          <Button variant="outline" className="bg-accent hover:bg-accent/90 text-accent-foreground">
-            <FileText className="mr-2 h-4 w-4" /> Nova Anotação
-          </Button>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={handleGenerateProntuario} className="bg-accent hover:bg-accent/90 text-accent-foreground">
+              <UploadCloud className="mr-2 h-4 w-4" /> Gerar Prontuário
+            </Button>
+            <Button variant="outline" className="bg-accent hover:bg-accent/90 text-accent-foreground">
+              <FileText className="mr-2 h-4 w-4" /> Nova Anotação
+            </Button>
+          </div>
         </CardHeader>
         <CardContent className="space-y-4">
           {sessionNotes.map(note => (

--- a/src/services/prontuarioService.ts
+++ b/src/services/prontuarioService.ts
@@ -1,0 +1,36 @@
+"use client";
+
+export interface SessionNote {
+  id: string;
+  date: string;
+  summary: string;
+  [key: string]: unknown;
+}
+
+export async function gerarProntuario(
+  patientId: string,
+  notes: SessionNote[],
+): Promise<{ success: boolean; message?: string }> {
+  const url = process.env.NEXT_PUBLIC_GAS_PRONTUARIO_URL;
+  if (!url) {
+    throw new Error("GAS URL não configurada");
+  }
+
+  const procedimentoAnalise = notes.map((n) => n.summary).join("\n\n");
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      patientId,
+      procedimentoAnalise,
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || "Erro ao gerar prontuário");
+  }
+
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add service to call Google Apps Script for prontuario generation
- wire up page to send session notes to the service
- show `Gerar Prontuário` button in patient details

## Testing
- `npm run lint` *(fails: Definition for rule '@next/next/link-passhref' was not found, many parsing errors)*
- `npm run typecheck` *(fails: TS1128 Declaration or statement expected)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_684a536b0dd08324821dceee4f84db3b