### PR TITLE
Implement FCM notifications

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -1,0 +1,3 @@
+# Cloud Functions
+
+This directory contains Firebase Cloud Functions for PsiGuard. The `scheduleReminders` function runs hourly and checks appointments and tasks that occur within the next 24 hours. Any matching records trigger push notifications to users via Firebase Cloud Messaging.

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "functions",
+  "engines": {"node": "18"},
+  "main": "dist/index.js",
+  "scripts": {"build": "tsc", "deploy": "firebase deploy --only functions"},
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.4.1"
+  },
+  "devDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,0 +1,61 @@
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+
+admin.initializeApp();
+const db = admin.firestore();
+
+export const scheduleReminders = functions.pubsub
+  .schedule('every 1 hours')
+  .onRun(async () => {
+    const now = admin.firestore.Timestamp.now();
+    const tomorrow = admin.firestore.Timestamp.fromMillis(now.toMillis() + 24 * 60 * 60 * 1000);
+
+    const appointments = await db
+      .collection('appointments')
+      .where('startDate', '>=', now)
+      .where('startDate', '<=', tomorrow)
+      .get();
+
+    const tasks = await db
+      .collection('tasks')
+      .where('dueDate', '>=', now)
+      .where('dueDate', '<=', tomorrow)
+      .where('status', '!=', 'Concluída')
+      .get();
+
+    const messaging = admin.messaging();
+
+    const sendToUser = async (userId: string, payload: admin.messaging.MessagingPayload) => {
+      const tokensSnap = await db.collection('users').doc(userId).collection('fcmTokens').get();
+      const tokens = tokensSnap.docs.map(d => d.id);
+      if (tokens.length) {
+        await messaging.sendEachForMulticast({ tokens, ...payload });
+      }
+    };
+
+    await Promise.all(
+      appointments.docs.map(async doc => {
+        const data = doc.data();
+        await sendToUser(data.userId, {
+          notification: {
+            title: 'Lembrete de Agendamento',
+            body: `Você tem um agendamento amanhã às ${data.startTime}`,
+          },
+          data: { type: 'appointment_reminder', id: doc.id },
+        });
+      })
+    );
+
+    await Promise.all(
+      tasks.docs.map(async doc => {
+        const data = doc.data();
+        await sendToUser(data.assignedTo, {
+          notification: {
+            title: 'Lembrete de Tarefa',
+            body: `A tarefa "${data.title}" vence amanhã.`,
+          },
+          data: { type: 'task_due', id: doc.id },
+        });
+      })
+    );
+  });

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "lib": ["es2020"],
+    "module": "commonjs",
+    "target": "es2017",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,0 +1,19 @@
+importScripts('https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js');
+importScripts('https://www.gstatic.com/firebasejs/9.22.2/firebase-messaging-compat.js');
+
+firebase.initializeApp({
+  apiKey: "",
+  authDomain: "",
+  projectId: "",
+  messagingSenderId: "",
+  appId: ""
+});
+
+const messaging = firebase.messaging();
+
+messaging.onBackgroundMessage(function(payload) {
+  self.registration.showNotification(payload.notification.title, {
+    body: payload.notification.body,
+    icon: '/favicon.ico'
+  });
+});

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+import { listenToNotifications, Notification } from '@/services/notificationService';
+import { auth } from '@/services/firebase';
+
+export function useNotifications(userId?: string) {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const uid = userId || auth.currentUser?.uid;
+    if (!uid) { setLoading(false); return; }
+    const unsub = listenToNotifications(uid, list => {
+      setNotifications(list);
+      setLoading(false);
+    });
+    return () => unsub();
+  }, [userId]);
+
+  return { notifications, loading };
+}

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -3,6 +3,7 @@ import { initializeApp, getApps, getApp, type FirebaseApp } from 'firebase/app';
 import { getAuth, connectAuthEmulator, type Auth } from 'firebase/auth';
 import { getFirestore, connectFirestoreEmulator, type Firestore } from 'firebase/firestore';
 import { getStorage, connectStorageEmulator, type FirebaseStorage } from 'firebase/storage';
+import { getMessaging, type Messaging } from 'firebase/messaging';
 // Para Functions, se for usar diretamente no cliente no futuro:
 // import { getFunctions, connectFunctionsEmulator, type Functions } from 'firebase/functions';
 
@@ -38,6 +39,10 @@ const app: FirebaseApp = !getApps().length ? initializeApp(firebaseConfig) : get
 const auth: Auth = getAuth(app);
 const db: Firestore = getFirestore(app);
 const storage: FirebaseStorage = getStorage(app);
+let messaging: Messaging | null = null;
+if (typeof window !== 'undefined') {
+  messaging = getMessaging(app);
+}
 // const functions: Functions = getFunctions(app); // Descomente se for usar Functions no cliente
 
 if (process.env.NODE_ENV === 'development') {
@@ -64,5 +69,5 @@ if (process.env.NODE_ENV === 'development') {
   }
 }
 
-export { app, auth, db, storage }; // Adicionar 'functions' aqui se for usá-las globalmente
+export { app, auth, db, storage, messaging }; // Adicionar 'functions' aqui se for usá-las globalmente
     

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -1,0 +1,39 @@
+import { messaging, db } from './firebase';
+import { getToken } from 'firebase/messaging';
+import { doc, setDoc, serverTimestamp, collection, query, orderBy, onSnapshot, Unsubscribe } from 'firebase/firestore';
+
+export interface Notification {
+  id: string;
+  type: string;
+  message: string;
+  date: string;
+  read: boolean;
+  link?: string;
+}
+
+export async function registerFcmToken(userId: string): Promise<string | null> {
+  if (!messaging) return null;
+  try {
+    const token = await getToken(messaging, {
+      vapidKey: process.env.NEXT_PUBLIC_FIREBASE_VAPID_KEY,
+    });
+    if (token) {
+      await setDoc(doc(db, 'users', userId, 'fcmTokens', token), {
+        token,
+        createdAt: serverTimestamp(),
+      });
+    }
+    return token;
+  } catch (err) {
+    console.error('Unable to get FCM token', err);
+    return null;
+  }
+}
+
+export function listenToNotifications(userId: string, callback: (n: Notification[]) => void): Unsubscribe {
+  const q = query(collection(db, 'users', userId, 'notifications'), orderBy('date', 'desc'));
+  return onSnapshot(q, snap => {
+    const list: Notification[] = snap.docs.map(d => ({ id: d.id, ...(d.data() as Omit<Notification,'id'>) }));
+    callback(list);
+  });
+}


### PR DESCRIPTION
## Summary
- configure Firebase Cloud Messaging in client
- add notification service and hook for Firestore data
- update notifications page to display real messages and register tokens
- implement scheduled Cloud Function to send reminders
- add FCM service worker

## Testing
- `npm run typecheck` *(fails: Declaration or statement expected)*

------
https://chatgpt.com/codex/tasks/task_e_684a5353c7988324af6d1a86f3ee6353