### PR TITLE
Implement Firestore services and integrate forms

### DIFF
--- a/src/app/(app)/patients/page.tsx
+++ b/src/app/(app)/patients/page.tsx
@@ -4,9 +4,17 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { UserPlus, Search, Filter, Users } from "lucide-react";
 import Link from "next/link";
 import PatientListItem from "@/components/patients/patient-list-item";
-import { mockPatients } from "@/mocks/patients";
+import { listPatients, Patient } from '@/services/patientService';
+import React from 'react';
 
 export default function PatientsPage() {
+  const [patients, setPatients] = React.useState<Patient[]>([]);
+  const [loading, setLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    listPatients().then((data) => setPatients(data)).finally(() => setLoading(false));
+  }, []);
+
   return (
     <div className="space-y-6">
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
@@ -36,9 +44,11 @@ export default function PatientsPage() {
           </div>
         </CardHeader>
         <CardContent>
-          {mockPatients.length > 0 ? (
+          {loading ? (
+            <p>Carregando...</p>
+          ) : patients.length > 0 ? (
             <div className="space-y-4">
-              {mockPatients.map(patient => (
+              {patients.map(patient => (
                 <PatientListItem key={patient.id} patient={patient} />
               ))}
             </div>

--- a/src/app/api/ai/report-draft/route.ts
+++ b/src/app/api/ai/report-draft/route.ts
@@ -25,6 +25,3 @@ export async function POST(req: Request) {
     );
   }
 }
-
-  }
-}

--- a/src/app/api/ai/session-insights/route.ts
+++ b/src/app/api/ai/session-insights/route.ts
@@ -25,6 +25,3 @@ export async function POST(req: Request) {
     );
   }
 }
-
-  }
-}

--- a/src/app/api/ai/session-note-template/route.ts
+++ b/src/app/api/ai/session-note-template/route.ts
@@ -25,6 +25,3 @@ export async function POST(req: Request) {
     );
   }
 }
-
-  }
-}

--- a/src/mocks/patients.ts
+++ b/src/mocks/patients.ts
@@ -1,7 +1,0 @@
-export const mockPatients = [
-  { id: "1", name: "Alice Wonderland", email: "alice@example.com", lastSession: "2024-07-15", nextAppointment: "2024-07-22", avatarUrl: "https://placehold.co/100x100/D0BFFF/4F3A76?text=AW", dataAiHint: "female avatar" },
-  { id: "2", name: "Bob O Construtor", email: "bob@example.com", lastSession: "2024-07-10", nextAppointment: "2024-07-20", avatarUrl: "https://placehold.co/100x100/70C1B3/FFFFFF?text=BB", dataAiHint: "male avatar" },
-  { id: "3", name: "Charlie Brown", email: "charlie@example.com", lastSession: "2024-07-12", nextAppointment: "2024-07-25", avatarUrl: "https://placehold.co/100x100/D0BFFF/4F3A76?text=CB", dataAiHint: "child avatar" },
-  { id: "4", name: "Diana Prince", email: "diana@example.com", lastSession: "2024-07-18", nextAppointment: null, avatarUrl: "https://placehold.co/100x100/70C1B3/FFFFFF?text=DP", dataAiHint: "female hero" },
-];
-export type MockPatient = (typeof mockPatients)[number];

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -33,8 +33,6 @@ async function requestAI<T>(url: string, body: unknown): Promise<T> {
   }
 }
 
