### PR TITLE
Add skeleton loading and QoL components

### DIFF
--- a/src/app/(app)/patients/[id]/page.tsx
+++ b/src/app/(app)/patients/[id]/page.tsx
@@ -5,6 +5,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from "@/components/ui/card";
 import { Mail, Phone, CalendarDays, Edit, FileText, Brain, CheckCircle, Clock, MessageSquare, Trash2, Users as UsersIconLucide, Home as HomeIconLucide, Share2, UploadCloud, Calendar as CalendarIconShad, Lightbulb, Tag, BarChart3 as BarChart3Icon, ShieldAlert as ShieldAlertIcon, CheckCircle as CheckCircleIcon, TrendingUp, BookOpen, Activity, Users2, ClipboardList, Target, ListChecks, PlusCircle, Archive } from "lucide-react";
+import CopyButton from "@/components/ui/copy-button";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import PatientTimeline from "@/components/patients/patient-timeline";
@@ -357,8 +358,14 @@ export default function PatientDetailPage({ params }: { params: { id: string } }
             <div className="flex-1">
               <h1 className="text-3xl font-headline font-bold">{patient.name}</h1>
               <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground mt-1">
-                <span className="flex items-center"><Mail className="mr-1.5 h-4 w-4" /> {patient.email}</span>
-                <span className="flex items-center"><Phone className="mr-1.5 h-4 w-4" /> {patient.phone}</span>
+                <span className="flex items-center">
+                  <Mail className="mr-1.5 h-4 w-4" /> {patient.email}
+                  <CopyButton value={patient.email} className="ml-1" />
+                </span>
+                <span className="flex items-center">
+                  <Phone className="mr-1.5 h-4 w-4" /> {patient.phone}
+                  <CopyButton value={patient.phone} className="ml-1" />
+                </span>
                 <span className="flex items-center"><CalendarDays className="mr-1.5 h-4 w-4" /> Nasc: {formattedDob}</span>
               </div>
             </div>

--- a/src/app/(app)/patients/page.tsx
+++ b/src/app/(app)/patients/page.tsx
@@ -6,20 +6,30 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { UserPlus, Search, Filter, Users } from "lucide-react";
 import Link from "next/link";
 import PatientListItem from "@/components/patients/patient-list-item";
-import { mockPatients } from "@/mocks/patients";
+import { mockPatients, type MockPatient } from "@/mocks/patients";
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { checkUserRole } from "@/services/authRole";
 import EmptyState from "@/components/ui/empty-state";
+import PatientListItemSkeleton from "@/components/patients/patient-list-item-skeleton";
 import { APP_ROUTES } from "@/lib/routes";
 
 export default function PatientsPage() {
   const router = useRouter();
+  const [patients, setPatients] = useState<MockPatient[]>([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    checkUserRole(['Admin', 'Psychologist', 'Secretary']).then((ok) => {
-      if (!ok) router.replace('/');
+    checkUserRole(["Admin", "Psychologist", "Secretary"]).then((ok) => {
+      if (!ok) router.replace("/");
     });
+
+    const timer = setTimeout(() => {
+      setPatients(mockPatients);
+      setLoading(false);
+    }, 600);
+
+    return () => clearTimeout(timer);
   }, [router]);
 
   return (
@@ -51,9 +61,15 @@ export default function PatientsPage() {
           </div>
         </CardHeader>
         <CardContent>
-          {mockPatients.length > 0 ? (
+          {loading ? (
             <div className="space-y-4">
-              {mockPatients.map((patient) => (
+              {Array.from({ length: 3 }).map((_, idx) => (
+                <PatientListItemSkeleton key={idx} />
+              ))}
+            </div>
+          ) : patients.length > 0 ? (
+            <div className="space-y-4">
+              {patients.map((patient) => (
                 <PatientListItem key={patient.id} patient={patient} />
               ))}
             </div>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -15,8 +15,9 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Search, Bell, UserCircle, Settings, LogOut, Moon, Sun } from "lucide-react";
+import { Search, Bell, UserCircle, Settings, LogOut } from "lucide-react";
 import Link from "next/link";
+import ThemeToggle from "@/components/ui/theme-toggle";
 // import { useTheme } from "next-themes"; // Assuming next-themes is installed for theme toggling
 
 export default function AppHeader() {
@@ -24,13 +25,6 @@ export default function AppHeader() {
 
   const { user } = useAuth();
 
-  // Placeholder for theme toggling if next-themes is not used.
-  const [currentTheme, setCurrentTheme] = React.useState('light');
-  const toggleTheme = () => {
-    const newTheme = currentTheme === 'light' ? 'dark' : 'light';
-    setCurrentTheme(newTheme);
-    document.documentElement.classList.toggle('dark', newTheme === 'dark');
-  };
 
 
   return (
@@ -48,9 +42,7 @@ export default function AppHeader() {
         </form> */}
       </div>
       <div className="flex items-center gap-4">
-        <Button variant="ghost" size="icon" onClick={toggleTheme} aria-label={currentTheme === 'light' ? "Ativar tema escuro" : "Ativar tema claro"}>
-          {currentTheme === 'light' ? <Moon className="h-5 w-5" /> : <Sun className="h-5 w-5" />}
-        </Button>
+        <ThemeToggle />
         <Button variant="ghost" size="icon" asChild aria-label="Ver notificações">
           <Link href="/notifications">
             <Bell className="h-5 w-5" />

--- a/src/components/patients/patient-list-item-skeleton.tsx
+++ b/src/components/patients/patient-list-item-skeleton.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function PatientListItemSkeleton() {
+  return (
+    <Card className="hover:shadow-md transition-shadow duration-200">
+      <CardContent className="p-4">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-4 flex-1 min-w-0">
+            <Skeleton className="h-12 w-12 rounded-full" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-1/2" />
+              <Skeleton className="h-3 w-1/3" />
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-8 w-8" />
+            <Skeleton className="h-8 w-8" />
+            <Skeleton className="h-8 w-8" />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/ui/copy-button.tsx
+++ b/src/components/ui/copy-button.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Clipboard, Check } from "lucide-react";
+import React from "react";
+import { Button } from "@/components/ui/button";
+
+interface CopyButtonProps {
+  value: string;
+  className?: string;
+}
+
+export default function CopyButton({ value, className }: CopyButtonProps) {
+  const [copied, setCopied] = React.useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch (e) {
+      console.error("Failed to copy", e);
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      onClick={handleCopy}
+      className={className}
+      aria-label="Copiar para a\u00e1rea de transfer\u00eancia"
+    >
+      {copied ? (
+        <Check className="h-4 w-4 text-green-600" />
+      ) : (
+        <Clipboard className="h-4 w-4" />
+      )}
+    </Button>
+  );
+}

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import React from "react";
+import { Moon, Sun } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = React.useState<"light" | "dark">(() =>
+    typeof window !== "undefined" && document.documentElement.classList.contains("dark")
+      ? "dark"
+      : "light"
+  );
+
+  const toggleTheme = () => {
+    const newTheme = theme === "light" ? "dark" : "light";
+    setTheme(newTheme);
+    document.documentElement.classList.toggle("dark", newTheme === "dark");
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleTheme}
+      aria-label={theme === "light" ? "Ativar tema escuro" : "Ativar tema claro"}
+    >
+      {theme === "light" ? <Moon className="h-5 w-5" /> : <Sun className="h-5 w-5" />}
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- create skeleton component for patient list items
- create copy-to-clipboard button and dark/light theme toggle components
- use new ThemeToggle in the header
- show skeletons while patients load in patient list
- add copy buttons to patient details

## Testing
- `npm run lint` *(fails: Definition for rule '@next/next/link-passhref' not found)*
- `npm run typecheck` *(fails: TS1005 ')' expected)*
- `npm test` *(fails: download failed, status 403: Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684b835d3f988324aa75a9cea95b5f62