### PR TITLE
Add client error boundary

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,4 +1,5 @@
 import AppLayout from "@/components/layout/app-layout";
+import ErrorBoundary from "@/components/layout/error-boundary";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -11,5 +12,9 @@ export default function AuthenticatedAppLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <AppLayout>{children}</AppLayout>;
+  return (
+    <ErrorBoundary>
+      <AppLayout>{children}</AppLayout>
+    </ErrorBoundary>
+  );
 }

--- a/src/components/layout/error-boundary.tsx
+++ b/src/components/layout/error-boundary.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import React from "react";
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error("Uncaught error:", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        this.props.fallback || (
+          <div className="flex flex-col items-center justify-center py-10">
+            <h2 className="text-xl font-semibold">Algo deu errado.</h2>
+            <button
+              onClick={() => this.setState({ hasError: false })}
+              className="mt-4 underline"
+            >
+              Tentar novamente
+            </button>
+          </div>
+        )
+      );
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## Summary
- add ErrorBoundary component for catching runtime errors
- wrap main layout with ErrorBoundary

## Testing
- `npm test` *(fails: `firebase` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b856edf5c8324ba0bd639e7e1610e