### PR TITLE
Remove obsolete Next.js type augmentation

### DIFF
--- a/src/types/nextjs.d.ts
+++ b/src/types/nextjs.d.ts
@@ -1,7 +1,0 @@
-import 'next'
-
-declare module 'next' {
-  interface ExperimentalConfig {
-    allowedDevOrigins?: string[]
-  }
-}


### PR DESCRIPTION
## Summary
- drop local Next.js augmentation for `allowedDevOrigins`
- verify TypeScript accepts the official `allowedDevOrigins` property

## Testing
- `npm run typecheck` *(fails: Declaration or statement expected)*
- `npx tsc --allowJs --skipLibCheck next.config.ts`

------
https://chatgpt.com/codex/tasks/task_e_684a52bcd8448324853fad52dd4a4bdb