### PR TITLE
Fix test setup for Firestore emulator

### DIFF
--- a/__tests__/firestore-rules.test.ts
+++ b/__tests__/firestore-rules.test.ts
@@ -6,11 +6,15 @@ import fetch from 'node-fetch';
 let testEnv: Awaited<ReturnType<typeof initializeTestEnvironment>>;
 
 beforeAll(async () => {
+  const hostPort = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8082';
+  const [host, portStr] = hostPort.split(':');
+  const port = parseInt(portStr, 10);
+
   testEnv = await initializeTestEnvironment({
     projectId: 'demo-project',
     firestore: {
-      host: '127.0.0.1',
-      port: 8082,
+      host,
+      port,
       rules: readFileSync('firestore.rules', 'utf8'),
     },
   });

--- a/__tests__/patients.rules.test.ts
+++ b/__tests__/patients.rules.test.ts
@@ -6,11 +6,15 @@ import fetch from 'node-fetch';
 let testEnv: Awaited<ReturnType<typeof initializeTestEnvironment>>;
 
 beforeAll(async () => {
+  const hostPort = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8082';
+  const [host, portStr] = hostPort.split(':');
+  const port = parseInt(portStr, 10);
+
   testEnv = await initializeTestEnvironment({
     projectId: 'demo-project',
     firestore: {
-      host: '127.0.0.1',
-      port: 8082,
+      host,
+      port,
       rules: readFileSync('firestore.rules', 'utf8'),
     },
   });

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "jest",
+    "test": "firebase emulators:exec --project demo-project jest",
     "test:rules": "firebase emulators:exec --project demo-project jest --selectProjects firestore",
     "jest": "jest",
     "backup": "node scripts/backup.js"

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -33,8 +33,6 @@ async function requestAI<T>(url: string, body: unknown): Promise<T> {
   }
 }
 
-}
-
 export async function generateSessionInsights(
   input: GenerateSessionInsightsInput,
 ): Promise<GenerateSessionInsightsOutput> {


### PR DESCRIPTION
## Summary
- make Firestore rule tests honor `FIRESTORE_EMULATOR_HOST`
- remove stray brace in `aiService`
- run `npm test` with the Firestore emulator

## Testing
- `npm test` *(fails: download failed, status 403: Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684b7f53366883248850de6cdb7be692