### PR TITLE
Add onCreateUser Cloud Function

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -1,3 +1,6 @@
 # Cloud Functions
 
-This directory contains Firebase Cloud Functions for PsiGuard. The `scheduleReminders` function runs hourly and checks appointments and tasks that occur within the next 24 hours. Any matching records trigger push notifications to users via Firebase Cloud Messaging.
+This directory contains Firebase Cloud Functions for PsiGuard.
+
+* `scheduleReminders` runs hourly and checks appointments and tasks that occur within the next 24 hours. Any matching records trigger push notifications to users via Firebase Cloud Messaging.
+* `onCreateUser` triggers when a new Firebase Authentication user is created and assigns a custom claim `role`. Emails under the `@psiguard.app` domain become `Admin`; all others default to `Psychologist`.

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -59,3 +59,10 @@ export const scheduleReminders = functions.pubsub
       })
     );
   });
+
+export const onCreateUser = functions.auth.user().onCreate(async user => {
+  const email = user.email || '';
+  const role = email.endsWith('@psiguard.app') ? 'Admin' : 'Psychologist';
+
+  await admin.auth().setCustomUserClaims(user.uid, { role });
+});


### PR DESCRIPTION
## Summary
- add an auth trigger to set user roles
- document the new function

## Testing
- `npm run typecheck` *(fails: Declaration or statement expected)*
- `npx jest` *(fails: needs jest installation)*

------
https://chatgpt.com/codex/tasks/task_e_684a5a2c907883248135e61667f7b15d