-}
-
 export async function generateSessionInsights(
   input: GenerateSessionInsightsInput,
 ): Promise<GenerateSessionInsightsOutput> {

--- a/src/services/patientService.ts
+++ b/src/services/patientService.ts
@@ -1,0 +1,34 @@
+import { db } from './firebase';
+import { collection, addDoc, getDocs, updateDoc, deleteDoc, doc } from 'firebase/firestore';
+
+export interface Patient {
+  id: string;
+  name: string;
+  email: string;
+  phone?: string;
+  dob?: string;
+  address?: string;
+  avatarUrl?: string;
+  lastSession?: string | null;
+  nextAppointment?: string | null;
+}
+
+const collectionName = 'patients';
+
+export async function listPatients(): Promise<Patient[]> {
+  const snap = await getDocs(collection(db, collectionName));
+  return snap.docs.map(d => ({ id: d.id, ...(d.data() as Omit<Patient,'id'>) }));
+}
+
+export async function createPatient(data: Omit<Patient, 'id'>): Promise<Patient> {
+  const docRef = await addDoc(collection(db, collectionName), data);
+  return { id: docRef.id, ...data };
+}
+
+export async function updatePatient(id: string, data: Partial<Patient>): Promise<void> {
+  await updateDoc(doc(db, collectionName, id), data);
+}
+
+export async function deletePatient(id: string): Promise<void> {
+  await deleteDoc(doc(db, collectionName, id));
+}

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -1,63 +1,38 @@
+"use client";
 
-"use client"; // Pode ser necessário se usarmos hooks ou se for chamado por client components. Por ora, seguro adicionar.
+import type { Task } from "@/types";
+import { db } from "./firebase";
+import { collection, addDoc, getDocs, updateDoc, deleteDoc, doc, getDoc, query, where } from "firebase/firestore";
 
-import type { Task, TaskStatus, TaskPriority } from "@/types";
-import { format, isEqual, startOfDay, parse } from 'date-fns';
+const collectionName = 'tasks';
 
-// Mock data for tasks - agora centralizado aqui.
-export const mockTasksData: Task[] = [
-  { id: "task1", title: "Acompanhar Alice W.", description: "Ligar para Alice para verificar seu progresso e agendar próxima consulta.", dueDate: "2024-07-25", assignedTo: "Dr. Silva", status: "Pendente", priority: "Alta", patientId: "1" },
-  { id: "task2", title: "Preparar relatório de avaliação para Bob B.", description: "Compilar os resultados da avaliação GAD-7 e BDI para Bob.", dueDate: "2024-07-22", assignedTo: "Secretaria", status: "Em Progresso", priority: "Média", patientId: "2" },
-  { id: "task3", title: "Revisar entrada de novo paciente - Charlie B.", description: "Verificar todos os documentos e informações de Charlie.", dueDate: "2024-07-20", assignedTo: "Dra. Jones", status: "Concluída", priority: "Alta", patientId: "3" },
-  { id: "task4", title: "Enviar lembrete para Diana P. para avaliação", description: "Diana precisa completar a PCL-5 até o final da semana.", dueDate: "2024-07-28", assignedTo: "Secretaria", status: "Pendente", priority: "Baixa", patientId: "4" },
-  { id: "task5", title: "Atualizar documento de políticas da clínica", description: "Incorporar novas diretrizes de teleatendimento.", dueDate: "2024-08-01", assignedTo: "Admin", status: "Pendente", priority: "Média" },
-];
-
-// Simula uma chamada de API para buscar todas as tarefas
-export async function getTasks(): Promise<Task[]> {
-  // Simula um delay de rede
-  await new Promise(resolve => setTimeout(resolve, 100));
-  return [...mockTasksData]; // Retorna uma cópia para evitar mutações diretas no mock
+export async function listTasks(): Promise<Task[]> {
+  const snap = await getDocs(collection(db, collectionName));
+  return snap.docs.map(d => ({ id: d.id, ...(d.data() as Omit<Task,'id'>) }));
 }
 
-// Simula uma chamada de API para buscar uma tarefa por ID
 export async function getTaskById(id: string): Promise<Task | undefined> {
-  // Simula um delay de rede
-  await new Promise(resolve => setTimeout(resolve, 50));
-  return mockTasksData.find(task => task.id === id);
+  const ref = doc(db, collectionName, id);
+  const snap = await getDoc(ref);
+  return snap.exists() ? ({ id: snap.id, ...(snap.data() as Omit<Task,'id'>) }) : undefined;
 }
 
-// Simula uma chamada de API para buscar tarefas para uma data específica
-export async function getTasksForDate(date: Date): Promise<Task[]> {
-  await new Promise(resolve => setTimeout(resolve, 80));
-  return mockTasksData.filter(task => {
-    try {
-      const taskDueDate = parse(task.dueDate, 'yyyy-MM-dd', new Date());
-      return isEqual(startOfDay(taskDueDate), startOfDay(date));
-    } catch (e) {
-      // console.error("Erro ao parsear data da tarefa:", task.dueDate, e); // Removido
-      return false;
-    }
-  });
+export async function listTasksForDate(date: Date): Promise<Task[]> {
+  const dateStr = date.toISOString().slice(0,10);
+  const q = query(collection(db, collectionName), where('dueDate', '==', dateStr));
+  const snap = await getDocs(q);
+  return snap.docs.map(d => ({ id: d.id, ...(d.data() as Omit<Task,'id'>) }));
 }
 
-// Futuras funções para adicionar, atualizar, deletar tarefas podem ser adicionadas aqui.
-// Exemplo:
-// export async function createTask(taskData: Omit<Task, 'id'>): Promise<Task> {
-//   const newTask: Task = { ...taskData, id: `task_${Date.now()}` };
-//   mockTasksData.push(newTask);
-//   return newTask;
-// }
+export async function createTask(data: Omit<Task, 'id'>): Promise<Task> {
+  const docRef = await addDoc(collection(db, collectionName), data);
+  return { id: docRef.id, ...data };
+}
 
-// export async function updateTask(taskId: string, updates: Partial<Task>): Promise<Task | undefined> {
-//   const taskIndex = mockTasksData.findIndex(task => task.id === taskId);
-//   if (taskIndex === -1) return undefined;
-//   mockTasksData[taskIndex] = { ...mockTasksData[taskIndex], ...updates };
-//   return mockTasksData[taskIndex];
-// }
+export async function updateTask(id: string, data: Partial<Task>): Promise<void> {
+  await updateDoc(doc(db, collectionName, id), data);
+}
 
-// export async function deleteTask(taskId: string): Promise<boolean> {
-//   const initialLength = mockTasksData.length;
-//   mockTasksData = mockTasksData.filter(task => task.id !== taskId);
-//   return mockTasksData.length < initialLength;
-// }
+export async function deleteTask(id: string): Promise<void> {
+  await deleteDoc(doc(db, collectionName, id));
+}


### PR DESCRIPTION
## Summary
- create `patientService` with basic CRUD
- move task service and appointment service to Firestore
- fetch patients from Firestore in patient/task/appointment forms
- use service data on patient list page
- clean up API route files
- remove old patient mocks

## Testing
- `npm run typecheck` *(fails: cannot find modules and other type errors)*
- `npx jest` *(fails: tries to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_684a5349282883249a63e92993c800a8