### PR TITLE
Implement notes interface and FAQ page

### DIFF
--- a/src/app/(app)/admin/metrics/page.tsx
+++ b/src/app/(app)/admin/metrics/page.tsx
@@ -24,6 +24,8 @@ const mockAdminMetrics = {
   totalPatients: 157,
   sessionsThisMonth: 523,
   avgSessionDuration: 52, // minutes
+  totalPsychologists: 8,
+  openTasks: 34,
 };
 
 
@@ -55,10 +57,32 @@ export default function AdminMetricsPage() {
       </CardDescription>
 
       {/* General Clinic KPIs */}
-      <div className="grid gap-4 md:grid-cols-3">
-        <StatsCard title="Total de Pacientes Ativos" value={mockAdminMetrics.totalPatients.toString()} icon={<Users className="text-primary" />} />
-        <StatsCard title="Sessões Realizadas (Este Mês)" value={mockAdminMetrics.sessionsThisMonth.toString()} icon={<CalendarCheck className="text-primary" />} />
-        <StatsCard title="Duração Média da Sessão" value={`${mockAdminMetrics.avgSessionDuration} min`} icon={<Clock className="text-primary" />} />
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5">
+        <StatsCard
+          title="Total de Pacientes Ativos"
+          value={mockAdminMetrics.totalPatients.toString()}
+          icon={<Users className="text-primary" />}
+        />
+        <StatsCard
+          title="Sessões Realizadas (Este Mês)"
+          value={mockAdminMetrics.sessionsThisMonth.toString()}
+          icon={<CalendarCheck className="text-primary" />}
+        />
+        <StatsCard
+          title="Psicólogos Ativos"
+          value={mockAdminMetrics.totalPsychologists.toString()}
+          icon={<Users className="text-primary" />}
+        />
+        <StatsCard
+          title="Tarefas Abertas"
+          value={mockAdminMetrics.openTasks.toString()}
+          icon={<Clock className="text-primary" />}
+        />
+        <StatsCard
+          title="Duração Média da Sessão"
+          value={`${mockAdminMetrics.avgSessionDuration} min`}
+          icon={<Clock className="text-primary" />}
+        />
       </div>
 
       {/* Charts Section */}

--- a/src/app/(app)/notes/page.tsx
+++ b/src/app/(app)/notes/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Calendar } from "@/components/ui/calendar";
+import DateNotesForm from "@/components/forms/date-notes-form";
+import { NotebookPen } from "lucide-react";
+import { format } from "date-fns";
+import { ptBR } from "date-fns/locale";
+
+export default function NotesPage() {
+  const [selectedDate, setSelectedDate] = useState<Date | undefined>(new Date());
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-2">
+        <NotebookPen className="h-7 w-7 text-primary" />
+        <h1 className="text-3xl font-headline font-bold">Anotações por Data</h1>
+      </div>
+      <CardDescription>Escolha uma data no calendário e registre suas notas.</CardDescription>
+      <div className="grid gap-6 md:grid-cols-2">
+        <Card className="shadow-sm">
+          <CardHeader>
+            <CardTitle className="font-headline">Selecione a Data</CardTitle>
+          </CardHeader>
+          <CardContent className="flex justify-center">
+            <Calendar locale={ptBR} mode="single" selected={selectedDate} onSelect={setSelectedDate} />
+          </CardContent>
+        </Card>
+        <Card className="shadow-sm">
+          <CardHeader>
+            <CardTitle className="font-headline">
+              {selectedDate ? `Notas de ${format(selectedDate, "P", { locale: ptBR })}` : "Notas"}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <DateNotesForm key={selectedDate?.toISOString()} defaultDateTime={selectedDate ?? new Date()} />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/tools/knowledge-base/page.tsx
+++ b/src/app/(app)/tools/knowledge-base/page.tsx
@@ -1,128 +1,39 @@
-
 "use client";
 
-import React from "react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle, CardFooter } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { BrainCog, FolderKanban, FileText, Search, Filter, Download, ExternalLink } from "lucide-react"; // Changed BookOpenText to FolderKanban
-import { Input } from "@/components/ui/input";
-import Link from "next/link";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import { BookOpen } from "lucide-react";
 
-// Mock data for Drive files - replace with actual API call result
-const mockDriveFiles = [
-  { id: "drive_pdf_1", name: "Manual_TCC_Completo.pdf", type: "pdf", lastModified: "2024-07-20", size: "5.2MB", shared: true, dataAiHint: "documento manual" },
-  { id: "drive_pdf_2", name: "Artigo_Mindfulness_Estresse.pdf", type: "pdf", lastModified: "2024-06-15", size: "1.8MB", shared: false, dataAiHint: "documento artigo" },
-  { id: "drive_img_1", name: "Infografico_Ansiedade.png", type: "image", lastModified: "2024-05-10", size: "3.1MB", shared: true, dataAiHint: "imagem infográfico" },
-  { id: "drive_folder_1", name: "Recursos para Pacientes", type: "folder", lastModified: "2024-07-22", dataAiHint: "pasta documentos" },
+const faqs = [
+  { id: "faq1", question: "Como realizo o backup do sistema?", answer: "Acesse a ferramenta de Backup no menu de Ferramentas e clique em 'Iniciar Novo Backup'." },
+  { id: "faq2", question: "Posso restaurar dados de um backup antigo?", answer: "Sim. Na tela de Backup há uma seção de histórico onde é possível restaurar a partir de um ponto salvo." },
+  { id: "faq3", question: "Como adiciono novos usuários?", answer: "Usuários são gerenciados na área de Admin > Aprovações de Usuários. Lá é possível convidar e definir permissões." },
+  { id: "faq4", question: "Onde encontro relatórios de métricas?", answer: "O Dashboard de Métricas do Admin reúne informações gerais do sistema como número de pacientes e sessões." },
 ];
 
-const getFileIcon = (type: string) => {
-  if (type === 'pdf') return <FileText className="h-5 w-5 text-red-500" />;
-  if (type === 'image') return <FileText className="h-5 w-5 text-green-500" />; // Could be FileImage
-  if (type === 'folder') return <FolderKanban className="h-5 w-5 text-yellow-600" />;
-  return <FileText className="h-5 w-5 text-muted-foreground" />;
-};
-
-
-export default function KnowledgeBaseDrivePage() {
-  const [isConnected, setIsConnected] = React.useState(false); // Simulate Drive connection status
-  const [driveFiles, setDriveFiles] = React.useState<typeof mockDriveFiles>([]);
-
-  const handleConnectDrive = () => {
-    // Simulate API call to connect and fetch files
-    setIsConnected(true);
-    setDriveFiles(mockDriveFiles); 
-    // In a real app, this would initiate OAuth flow and then fetch files
-  };
-
+export default function KnowledgeBasePage() {
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-2">
-        <BrainCog className="h-7 w-7 text-primary" />
-        <h1 className="text-3xl font-headline font-bold">Base de Conhecimento (Google Drive)</h1>
+        <BookOpen className="h-7 w-7 text-primary" />
+        <h1 className="text-3xl font-headline font-bold">Perguntas Frequentes</h1>
       </div>
-      <CardDescription>
-        Conecte sua conta Google Drive para acessar, visualizar e baixar seus documentos e PDFs diretamente no PsiGuard.
-      </CardDescription>
-
-      {!isConnected ? (
-        <Card className="shadow-sm text-center">
-          <CardHeader>
-            <CardTitle className="font-headline">Conectar ao Google Drive</CardTitle>
-            <CardDescription>
-              Autorize o PsiGuard a acessar seus arquivos do Google Drive para uma integração transparente.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Button onClick={handleConnectDrive} className="bg-accent hover:bg-accent/90 text-accent-foreground">
-              <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M19.51,5.363l-2.939,5.09H22L12,21.545L6.49,12.273H2l2.939-5.09L9.021,12.5l2.979-5.159L14.979,12.5Z"/>
-              </svg>
-              Conectar com Google Drive
-            </Button>
-            <p className="text-xs text-muted-foreground mt-3">
-              PsiGuard solicitará apenas permissão para visualizar arquivos que você selecionar ou que estejam em pastas específicas.
-            </p>
-          </CardContent>
-        </Card>
-      ) : (
-        <Card className="shadow-sm">
-          <CardHeader>
-            <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3">
-                <CardTitle className="font-headline">Seus Documentos do Drive</CardTitle>
-                <Button variant="outline" size="sm" onClick={() => {setIsConnected(false); setDriveFiles([])}}>
-                    Desconectar Drive
-                </Button>
-            </div>
-            <div className="flex flex-col sm:flex-row gap-2 pt-4">
-                <div className="relative flex-1">
-                    <Search className="absolute left-2.5 top-3 h-4 w-4 text-muted-foreground" />
-                    <Input placeholder="Buscar em seus documentos do Drive..." className="pl-8" />
-                </div>
-                <Button variant="outline">
-                    <Filter className="mr-2 h-4 w-4" /> Filtrar por Tipo
-                </Button>
-            </div>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {driveFiles.length > 0 ? (
-              driveFiles.map(file => (
-                <Card key={file.id} className="shadow-xs hover:shadow-sm transition-shadow">
-                  <CardContent className="p-3 flex items-center justify-between gap-3">
-                    <div className="flex items-center gap-3 flex-1 min-w-0">
-                      {getFileIcon(file.type)}
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm font-medium truncate" title={file.name}>{file.name}</p>
-                        <p className="text-xs text-muted-foreground">
-                          Modificado: {file.lastModified} {file.size ? `| Tamanho: ${file.size}` : ''}
-                        </p>
-                      </div>
-                    </div>
-                    <div className="flex gap-1.5">
-                      <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Baixar arquivo">
-                        <Download className="h-4 w-4" />
-                      </Button>
-                       {file.type !== 'folder' && (
-                         <Button variant="ghost" size="icon" asChild className="h-7 w-7" aria-label="Abrir no Google Drive">
-                           <Link href="#" target="_blank" rel="noopener noreferrer">
-                            <ExternalLink className="h-4 w-4" />
-                           </Link>
-                         </Button>
-                       )}
-                    </div>
-                  </CardContent>
-                </Card>
-              ))
-            ) : (
-              <div className="text-center py-10 text-muted-foreground">
-                <FolderKanban className="mx-auto h-12 w-12" />
-                <p className="mt-2">Nenhum arquivo encontrado ou o Drive não está conectado.</p>
-                <p className="text-sm">Verifique suas permissões ou tente reconectar.</p>
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      )}
+      <CardDescription>Encontre respostas rápidas para dúvidas comuns sobre a plataforma.</CardDescription>
+      <Card className="shadow-sm">
+        <CardHeader>
+          <CardTitle className="font-headline">FAQ</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Accordion type="multiple" className="w-full">
+            {faqs.map((faq) => (
+              <AccordionItem key={faq.id} value={faq.id}>
+                <AccordionTrigger className="hover:no-underline">{faq.question}</AccordionTrigger>
+                <AccordionContent>{faq.answer}</AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/components/forms/date-notes-form.tsx
+++ b/src/components/forms/date-notes-form.tsx
@@ -33,14 +33,24 @@ export const dateNotesSchema = z.object({
 
 export type DateNotesFormValues = z.infer<typeof dateNotesSchema>;
 
-export default function DateNotesForm() {
+interface DateNotesFormProps {
+  defaultDateTime?: Date;
+}
+
+export default function DateNotesForm({ defaultDateTime }: DateNotesFormProps) {
   const form = useForm<DateNotesFormValues>({
     resolver: zodResolver(dateNotesSchema),
     defaultValues: {
-      dateTime: new Date(),
+      dateTime: defaultDateTime ?? new Date(),
       notes: "",
     },
   });
+
+  React.useEffect(() => {
+    if (defaultDateTime) {
+      form.setValue("dateTime", defaultDateTime);
+    }
+  }, [defaultDateTime, form]);
 
   function onSubmit(data: DateNotesFormValues) {
     console.log("Form submitted", data);


### PR DESCRIPTION
## Summary
- enhance admin metrics cards layout
- add prop support to DateNotesForm
- add a page to record notes by date
- rewrite knowledge base page as FAQ

## Testing
- `npm run lint` *(fails: Definition for rule '@next/next/link-passhref' was not found)*
- `npm run typecheck` *(fails: dashboard page errors)*
- `npm test` *(fails: download failed, status 403)*

------
https://chatgpt.com/codex/tasks/task_e_684b8345d0648324882c5d60c4b6bc43