### PR TITLE
Fix Jest setup for Firestore and React tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,11 +10,18 @@ const webConfig = createJestConfig({
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
-    '^.+\\.(css|scss|sass)$': 'identity-obj-proxy'
+    '^.+\\.(css|scss|sass)$': 'identity-obj-proxy',
+    '^lucide-react$': '<rootDir>/node_modules/lucide-react/dist/cjs/lucide-react.js'
   },
   transform: {
     '^.+\\.(js|jsx|ts|tsx)$': ['babel-jest', { presets: ['next/babel'] }],
   },
+  transformIgnorePatterns: [
+    'node_modules/(?!(lucide-react)/)'
+  ],
+  testPathIgnorePatterns: [
+    '/__tests__/.*rules\\.test\\.ts$'
+  ],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
 });
 
@@ -27,8 +34,11 @@ const firestoreConfig = {
     '<rootDir>/__tests__/**/*.rules.test.ts',
     '<rootDir>/__tests__/**/*firestore*.test.ts'
   ],
+  testTimeout: 10000,
 };
 
-module.exports = {
-  projects: [webConfig, firestoreConfig],
+module.exports = async () => {
+  return {
+    projects: [await webConfig(), firestoreConfig],
+  };
 };

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -9,3 +9,10 @@ if (typeof global.fetch === 'undefined') {
   global.Request = fetchModule.Request;
   global.Response = fetchModule.Response;
 }
+
+// Polyfill setImmediate for environments where it's not available
+if (typeof global.setImmediate === 'undefined') {
+  global.setImmediate = (fn: (...args: any[]) => void, ...args: any[]) => {
+    return setTimeout(fn, 0, ...args);
+  };
+}


### PR DESCRIPTION
## Summary
- polyfill `setImmediate` in Jest setup
- transpile `lucide-react` by mapping to its CJS build and allow transform
- ignore Firestore rules tests in jsdom project and extend timeout
- export Jest config asynchronously so Next.js helper runs correctly

## Testing
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:8082)*

------
https://chatgpt.com/codex/tasks/task_e_684b7d51ba7c83249af6d43dc1557b2a