### PR TITLE
Implement session inactivity hook

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,9 @@ import './globals.css';
 import { Toaster } from "@/components/ui/toaster";
 import usePageView from "@/hooks/use-page-view";
 import useSessionTimeout from "@/hooks/use-session-timeout";
+import { signOut } from "firebase/auth";
+import { auth } from "@/services/firebase";
+import { useRouter } from "next/navigation";
 
 
 export default function RootLayout({
@@ -12,7 +15,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   usePageView();
-  useSessionTimeout();
+  const router = useRouter();
+  useSessionTimeout(async () => {
+    await signOut(auth);
+    router.push("/login");
+  });
   return (
     <html lang="pt-BR" suppressHydrationWarning>
       <head>


### PR DESCRIPTION
## Summary
- implement a generic `useSessionTimeout` hook to detect inactivity
- update RootLayout to use the hook with logout callback

## Testing
- `npm test` *(fails: firebase not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b78e3e51c832499733a276cb05fa8