### PR TITLE
Add Google Calendar OAuth integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "dotenv": "^16.5.0",
         "firebase": "^11.8.1",
         "genkit": "^1.8.0",
+        "googleapis": "^130.0.0",
         "lucide-react": "^0.475.0",
         "next": "15.3.3",
         "patch-package": "^8.0.0",
@@ -7963,6 +7964,49 @@
         "node": ">=14"
       }
     },
+    "node_modules/googleapis": {
+      "version": "130.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-130.0.0.tgz",
+      "integrity": "sha512-+ZSOowVv+vGBTueu1Ot9O7EqC0U4PS9l7fUjzc0ThCT4w4g+r78Vgn17q7eGBB5JMu4hxYC1hbbm1U/MCnYFdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -12278,6 +12322,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
     },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "dotenv": "^16.5.0",
     "firebase": "^11.8.1",
     "genkit": "^1.8.0",
+    "googleapis": "^130.0.0",
     "lucide-react": "^0.475.0",
     "next": "15.3.3",
     "patch-package": "^8.0.0",

--- a/src/services/googleCalendar.ts
+++ b/src/services/googleCalendar.ts
@@ -1,0 +1,103 @@
+"use client";
+
+import { google, calendar_v3 } from 'googleapis';
+
+const SCOPES = ['https://www.googleapis.com/auth/calendar'];
+
+interface StoredToken {
+  access_token?: string;
+  refresh_token?: string;
+  scope?: string;
+  token_type?: string;
+  expiry_date?: number;
+}
+
+function tokenKey(userId: string): string {
+  return `gcal_token_${userId}`;
+}
+
+function createClient() {
+  return new google.auth.OAuth2(
+    process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID,
+    process.env.NEXT_PUBLIC_GOOGLE_CLIENT_SECRET,
+    process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI,
+  );
+}
+
+export function getOAuthClient(userId: string) {
+  const client = createClient();
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem(tokenKey(userId));
+    if (stored) {
+      client.setCredentials(JSON.parse(stored) as StoredToken);
+    }
+  }
+  return client;
+}
+
+export function hasTokens(userId: string): boolean {
+  if (typeof window === 'undefined') return false;
+  return !!localStorage.getItem(tokenKey(userId));
+}
+
+export function clearTokens(userId: string) {
+  if (typeof window !== 'undefined') {
+    localStorage.removeItem(tokenKey(userId));
+  }
+}
+
+export function getAuthUrl(userId: string): string {
+  const client = getOAuthClient(userId);
+  return client.generateAuthUrl({
+    access_type: 'offline',
+    scope: SCOPES,
+    prompt: 'consent',
+  });
+}
+
+export async function exchangeCodeForTokens(userId: string, code: string) {
+  const client = getOAuthClient(userId);
+  const { tokens } = await client.getToken(code);
+  setTokens(userId, tokens as StoredToken);
+  return tokens;
+}
+
+export function setTokens(userId: string, tokens: StoredToken) {
+  const client = getOAuthClient(userId);
+  client.setCredentials(tokens);
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(tokenKey(userId), JSON.stringify(tokens));
+  }
+}
+
+export async function insertOrUpdateEvent(userId: string, event: calendar_v3.Schema$Event) {
+  const auth = getOAuthClient(userId);
+  const calendar = google.calendar({ version: 'v3', auth });
+
+  if (event.id) {
+    const res = await calendar.events.update({
+      calendarId: 'primary',
+      eventId: event.id,
+      requestBody: event,
+    });
+    return res.data;
+  }
+  const res = await calendar.events.insert({
+    calendarId: 'primary',
+    requestBody: event,
+  });
+  return res.data;
+}
+
+export async function listUpcomingEvents(userId: string, maxResults = 10) {
+  const auth = getOAuthClient(userId);
+  const calendar = google.calendar({ version: 'v3', auth });
+  const res = await calendar.events.list({
+    calendarId: 'primary',
+    timeMin: new Date().toISOString(),
+    maxResults,
+    singleEvents: true,
+    orderBy: 'startTime',
+  });
+  return res.data.items || [];
+}


### PR DESCRIPTION
## Summary
- add googleapis dependency
- implement Google Calendar service with OAuth token storage
- sync and OAuth management buttons on schedule page

## Testing
- `npm run typecheck` *(fails: Declaration or statement expected)*

------
https://chatgpt.com/codex/tasks/task_e_684a5357586c83248f868080727923cb