### PR TITLE
Fix redirect to missing 403 page

### DIFF
--- a/src/app/403/page.tsx
+++ b/src/app/403/page.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function ForbiddenPage() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen text-center p-4 space-y-4">
+      <h1 className="text-4xl font-headline font-bold">403 - Acesso Negado</h1>
+      <p className="text-muted-foreground">Você não tem permissão para acessar esta página.</p>
+      <Button asChild>
+        <Link href="/login">Ir para Login</Link>
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add missing 403 route

## Testing
- `npm test` *(fails: connect ECONNREFUSED to firestore emulator)*
- `npm run jest` *(fails: same error and jest config issues)*

------
https://chatgpt.com/codex/tasks/task_e_684b78fdfa288324bdc8d26384049798