### PR TITLE
Centralize Firestore collection constants

### DIFF
--- a/src/lib/firestore-collections.ts
+++ b/src/lib/firestore-collections.ts
@@ -1,0 +1,13 @@
+export const FIRESTORE_COLLECTIONS = {
+  USERS: 'users',
+  PATIENTS: 'patients',
+  APPOINTMENTS: 'appointments',
+  ASSESSMENTS: 'assessments',
+  TASKS: 'tasks',
+  CHATS: 'chats',
+  NOTIFICATIONS: 'notifications',
+  FCM_TOKENS: 'fcmTokens',
+  MESSAGES: 'messages',
+} as const;
+
+export type FirestoreCollectionKeys = keyof typeof FIRESTORE_COLLECTIONS;

--- a/src/services/assessmentService.ts
+++ b/src/services/assessmentService.ts
@@ -1,10 +1,11 @@
 "use client";
 import { collection, addDoc, updateDoc, doc, getDocs, query, where } from 'firebase/firestore';
 import { db } from './firebase';
+import { FIRESTORE_COLLECTIONS } from '@/lib/firestore-collections';
 import type { Assessment } from '@/types/assessment';
 
 export async function createAssessment(data: Omit<Assessment, 'id' | 'createdAt' | 'completedAt'>): Promise<string> {
-  const docRef = await addDoc(collection(db, 'assessments'), {
+  const docRef = await addDoc(collection(db, FIRESTORE_COLLECTIONS.ASSESSMENTS), {
     ...data,
     createdAt: new Date().toISOString(),
   });
@@ -12,7 +13,7 @@ export async function createAssessment(data: Omit<Assessment, 'id' | 'createdAt'
 }
 
 export async function submitAssessmentResponses(assessmentId: string, responses: Record<string, unknown>): Promise<void> {
-  await updateDoc(doc(db, 'assessments', assessmentId), {
+  await updateDoc(doc(db, FIRESTORE_COLLECTIONS.ASSESSMENTS, assessmentId), {
     responses,
     status: 'completed',
     completedAt: new Date().toISOString(),
@@ -20,7 +21,7 @@ export async function submitAssessmentResponses(assessmentId: string, responses:
 }
 
 export async function getAssessmentsByPatient(patientId: string): Promise<Assessment[]> {
-  const q = query(collection(db, 'assessments'), where('patientId', '==', patientId));
+  const q = query(collection(db, FIRESTORE_COLLECTIONS.ASSESSMENTS), where('patientId', '==', patientId));
   const snapshot = await getDocs(q);
   return snapshot.docs.map(d => ({ id: d.id, ...(d.data() as Omit<Assessment, 'id'>) }));
 }


### PR DESCRIPTION
## Summary
- centralize Firestore collection names in `src/lib/firestore-collections.ts`
- refactor `assessmentService` to use the new constants

## Testing
- `npm run lint` *(fails: Definition for rule '@next/next/link-passhref' was not found)*
- `npm run typecheck` *(fails: several TypeScript errors)*
- `npm test` *(fails: Error: download failed, status 403: Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684b791c6f008324b52be0e4cc1be63f