### PR TITLE
Fix stray closing braces in API routes

### DIFF
--- a/src/app/api/ai/report-draft/route.ts
+++ b/src/app/api/ai/report-draft/route.ts
@@ -25,6 +25,3 @@ export async function POST(req: Request) {
     );
   }
 }
-
-  }
-}

--- a/src/app/api/ai/session-insights/route.ts
+++ b/src/app/api/ai/session-insights/route.ts
@@ -25,6 +25,3 @@ export async function POST(req: Request) {
     );
   }
 }
-
-  }
-}

--- a/src/app/api/ai/session-note-template/route.ts
+++ b/src/app/api/ai/session-note-template/route.ts
@@ -25,6 +25,3 @@ export async function POST(req: Request) {
     );
   }
 }
-
-  }
-}


### PR DESCRIPTION
## Summary
- clean up extra braces in report-draft, session-insights and session-note-template API routes

## Testing
- `npm test` *(fails: `firebase` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a7fe56bd08324807b5aaeca81660a