### PR TITLE
Update patient rule

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -45,8 +45,8 @@ service cloud.firestore {
       allow write: if request.auth.uid == userId || isAdmin();
     }
 
-    match /patients/{patientId} {
-      allow read, write: if isAdmin() || isPsychologist();
+    match /patients/{id} {
+      allow read, write: if request.auth != null && request.auth.uid == resource.data.ownerId;
     }
 
     // Chat messages


### PR DESCRIPTION
## Summary
- restrict read/write of patient documents by owner ID in firestore.rules

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails with TS1128 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a5b7c678483248b9f3ac95612e917