### PR TITLE
Move metadata export out of client layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,10 @@
 "use client";
 
-import type { Metadata } from 'next';
 import './globals.css';
 import { Toaster } from "@/components/ui/toaster";
 import usePageView from "@/hooks/use-page-view";
 import useSessionTimeout from "@/hooks/use-session-timeout";
 
-export const metadata: Metadata = {
-  title: 'PsiGuard - Plataforma de Bem-Estar Mental',
-  description: 'Plataforma completa para gerenciamento de consultórios de psicologia.',
-};
 
 export default function RootLayout({
   children,

--- a/src/app/metadata.ts
+++ b/src/app/metadata.ts
@@ -1,0 +1,6 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'PsiGuard - Plataforma de Bem-Estar Mental',
+  description: 'Plataforma completa para gerenciamento de consultórios de psicologia.',
+};


### PR DESCRIPTION
## Summary
- move root layout metadata to a server file
- keep layout as a client component

## Testing
- `npx next build` *(fails: Syntax Error in other files)*

------
https://chatgpt.com/codex/tasks/task_e_684a7fe4b3b48324a1fcc6568862d05e