### PR TITLE
Fix Jest setup with pre-env polyfills

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ const createJestConfig = nextJest({
 const webConfig = createJestConfig({
   displayName: 'web',
   testEnvironment: 'jsdom',
+  setupFiles: ['<rootDir>/jest.polyfills.ts'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
@@ -29,6 +30,7 @@ const firestoreConfig = {
   displayName: 'firestore',
   preset: 'ts-jest',
   testEnvironment: 'node',
+  setupFiles: ['<rootDir>/jest.polyfills.ts'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   testMatch: [
     '<rootDir>/__tests__/**/*.rules.test.ts',

--- a/jest.polyfills.ts
+++ b/jest.polyfills.ts
@@ -1,0 +1,22 @@
+// Polyfills for Jest tests
+if (typeof global.fetch === 'undefined') {
+  const fetchModule = require('cross-fetch');
+  global.fetch = fetchModule.default || fetchModule;
+  global.Headers = fetchModule.Headers;
+  global.Request = fetchModule.Request;
+  global.Response = fetchModule.Response;
+}
+
+if (typeof global.setImmediate === 'undefined') {
+  global.setImmediate = (fn: (...args: any[]) => void, ...args: any[]) => {
+    return setTimeout(fn, 0, ...args);
+  };
+}
+
+if (typeof (global as any).ResizeObserver === 'undefined') {
+  (global as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,18 +1,1 @@
 import '@testing-library/jest-dom';
-
-// Polyfill for fetch in Node.js environment for Firebase rules testing
-// 'cross-fetch/polyfill' should ideally do this, but to be more explicit:
-if (typeof global.fetch === 'undefined') {
-  const fetchModule = require('cross-fetch');
-  global.fetch = fetchModule.default || fetchModule; // Handles different export styles
-  global.Headers = fetchModule.Headers;
-  global.Request = fetchModule.Request;
-  global.Response = fetchModule.Response;
-}
-
-// Polyfill setImmediate for environments where it's not available
-if (typeof global.setImmediate === 'undefined') {
-  global.setImmediate = (fn: (...args: any[]) => void, ...args: any[]) => {
-    return setTimeout(fn, 0, ...args);
-  };
-}


### PR DESCRIPTION
## Summary
- ensure polyfills run before tests by creating `jest.polyfills.ts`
- use new polyfills file in both web and firestore projects
- keep `jest.setup.ts` only for `jest-dom`

## Testing
- `npx jest __tests__/resizeobserver.test.ts --runInBand`
- `npx jest --selectProjects firestore` *(fails: connect ECONNREFUSED 127.0.0.1:8082)*

------
https://chatgpt.com/codex/tasks/task_e_684b82abe6cc832492127534d3140f75