### PR TITLE
Isolate Firebase admin secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ This project uses environment variables for configuration, especially for Fireba
     *   May include other public keys for Google services like `NEXT_PUBLIC_GAS_PRONTUARIO_URL` or Google OAuth credentials if used directly on the client.
 
 *   **Server-Side Firebase Admin SDK Configuration (Secret)**:
-    *   These variables are **NOT** prefixed with `NEXT_PUBLIC_` (e.g., `FIREBASE_ADMIN_PROJECT_ID`, `FIREBASE_ADMIN_CLIENT_EMAIL`, `FIREBASE_ADMIN_PRIVATE_KEY`).
+*   These variables are **NOT** prefixed with `NEXT_PUBLIC_` (e.g., `FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL`, `FIREBASE_PRIVATE_KEY`).
     *   These are highly sensitive credentials used to initialize the Firebase Admin SDK on the server-side (e.g., in API routes, server components, or Genkit flows running in a Node.js environment).
     *   **CRITICAL**: These variables must be kept secret and should never be exposed to the client-side/browser.
     *   You can generate a new private key (which contains these values) in your Firebase project settings under "Service accounts". When copying the private key, ensure to format it correctly for a single-line environment variable (replace newlines `\n` with `\\n`).
     *   The `src/lib/firebaseAdmin.ts` file uses these variables to interact with Firebase services with admin privileges.
 
-**Important Security Note**: Always ensure that variables containing sensitive information (like `FIREBASE_ADMIN_PRIVATE_KEY`) are *never* prefixed with `NEXT_PUBLIC_` and are only used in server-side code.
+**Important Security Note**: Always ensure that variables containing sensitive information (like `FIREBASE_PRIVATE_KEY`) are *never* prefixed with `NEXT_PUBLIC_` and are only used in server-side code.
 =======
 ## Deploy
 
