### PR TITLE
Implement empty state and profile page

### DIFF
--- a/src/app/(app)/patients/page.tsx
+++ b/src/app/(app)/patients/page.tsx
@@ -10,6 +10,8 @@ import { mockPatients } from "@/mocks/patients";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { checkUserRole } from "@/services/authRole";
+import EmptyState from "@/components/ui/empty-state";
+import { APP_ROUTES } from "@/lib/routes";
 
 export default function PatientsPage() {
   const router = useRouter();
@@ -51,23 +53,23 @@ export default function PatientsPage() {
         <CardContent>
           {mockPatients.length > 0 ? (
             <div className="space-y-4">
-              {mockPatients.map(patient => (
+              {mockPatients.map((patient) => (
                 <PatientListItem key={patient.id} patient={patient} />
               ))}
             </div>
           ) : (
-            <div className="text-center py-10">
-              <Users className="mx-auto h-12 w-12 text-muted-foreground" />
-              <h3 className="mt-2 text-sm font-medium text-foreground">Nenhum paciente encontrado</h3>
-              <p className="mt-1 text-sm text-muted-foreground">Comece adicionando um novo paciente.</p>
-              <div className="mt-6">
+            <EmptyState
+              icon={<Users className="mx-auto h-12 w-12 text-muted-foreground" />}
+              title="Nenhum paciente encontrado"
+              description="Comece adicionando um novo paciente."
+              action={
                 <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
-                  <Link href="/patients/new">
+                  <Link href={APP_ROUTES.newPatient}>
                     <UserPlus className="mr-2 h-4 w-4" /> Adicionar Novo Paciente
                   </Link>
                 </Button>
-              </div>
-            </div>
+              }
+            />
           )}
         </CardContent>
       </Card>

--- a/src/app/my-profile/page.tsx
+++ b/src/app/my-profile/page.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { UserCircle, Mail, Phone, CalendarDays } from "lucide-react";
+
+export default function MyProfilePage() {
+  const patient = {
+    name: "Ana Souza",
+    email: "ana.souza@example.com",
+    phone: "(11) 91234-5678",
+    birthDate: "1990-05-15",
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-2">
+        <UserCircle className="h-7 w-7 text-primary" />
+        <h1 className="text-3xl font-headline font-bold">Meu Perfil</h1>
+      </div>
+
+      <Card className="shadow-lg">
+        <CardHeader>
+          <CardTitle className="font-headline text-2xl">{patient.name}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm">
+          <InfoRow label="E-mail" value={patient.email} icon={<Mail />} />
+          <InfoRow label="Contato" value={patient.phone} icon={<Phone />} />
+          <InfoRow label="Data de Nascimento" value={patient.birthDate} icon={<CalendarDays />} />
+        </CardContent>
+        <CardFooter className="flex justify-end">
+          <Button disabled>Editar Informações</Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}
+
+interface InfoRowProps {
+  label: string;
+  value: string;
+  icon: React.ReactNode;
+}
+
+function InfoRow({ label, value, icon }: InfoRowProps) {
+  return (
+    <div className="flex items-start gap-2">
+      <span className="text-muted-foreground mt-0.5">{icon}</span>
+      <div>
+        <p className="font-medium text-foreground">{label}</p>
+        <p className="text-muted-foreground">{value}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/sidebar-nav.tsx
+++ b/src/components/layout/sidebar-nav.tsx
@@ -25,8 +25,9 @@ import {
   BarChartBig, 
   Users2 as GroupsIcon,
   Network,
-  LineChart 
+  LineChart
 } from "lucide-react";
+import { APP_ROUTES } from "@/lib/routes";
 import {
   SidebarMenu,
   SidebarMenuItem,
@@ -49,43 +50,43 @@ interface NavItem {
 }
 
 const navStructure: NavItem[] = [
-  { href: "/dashboard", label: "Painel", icon: LayoutDashboard, group: "Visão Geral" },
-  { href: "/schedule", label: "Agenda", icon: CalendarDays, group: "Visão Geral" },
+  { href: APP_ROUTES.dashboard, label: "Painel", icon: LayoutDashboard, group: "Visão Geral" },
+  { href: APP_ROUTES.schedule, label: "Agenda", icon: CalendarDays, group: "Visão Geral" },
   
-  { href: "/patients", label: "Pacientes", icon: Users, group: "Gestão de Pacientes" },
-  { href: "/groups", label: "Grupos Terapêuticos", icon: GroupsIcon, group: "Gestão de Pacientes"},
-  { href: "/waiting-list", label: "Lista de Espera", icon: ListChecks, group: "Gestão de Pacientes" },
-  { href: "/templates", label: "Modelos Inteligentes", icon: FileText, group: "Gestão de Pacientes" },
+  { href: APP_ROUTES.patients, label: "Pacientes", icon: Users, group: "Gestão de Pacientes" },
+  { href: APP_ROUTES.groups, label: "Grupos Terapêuticos", icon: GroupsIcon, group: "Gestão de Pacientes"},
+  { href: APP_ROUTES.waitingList, label: "Lista de Espera", icon: ListChecks, group: "Gestão de Pacientes" },
+  { href: APP_ROUTES.templates, label: "Modelos Inteligentes", icon: FileText, group: "Gestão de Pacientes" },
   
-  { href: "/tasks", label: "Tarefas", icon: CheckSquare, group: "Operações da Clínica" },
-  { href: "/resources", label: "Recursos da Clínica", icon: FolderArchive, group: "Operações da Clínica" },
+  { href: APP_ROUTES.tasks, label: "Tarefas", icon: CheckSquare, group: "Operações da Clínica" },
+  { href: APP_ROUTES.resources, label: "Recursos da Clínica", icon: FolderArchive, group: "Operações da Clínica" },
   { 
-    href: "/analytics", label: "Análises", icon: BarChartBig, group: "Operações da Clínica",
+    href: APP_ROUTES.analytics, label: "Análises", icon: BarChartBig, group: "Operações da Clínica",
     subItems: [
-      { href: "/analytics/clinic-occupancy", label: "Ocupação da Clínica", icon: BarChartBig },
+      { href: APP_ROUTES.analyticsClinicOccupancy, label: "Ocupação da Clínica", icon: BarChartBig },
     ]
   },
 
   { 
-    href: "/tools", label: "Ferramentas Clínicas", icon: Wrench, group: "Utilidades",
+    href: APP_ROUTES.tools, label: "Ferramentas Clínicas", icon: Wrench, group: "Utilidades",
     subItems: [
-      { href: "/tools/psychopharmacology", label: "Psicofarmacologia", icon: BookOpen },
-      { href: "/tools/knowledge-base", label: "Base de Conhecimento", icon: BrainCog },
-      { href: "/tools/case-formulation-models", label: "Modelos de Formulação", icon: Network },
-      { href: "/inventories-scales", label: "Inventários e Escalas", icon: ClipboardList },
+      { href: APP_ROUTES.toolsPsychopharmacology, label: "Psicofarmacologia", icon: BookOpen },
+      { href: APP_ROUTES.toolsKnowledgeBase, label: "Base de Conhecimento", icon: BrainCog },
+      { href: APP_ROUTES.toolsCaseFormulationModels, label: "Modelos de Formulação", icon: Network },
+      { href: APP_ROUTES.inventoriesScales, label: "Inventários e Escalas", icon: ClipboardList },
     ]
   },
   
   { 
     href: "#", label: "Ferramentas Admin", icon: Settings, adminOnly: true, group: "Administração", 
     subItems: [
-        { href: "/user-approvals", label: "Aprovação de Usuários", icon: ShieldQuestion, adminOnly: true },
-        { href: "/tools/backup", label: "Backup de Dados", icon: DataBackupIcon, adminOnly: true },
-        { href: "/tools/audit-trail", label: "Trilha de Auditoria", icon: HistoryIcon, adminOnly: true }, 
-        { href: "/admin/metrics", label: "Métricas da Clínica", icon: LineChart, adminOnly: true },
+        { href: APP_ROUTES.userApprovals, label: "Aprovação de Usuários", icon: ShieldQuestion, adminOnly: true },
+        { href: APP_ROUTES.toolsBackup, label: "Backup de Dados", icon: DataBackupIcon, adminOnly: true },
+        { href: APP_ROUTES.toolsAuditTrail, label: "Trilha de Auditoria", icon: HistoryIcon, adminOnly: true }, 
+        { href: APP_ROUTES.adminMetrics, label: "Métricas da Clínica", icon: LineChart, adminOnly: true },
     ]
   },
-  { href: "/settings", label: "Configurações", icon: Settings, group: "Configuração" },
+  { href: APP_ROUTES.settings, label: "Configurações", icon: Settings, group: "Configuração" },
 ];
 
 

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { cn } from "@/shared/utils";
+
+interface EmptyStateProps {
+  title: string;
+  description: string;
+  action?: React.ReactNode;
+  icon?: React.ReactNode;
+  className?: string;
+}
+
+export default function EmptyState({ title, description, action, icon, className }: EmptyStateProps) {
+  return (
+    <div className={cn("text-center py-10", className)}>
+      {icon}
+      <h3 className="mt-2 text-sm font-medium text-foreground">{title}</h3>
+      <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+      {action && <div className="mt-6">{action}</div>}
+    </div>
+  );
+}

--- a/src/hooks/use-page-view.tsx
+++ b/src/hooks/use-page-view.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
+import { AnalyticsEvent } from '@/types/analytics';
 
 // Extend the Window interface to include gtag
 declare global {
@@ -8,14 +9,14 @@ declare global {
   }
 }
 
-export default function usePageView() {
+export default function usePageView(eventName: AnalyticsEvent = AnalyticsEvent.PAGE_VIEW) {
   const router = useRouter();
 
   useEffect(() => {
     if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
-      window.gtag('event', 'page_view', {
+      window.gtag('event', eventName, {
         page_path: router.pathname,
       });
     }
-  }, [router.pathname]);
+  }, [router.pathname, eventName]);
 }

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,0 +1,26 @@
+export const APP_ROUTES = {
+  dashboard: "/dashboard",
+  schedule: "/schedule",
+  patients: "/patients",
+  newPatient: "/patients/new",
+  groups: "/groups",
+  waitingList: "/waiting-list",
+  templates: "/templates",
+  tasks: "/tasks",
+  resources: "/resources",
+  analytics: "/analytics",
+  analyticsClinicOccupancy: "/analytics/clinic-occupancy",
+  tools: "/tools",
+  toolsPsychopharmacology: "/tools/psychopharmacology",
+  toolsKnowledgeBase: "/tools/knowledge-base",
+  toolsCaseFormulationModels: "/tools/case-formulation-models",
+  inventoriesScales: "/inventories-scales",
+  userApprovals: "/user-approvals",
+  toolsBackup: "/tools/backup",
+  toolsAuditTrail: "/tools/audit-trail",
+  adminMetrics: "/admin/metrics",
+  settings: "/settings",
+  help: "/help",
+};
+
+export type AppRouteKeys = keyof typeof APP_ROUTES;

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -1,0 +1,4 @@
+export enum AnalyticsEvent {
+  PAGE_VIEW = 'page_view',
+  PATIENT_CREATED = 'patient_created',
+}


### PR DESCRIPTION
## Summary
- add reusable `EmptyState` component
- show empty state on Patients page when there are no patients
- implement a simple My Profile page for patient portal
- type analytics events and refactor `usePageView`
- centralize sidebar routes in `APP_ROUTES`

## Testing
- `npx next lint` *(fails: need to install packages)*
- `npm run typecheck` *(fails: existing type errors)*
- `npm test` *(fails: firebase command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b07aff2248324a5472dcb6a277b7e