### PR TITLE
Add allowedDevOrigins to next config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -19,7 +19,10 @@ const nextConfig: NextConfig = {
       },
     ],
   },
-  experimental: {}
+  experimental: {
+    // Allow development from the default dev server origin
+    allowedDevOrigins: ['http://localhost:9002'],
+  }
 }; 
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- configure `allowedDevOrigins` so Next.js dev server is permitted

## Testing
- `npm run typecheck` *(fails: Declaration or statement expected)*
- `npx jest` *(fails: needs to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_684a52b0c33883248bd46790927f1b04