### PR TITLE
Implement basic RBAC

### DIFF
--- a/__tests__/firestore-rules.test.ts
+++ b/__tests__/firestore-rules.test.ts
@@ -22,7 +22,7 @@ function getAuthedDb(auth: { sub: string; role: string }): Firestore {
 }
 
 test('admin user can read other user profile', async () => {
-  const auth = { sub: 'user-id', role: 'admin' };
+  const auth = { sub: 'user-id', role: 'Admin' };
   const db = getAuthedDb(auth);
   await assertSucceeds(db.doc('users/otherUser').get());
 });

--- a/firestore.rules
+++ b/firestore.rules
@@ -3,6 +3,29 @@ rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    function hasRole(roleName) {
+      return isSignedIn() && request.auth.token.role == roleName;
+    }
+
+    function isAdmin() {
+      return hasRole('Admin');
+    }
+
+    function isPsychologist() {
+      return hasRole('Psychologist');
+    }
+
+    function isSecretary() {
+      return hasRole('Secretary');
+    }
+
+    function isStaff() {
+      return isAdmin() || isPsychologist() || isSecretary();
+    }
     // Allow public read access to a specific document
     // (e.g., a public profile)
     // match /users/{userId} {
@@ -18,11 +41,12 @@ service cloud.firestore {
     // Rules for user documents, allowing users to manage their own data
     // and admins to manage all user data.
     match /users/{userId} {
-      allow read: if request.auth != null; // All authenticated users can read user profiles (e.g., for listing assignees)
-      allow write: if request.auth.uid == userId; // Users can write to their own document
-      // allow create: if request.auth.uid == userId; // Covered by write for simplicity for now
-      // Admin access (assuming an 'admin' custom claim or role field in user's doc)
-      // allow read, write: if get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'Admin';
+      allow read: if isStaff();
+      allow write: if request.auth.uid == userId || isAdmin();
+    }
+
+    match /patients/{patientId} {
+      allow read, write: if isAdmin() || isPsychologist();
     }
 
     // Chat messages

--- a/src/app/(app)/admin/metrics/page.tsx
+++ b/src/app/(app)/admin/metrics/page.tsx
@@ -6,6 +6,9 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import StatsCard from "@/components/dashboard/stats-card";
 import dynamic from "next/dynamic";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { checkUserRole } from "@/services/authRole";
 
 const SessionsTrendChart = dynamic(() => import("@/components/dashboard/sessions-trend-chart").then(mod => mod.SessionsTrendChart), {
   loading: () => <Skeleton className="h-[350px] w-full" />,
@@ -33,6 +36,14 @@ const sessionsPerPsychologistData = [
 
 
 export default function AdminMetricsPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    checkUserRole('Admin').then((ok) => {
+      if (!ok) router.replace('/');
+    });
+  }, [router]);
+
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-2">

--- a/src/app/(app)/patients/page.tsx
+++ b/src/app/(app)/patients/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
@@ -5,8 +7,19 @@ import { UserPlus, Search, Filter, Users } from "lucide-react";
 import Link from "next/link";
 import PatientListItem from "@/components/patients/patient-list-item";
 import { mockPatients } from "@/mocks/patients";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { checkUserRole } from "@/services/authRole";
 
 export default function PatientsPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    checkUserRole(['Admin', 'Psychologist', 'Secretary']).then((ok) => {
+      if (!ok) router.replace('/');
+    });
+  }, [router]);
+
   return (
     <div className="space-y-6">
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">

--- a/src/services/authRole.ts
+++ b/src/services/authRole.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { auth } from './firebase';
+import { getIdTokenResult } from 'firebase/auth';
+
+export type UserRole = 'Admin' | 'Psychologist' | 'Secretary';
+
+export async function getCurrentUserRole(): Promise<UserRole | null> {
+  const user = auth.currentUser;
+  if (!user) return null;
+  try {
+    const tokenResult = await getIdTokenResult(user, true);
+    return (tokenResult.claims.role as UserRole) || null;
+  } catch (err) {
+    console.error('Failed to get user role', err);
+    return null;
+  }
+}
+
+export async function checkUserRole(required: UserRole | UserRole[]): Promise<boolean> {
+  const role = await getCurrentUserRole();
+  if (!role) return false;
+  const roles = Array.isArray(required) ? required : [required];
+  return roles.includes(role);
+}


### PR DESCRIPTION
## Summary
- add authRole utility for reading roles from custom claims
- check roles on Admin metrics and Patients pages
- enforce role permissions in firestore rules
- adjust unit test for new role value

## Testing
- `npm run lint` *(fails: Definition for rule `@next/next/link-passhref` was not found)*
- `npm run typecheck` *(fails: TS1128 Declaration or statement expected)*
- `npx jest` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a534e64a483249ea025242d7f45c7