### PR TITLE
Add assessments collection and patient interface

### DIFF
--- a/__tests__/firestore-rules.test.ts
+++ b/__tests__/firestore-rules.test.ts
@@ -26,3 +26,18 @@ test('admin user can read other user profile', async () => {
   const db = getAuthedDb(auth);
   await assertSucceeds(db.doc('users/otherUser').get());
 });
+
+test('authenticated user can create assessment', async () => {
+  const auth = { sub: 'therapist1', role: 'psychologist' };
+  const db = getAuthedDb(auth);
+  await assertSucceeds(
+    db.doc('assessments/testAssessment').set({
+      patientId: 'patient1',
+      assignedBy: auth.sub,
+      templateId: 'tpl1',
+      templateName: 'Demo',
+      status: 'assigned',
+      createdAt: '2024-01-01T00:00:00Z'
+    })
+  );
+});

--- a/firestore.rules
+++ b/firestore.rules
@@ -39,6 +39,18 @@ service cloud.firestore {
       // allow update, delete: if request.auth.uid == resource.data.senderId; // Example: only sender can delete/update
     }
 
+    // Assessments
+    // Documents representing an evaluation assigned to a patient.
+    match /assessments/{assessmentId} {
+      allow read: if request.auth != null;
+      allow create: if request.auth != null &&
+                      request.resource.data.patientId is string &&
+                      request.resource.data.assignedBy is string &&
+                      request.resource.data.status in ['assigned', 'in-progress', 'completed'];
+      allow update: if request.auth != null;
+      allow delete: if request.auth != null && request.auth.token.role == 'Admin';
+    }
+
     // Catch-all for any other paths - explicitly deny to be safe
     match /{document=**} {
       allow read, write: if false;

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,5 +5,5 @@ module.exports = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
-  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
+  setupFilesAfterEnv: ['@testing-library/jest-dom'],
 };

--- a/src/app/my-assessments/[id]/page.tsx
+++ b/src/app/my-assessments/[id]/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { submitAssessmentResponses } from '@/services/assessmentService';
+import { doc, getDoc } from 'firebase/firestore';
+import { db } from '@/services/firebase';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+
+export default function AssessmentResponsePage({ params }: { params: { id: string } }) {
+  const router = useRouter();
+  const [questions, setQuestions] = useState<string[]>([]);
+  const [answers, setAnswers] = useState<Record<number, string>>({});
+
+  useEffect(() => {
+    async function load() {
+      const snap = await getDoc(doc(db, 'assessments', params.id));
+      if (snap.exists()) {
+        const data = snap.data() as any;
+        if (Array.isArray(data.questions)) {
+          setQuestions(data.questions as string[]);
+        }
+      }
+    }
+    load();
+  }, [params.id]);
+
+  const handleSubmit = async () => {
+    await submitAssessmentResponses(params.id, answers);
+    router.push('/my-assessments');
+  };
+
+  return (
+    <Card className="max-w-2xl mx-auto">
+      <CardHeader>
+        <CardTitle>Responder Avaliação</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {questions.map((q, idx) => (
+          <div key={idx} className="space-y-2">
+            <p className="font-medium">{q}</p>
+            <Textarea
+              value={answers[idx] || ''}
+              onChange={(e) => setAnswers({ ...answers, [idx]: e.target.value })}
+              rows={3}
+            />
+          </div>
+        ))}
+        {questions.length === 0 && <p>Nenhuma pergunta encontrada.</p>}
+      </CardContent>
+      <CardFooter className="flex justify-end">
+        <Button onClick={handleSubmit} disabled={questions.length === 0}>Enviar Respostas</Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/app/my-assessments/page.tsx
+++ b/src/app/my-assessments/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+import { useEffect, useState } from 'react';
+import AssessmentCard from '@/components/assessments/assessment-card';
+import { getAssessmentsByPatient } from '@/services/assessmentService';
+import type { Assessment } from '@/types/assessment';
+import { ClipboardList } from 'lucide-react';
+
+export default function MyAssessmentsPage() {
+  const [assessments, setAssessments] = useState<Assessment[]>([]);
+  const patientId = 'demoPatient'; // In real app, derive from auth
+
+  useEffect(() => {
+    getAssessmentsByPatient(patientId).then(setAssessments).catch(() => setAssessments([]));
+  }, [patientId]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-2">
+        <ClipboardList className="h-7 w-7 text-primary" />
+        <h1 className="text-3xl font-headline font-bold">Minhas Avaliações</h1>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {assessments.map(a => (
+          <AssessmentCard key={a.id} assessment={{
+            id: a.id,
+            name: a.templateName,
+            description: undefined,
+            patientName: undefined,
+            dateSent: a.createdAt,
+            status: a.status === 'completed' ? 'Completed' : a.status === 'assigned' ? 'Sent' : 'Pending',
+            score: a.score ? String(a.score) : undefined,
+          }} />
+        ))}
+        {assessments.length === 0 && (
+          <p className="text-muted-foreground">Nenhuma avaliação disponível.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/services/assessmentService.ts
+++ b/src/services/assessmentService.ts
@@ -1,0 +1,26 @@
+"use client";
+import { collection, addDoc, updateDoc, doc, getDocs, query, where } from 'firebase/firestore';
+import { db } from './firebase';
+import type { Assessment } from '@/types/assessment';
+
+export async function createAssessment(data: Omit<Assessment, 'id' | 'createdAt' | 'completedAt'>): Promise<string> {
+  const docRef = await addDoc(collection(db, 'assessments'), {
+    ...data,
+    createdAt: new Date().toISOString(),
+  });
+  return docRef.id;
+}
+
+export async function submitAssessmentResponses(assessmentId: string, responses: Record<string, unknown>): Promise<void> {
+  await updateDoc(doc(db, 'assessments', assessmentId), {
+    responses,
+    status: 'completed',
+    completedAt: new Date().toISOString(),
+  });
+}
+
+export async function getAssessmentsByPatient(patientId: string): Promise<Assessment[]> {
+  const q = query(collection(db, 'assessments'), where('patientId', '==', patientId));
+  const snapshot = await getDocs(q);
+  return snapshot.docs.map(d => ({ id: d.id, ...(d.data() as Omit<Assessment, 'id'>) }));
+}

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -1,0 +1,15 @@
+export type AssessmentStatus = 'assigned' | 'in-progress' | 'completed';
+
+export interface Assessment {
+  id: string;
+  patientId: string;
+  templateId: string;
+  templateName: string;
+  assignedBy: string;
+  status: AssessmentStatus;
+  createdAt: string; // ISO date
+  dueDate?: string; // ISO date
+  completedAt?: string; // ISO date
+  responses?: Record<string, unknown>;
+  score?: number;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,3 +12,4 @@ export interface Task {
   priority: TaskPriority;
   patientId?: string;
 }
+export * from './assessment';


### PR DESCRIPTION
## Summary
- add Firestore rules for `assessments`
- define `Assessment` types and service helpers
- add patient pages for listing and answering assessments
- update jest configuration
- extend tests to cover new collection

## Testing
- `npx jest --runInBand` *(fails: The host and port of the firestore emulator must be specified, and Jest encountered unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_684a53652e548324ba0aec15bb4e2d8f