### PR TITLE
Fix allowedDevOrigins config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -19,7 +19,10 @@ const nextConfig: NextConfig = {
       },
     ],
   },
-  experimental: {}
+  allowedDevOrigins: [
+    '6000-firebase-studio-1749420368814.cluster-kc2r6y3mtba5mswcmol45orivs.cloudworkstations.dev',
+    // You might want to add http://localhost:6000 if you access it that way sometimes
+  ],
 }; 
 
 export default nextConfig;

--- a/src/types/nextjs.d.ts
+++ b/src/types/nextjs.d.ts
@@ -1,7 +1,7 @@
 import 'next'
 
 declare module 'next' {
-  interface ExperimentalConfig {
+  interface NextConfig {
     allowedDevOrigins?: string[]
   }
 }


### PR DESCRIPTION
## Summary
- move `allowedDevOrigins` outside `experimental`
- update Next.js type augmentation

## Testing
- `npx jest` *(fails: Preset ts-jest not found)*
- `npm run lint` *(fails to run lint rules)*
- `npm run typecheck` *(fails with TS1128 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a52bd95f08324b99f69db4b61a768