@@ -102,8 +102,8 @@ For a full blueprint of the application, see [docs/blueprint.md](docs/blueprint.
 1.  Vá para o dashboard do seu projeto no Vercel.
 2.  Navegue até a aba "Settings" (Configurações).
 3.  No menu lateral, clique em "Environment Variables" (Variáveis de Ambiente).
-4.  Adicione cada variável de ambiente necessária (tanto as `NEXT_PUBLIC_` quanto as de Admin SDK como `FIREBASE_ADMIN_PRIVATE_KEY`, etc.) conforme definido no seu `env.example` ou `.env.local`.
-    *   Para a `FIREBASE_ADMIN_PRIVATE_KEY`, que é uma chave multi-linha, você precisará formatá-la para uma única linha no Vercel, substituindo os caracteres de nova linha `\n` literais por `\\n`.
+4.  Adicione cada variável de ambiente necessária (tanto as `NEXT_PUBLIC_` quanto as de Admin SDK como `FIREBASE_PRIVATE_KEY`, etc.) conforme definido no seu `env.example` ou `.env.local`.
+    *   Para a `FIREBASE_PRIVATE_KEY`, que é uma chave multi-linha, você precisará formatá-la para uma única linha no Vercel, substituindo os caracteres de nova linha `\n` literais por `\\n`.
 5.  Escolha os ambientes (Produção, Pré-visualização, Desenvolvimento) onde cada variável deve estar disponível. Variáveis de Admin SDK (secretas) geralmente são necessárias em todos os ambientes para que as funções de backend funcionem.
 
 ### Comandos de Build

--- a/env.example
+++ b/env.example
@@ -27,11 +27,11 @@ NEXT_PUBLIC_GOOGLE_REDIRECT_URI="your_google_oauth_redirect_uri"
 # For Vercel: Set these as Environment Variables in your Vercel project settings.
 # For local development: Add them to a .env.local file (this file is gitignored).
 # -----------------------------------------------------------------------------
-FIREBASE_ADMIN_PROJECT_ID="your_firebase_project_id"
-FIREBASE_ADMIN_CLIENT_EMAIL="your_firebase_service_account_client_email"
+FIREBASE_PROJECT_ID="your_firebase_project_id"
+FIREBASE_CLIENT_EMAIL="your_firebase_service_account_client_email"
 # For the private key, it's often a multi-line string.
 # When setting it as an environment variable (e.g., in Vercel or .env.local):
 # 1. Copy the entire private key, including -----BEGIN PRIVATE KEY----- and -----END PRIVATE KEY-----.
 # 2. Replace all newline characters (\n) within the key with the literal string "\\n".
 # Example: "private_key": "-----BEGIN PRIVATE KEY-----\\nMIIEvA...\\n-----END PRIVATE KEY-----\\n"
-FIREBASE_ADMIN_PRIVATE_KEY="your_firebase_service_account_private_key"
+FIREBASE_PRIVATE_KEY="your_firebase_service_account_private_key"

--- a/scripts/backup.js
+++ b/scripts/backup.js
@@ -6,9 +6,9 @@ const fs = require('fs').promises;
 
 initializeApp({
   credential: cert({
-    projectId: process.env.FIREBASE_ADMIN_PROJECT_ID,
-    clientEmail: process.env.FIREBASE_ADMIN_CLIENT_EMAIL,
-    privateKey: process.env.FIREBASE_ADMIN_PRIVATE_KEY.replace(/\\n/g, '\n'),
+    projectId: process.env.FIREBASE_PROJECT_ID,
+    clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+    privateKey: process.env.FIREBASE_PRIVATE_KEY.replace(/\\n/g, '\n'),
   }),
 });
 

--- a/src/app/api/createAppointment/route.ts
+++ b/src/app/api/createAppointment/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
-import { adminDb } from '@/lib/firebaseAdmin';
+import { firestoreAdmin } from '@/lib/firebaseAdmin';
 
 const AppointmentSchema = z.object({
   appointmentDate: z.string(),
@@ -18,7 +18,7 @@ export async function POST(req: Request) {
     const body = await req.json();
     const data = AppointmentSchema.parse(body);
 
-    const qSnapshot = await adminDb
+    const qSnapshot = await firestoreAdmin
       .collection('appointments')
       .where('psychologistId', '==', data.psychologistId)
       .where('appointmentDate', '==', data.appointmentDate)
@@ -39,7 +39,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: 'Schedule conflict' }, { status: 409 });
     }
 
-    const docRef = await adminDb.collection('appointments').add({
+    const docRef = await firestoreAdmin.collection('appointments').add({
       ...data,
       status: 'Scheduled',
     });

--- a/src/lib/firebaseAdmin.ts
+++ b/src/lib/firebaseAdmin.ts
@@ -1,22 +1,13 @@
-import { initializeApp, getApps, cert, getApp, type AppOptions } from 'firebase-admin/app';
-import { getFirestore } from 'firebase-admin/firestore';
+import admin from 'firebase-admin';
 
-let options: AppOptions | undefined;
-
-if (
-  process.env.FIREBASE_ADMIN_PROJECT_ID &&
-  process.env.FIREBASE_ADMIN_CLIENT_EMAIL &&
-  process.env.FIREBASE_ADMIN_PRIVATE_KEY
-) {
-  options = {
-    credential: cert({
-      projectId: process.env.FIREBASE_ADMIN_PROJECT_ID,
-      clientEmail: process.env.FIREBASE_ADMIN_CLIENT_EMAIL,
-      privateKey: process.env.FIREBASE_ADMIN_PRIVATE_KEY.replace(/\\n/g, '\n'),
+const app =
+  admin.apps[0] ??
+  admin.initializeApp({
+    credential: admin.credential.cert({
+      projectId: process.env.FIREBASE_PROJECT_ID,
+      clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+      privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
     }),
-  };
-}
+  });
 
-const adminApp = getApps().length ? getApp() : initializeApp(options);
-
-export const adminDb = getFirestore(adminApp);
+export const firestoreAdmin = app.firestore();


### PR DESCRIPTION
## Summary
- use firebase admin credentials from env in server-only helper
- rename admin env vars in example file
- update backup script and API routes to use new helper
- document new env var names

## Testing
- `npm run build` *(fails: You are attempting to export "metadata" from a component marked with "use client")*

------
https://chatgpt.com/codex/tasks/task_e_684a7cd4075883249e15ed107faebf55