### PR TITLE
Implement centralized auth hook and route constants

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -123,30 +123,41 @@ export default function DashboardPage() {
  {isLoading && <Skeleton className="h-4 w-1/3" />}
           </CardHeader>
           <CardContent className="space-y-3">
- {isLoading ? (
+            {isLoading ? (
               <>
                 {[...Array(3)].map((_, i) => (
                   <SkeletonBox key={i} className="h-[60px] w-full" />
                 ))}
               </>
-            ) : (
- upcomingAppointments.length > 0 ? (
- upcomingAppointments.map(appt => (
- <div key={appt.id} className="flex items-center justify-between p-3 bg-secondary/50 rounded-md">
- <div>
- <p className="font-semibold">{appt.patientName}</p>
- <p className="text-sm text-muted-foreground">{appt.psychologist}</p>
+            ) : upcomingAppointments.length > 0 ? (
+              upcomingAppointments.map((appt) => (
+                <div
+                  key={appt.id}
+                  className="flex items-center justify-between p-3 bg-secondary/50 rounded-md"
+                >
+                  <div>
+                    <p className="font-semibold">{appt.patientName}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {appt.psychologist}
+                    </p>
                   </div>
                   <div className="text-right">
- <p className="font-medium">{appt.time}</p>
-                    <Button variant="link" size="sm" className="p-0 h-auto text-accent" asChild>
- <Link href={`/patients/${appt.id}`}>Ver Detalhes</Link>
+                    <p className="font-medium">{appt.time}</p>
+                    <Button
+                      variant="link"
+                      size="sm"
+                      className="p-0 h-auto text-accent"
+                      asChild
+                    >
+                      <Link href={`/patients/${appt.id}`}>Ver Detalhes</Link>
                     </Button>
                   </div>
                 </div>
               ))
             ) : (
-              <p className="text-muted-foreground">Nenhum próximo agendamento.</p>
+              <p className="text-muted-foreground">
+                Nenhum próximo agendamento.
+              </p>
             )}
           </CardContent>
         </Card>
@@ -156,19 +167,25 @@ export default function DashboardPage() {
             <CardTitle className="font-headline">Atividade Recente</CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
- {isLoading ? (
+            {isLoading ? (
               <>
                 {[...Array(3)].map((_, i) => (
                   <SkeletonBox key={i} className="h-[60px] w-full" />
                 ))}
               </>
+            ) : recentActivities.length > 0 ? (
+              recentActivities.map((activity) => (
+                <RecentActivityItem
+                  key={activity.id}
+                  description={activity.description}
+                  time={activity.time}
+                  icon={activity.icon}
+                />
+              ))
             ) : (
- recentActivities.length > 0 ? (
- recentActivities.map(activity => (
- <RecentActivityItem key={activity.id} description={activity.description} time={activity.time} icon={activity.icon} />
- ))
-            ) : (
-              <p className="text-muted-foreground">Nenhuma atividade recente.</p>
+              <p className="text-muted-foreground">
+                Nenhuma atividade recente.
+              </p>
             )}
           </CardContent>
         </Card>

--- a/src/app/(app)/notifications/page.tsx
+++ b/src/app/(app)/notifications/page.tsx
@@ -9,19 +9,21 @@ import Link from "next/link";
 import NotificationItem from "@/components/notifications/notification-item";
 import { useNotifications } from "@/hooks/useNotifications";
 import { registerFcmToken } from "@/services/notificationService";
-import { auth } from "@/services/firebase";
+import useAuth from "@/hooks/use-auth";
+import { APP_ROUTES } from "@/lib/routes";
 
 export default function NotificationsPage() {
   const { notifications } = useNotifications();
+  const { user } = useAuth();
   const unreadCount = notifications.filter(n => !n.read).length;
 
   React.useEffect(() => {
-    if (Notification.permission === 'granted' && auth.currentUser?.uid) {
-      registerFcmToken(auth.currentUser.uid);
-    } else if (Notification.permission === 'default' && auth.currentUser?.uid) {
+    if (Notification.permission === 'granted' && user.uid) {
+      registerFcmToken(user.uid);
+    } else if (Notification.permission === 'default' && user.uid) {
       Notification.requestPermission().then((permission) => {
         if (permission === 'granted') {
-          registerFcmToken(auth.currentUser!.uid);
+          registerFcmToken(user.uid!);
         }
       });
     }
@@ -44,7 +46,7 @@ export default function NotificationsPage() {
                 <CheckCheck className="mr-2 h-4 w-4" /> Marcar Todas como Lidas
             </Button>
             <Button variant="outline" asChild>
-                <Link href="/settings?tab=notifications"> 
+                <Link href={`${APP_ROUTES.settings}?tab=notifications`}>
                     <Settings className="mr-2 h-4 w-4" /> Config. de Notificações
                 </Link>
             </Button>

--- a/src/app/403/page.tsx
+++ b/src/app/403/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { APP_ROUTES } from "@/lib/routes";
 
 export default function ForbiddenPage() {
   return (
@@ -7,7 +8,7 @@ export default function ForbiddenPage() {
       <h1 className="text-4xl font-headline font-bold">403 - Acesso Negado</h1>
       <p className="text-muted-foreground">Você não tem permissão para acessar esta página.</p>
       <Button asChild>
-        <Link href="/login">Ir para Login</Link>
+        <Link href={APP_ROUTES.login}>Ir para Login</Link>
       </Button>
     </div>
   );

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -2,6 +2,7 @@
 import ForgotPasswordForm from "@/components/forms/auth/forgot-password-form";
 import { Brain } from "lucide-react";
 import Link from "next/link";
+import { APP_ROUTES } from "@/lib/routes";
 
 export default function ForgotPasswordPage() {
   return (
@@ -23,7 +24,7 @@ export default function ForgotPasswordPage() {
         <p className="px-8 text-center text-sm text-muted-foreground">
           Lembrou sua senha?{" "}
           <Link
-            href="/login"
+            href={APP_ROUTES.login}
             className="underline underline-offset-4 hover:text-primary"
           >
             Entrar

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import useSessionTimeout from "@/hooks/use-session-timeout";
 import { signOut } from "firebase/auth";
 import { auth } from "@/services/firebase";
 import { useRouter } from "next/navigation";
+import { APP_ROUTES } from "@/lib/routes";
 
 
 export default function RootLayout({
@@ -18,7 +19,7 @@ export default function RootLayout({
   const router = useRouter();
   useSessionTimeout(async () => {
     await signOut(auth);
-    router.push("/login");
+    router.push(APP_ROUTES.login);
   });
   return (
     <html lang="pt-BR" suppressHydrationWarning>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,6 +2,7 @@
 import LoginForm from "@/components/forms/auth/login-form";
 import { Brain } from "lucide-react";
 import Link from "next/link";
+import { APP_ROUTES } from "@/lib/routes";
 
 export default function LoginPage() {
   return (
@@ -23,7 +24,7 @@ export default function LoginPage() {
         <p className="px-8 text-center text-sm text-muted-foreground">
           Não tem uma conta?{" "}
           <Link
-            href="/signup"
+            href={APP_ROUTES.signup}
             className="underline underline-offset-4 hover:text-primary"
           >
             Cadastre-se
@@ -31,7 +32,7 @@ export default function LoginPage() {
         </p>
          <p className="px-8 text-center text-sm text-muted-foreground">
           <Link
-            href="/forgot-password"
+            href={APP_ROUTES.forgotPassword}
             className="underline underline-offset-4 hover:text-primary"
           >
             Esqueceu a senha?

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Brain, ShieldCheck, Users } from "lucide-react";
 import Link from "next/link";
+import { APP_ROUTES } from "@/lib/routes";
 
 export default function LandingPage() {
   return (
@@ -14,10 +15,10 @@ export default function LandingPage() {
           </div>
           <nav>
             <Button variant="ghost" asChild>
-              <Link href="/login">Entrar</Link>
+              <Link href={APP_ROUTES.login}>Entrar</Link>
             </Button>
             <Button asChild className="ml-2">
-              <Link href="/signup">Cadastre-se</Link>
+              <Link href={APP_ROUTES.signup}>Cadastre-se</Link>
             </Button>
           </nav>
         </div>
@@ -31,7 +32,7 @@ export default function LandingPage() {
           PsiGuard oferece uma plataforma segura, intuitiva e aprimorada por IA para gerenciar seu consultório de psicologia, para que você possa focar no que mais importa: seus pacientes.
         </p>
         <Button size="lg" asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
-          <Link href="/dashboard">Comece Agora</Link>
+          <Link href={APP_ROUTES.dashboard}>Comece Agora</Link>
         </Button>
       </main>
 

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -2,6 +2,7 @@
 import SignUpForm from "@/components/forms/auth/signup-form";
 import { Brain } from "lucide-react";
 import Link from "next/link";
+import { APP_ROUTES } from "@/lib/routes";
 
 export default function SignUpPage() {
   return (
@@ -23,7 +24,7 @@ export default function SignUpPage() {
         <p className="px-8 text-center text-sm text-muted-foreground">
           Já tem uma conta?{" "}
           <Link
-            href="/login"
+            href={APP_ROUTES.login}
             className="underline underline-offset-4 hover:text-primary"
           >
             Entrar

--- a/src/components/layout/app-layout.tsx
+++ b/src/components/layout/app-layout.tsx
@@ -1,7 +1,7 @@
 
 "use client";
 
-import React, { useEffect } from 'react'; 
+import React from 'react';
 import {
   SidebarProvider,
   Sidebar,
@@ -17,9 +17,8 @@ import Link from "next/link";
 import { usePathname } from 'next/navigation';
 import ChatFloatingButton from '@/components/chat/ChatFloatingButton';
 import ChatWindow from '@/components/chat/ChatWindow';
-import { useChatStore } from '@/stores/chatStore';
-import { auth } from '@/services/firebase'; 
-import { onAuthStateChanged } from 'firebase/auth'; 
+import useAuth from '@/hooks/use-auth';
+import { APP_ROUTES } from '@/lib/routes';
 
 interface AppLayoutProps {
   children: React.ReactNode;
@@ -27,7 +26,7 @@ interface AppLayoutProps {
 
 export default function AppLayout({ children }: AppLayoutProps) {
   const pathname = usePathname();
-  const { setCurrentUser, currentUser } = useChatStore(); 
+  useAuth();
   
   const [defaultOpen, setDefaultOpen] = React.useState(true);
 
@@ -44,40 +43,13 @@ export default function AppLayout({ children }: AppLayoutProps) {
     }
   }, []);
 
-  // Listen for Firebase auth state changes
-  useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
-      if (user) {
-        setCurrentUser({
-          uid: user.uid,
-          displayName: user.displayName || "Usuário Anônimo", // Fallback name
-          avatarUrl: user.photoURL,
-        });
-      } else {
-        setCurrentUser({ uid: null, displayName: null, avatarUrl: null });
-      }
-    });
-    return () => unsubscribe(); // Cleanup subscription on unmount
-  }, [setCurrentUser]);
-  
-  // For local development/testing if Firebase auth is not fully setup
-  // This will run once after the initial auth check.
-  useEffect(() => {
-    if (process.env.NODE_ENV === 'development' && !auth.currentUser && !currentUser?.uid) {
-      setCurrentUser({
-         uid: "dev-user-uid",
-         displayName: "Dev User",
-         avatarUrl: "https://placehold.co/40x40/orange/white?text=DU"
-      });
-    }
-  }, [setCurrentUser, currentUser?.uid]);
 
 
   return (
     <SidebarProvider defaultOpen={defaultOpen} open={defaultOpen} onOpenChange={(open) => setDefaultOpen(open)}>
       <Sidebar collapsible="icon" variant="sidebar" side="left">
         <SidebarHeader className="p-4">
-          <Link href="/dashboard" className="flex items-center gap-2 group-data-[collapsible=icon]:justify-center">
+          <Link href={APP_ROUTES.dashboard} className="flex items-center gap-2 group-data-[collapsible=icon]:justify-center">
             <Brain className="w-8 h-8 text-primary" />
             <span className="font-headline text-2xl font-bold text-primary group-data-[collapsible=icon]:hidden">PsiGuard</span>
           </Link>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -17,6 +17,7 @@ import {
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Search, Bell, UserCircle, Settings, LogOut, Moon, Sun } from "lucide-react";
 import Link from "next/link";
+import { APP_ROUTES } from "@/lib/routes";
 // import { useTheme } from "next-themes"; // Assuming next-themes is installed for theme toggling
 
 export default function AppHeader() {
@@ -52,7 +53,7 @@ export default function AppHeader() {
           {currentTheme === 'light' ? <Moon className="h-5 w-5" /> : <Sun className="h-5 w-5" />}
         </Button>
         <Button variant="ghost" size="icon" asChild aria-label="Ver notificações">
-          <Link href="/notifications">
+          <Link href={APP_ROUTES.notifications}>
             <Bell className="h-5 w-5" />
           </Link>
         </Button>
@@ -71,13 +72,13 @@ export default function AppHeader() {
             <DropdownMenuLabel>Minha Conta{user.displayName ? ` - ${user.displayName}` : ''}</DropdownMenuLabel>
             <DropdownMenuSeparator />
             <DropdownMenuItem asChild>
-              <Link href="/profile">
+              <Link href={APP_ROUTES.profile}>
                 <UserCircle className="mr-2 h-4 w-4" />
                 <span>Perfil</span>
               </Link>
             </DropdownMenuItem>
             <DropdownMenuItem asChild>
-              <Link href="/settings">
+              <Link href={APP_ROUTES.settings}>
                 <Settings className="mr-2 h-4 w-4" />
                 <span>Configurações</span>
               </Link>

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,20 +1,23 @@
 import { useEffect, useState } from 'react';
 import { listenToNotifications, Notification } from '@/services/notificationService';
 import { auth } from '@/services/firebase';
+import useAuth from './use-auth';
 
 export function useNotifications(userId?: string) {
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [loading, setLoading] = useState(true);
 
+  const { user } = useAuth();
+
   useEffect(() => {
-    const uid = userId || auth.currentUser?.uid;
+    const uid = userId || user.uid;
     if (!uid) { setLoading(false); return; }
     const unsub = listenToNotifications(uid, list => {
       setNotifications(list);
       setLoading(false);
     });
     return () => unsub();
-  }, [userId]);
+  }, [userId, user.uid]);
 
   return { notifications, loading };
 }

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -20,6 +20,11 @@ export const APP_ROUTES = {
   toolsAuditTrail: "/tools/audit-trail",
   adminMetrics: "/admin/metrics",
   settings: "/settings",
+  notifications: "/notifications",
+  profile: "/profile",
+  login: "/login",
+  signup: "/signup",
+  forgotPassword: "/forgot-password",
   help: "/help",
 };
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { APP_ROUTES } from './lib/routes';
 
 export function middleware(request: NextRequest) {
   const sessionCookie = request.cookies.get('session')?.value;
   if (!sessionCookie) {
-    return NextResponse.redirect(new URL('/login', request.url));
+    return NextResponse.redirect(new URL(APP_ROUTES.login, request.url));
   }
 
   try {
@@ -14,7 +15,7 @@ export function middleware(request: NextRequest) {
       return NextResponse.rewrite(new URL('/403', request.url));
     }
   } catch {
-    return NextResponse.redirect(new URL('/login', request.url));
+    return NextResponse.redirect(new URL(APP_ROUTES.login, request.url));
   }
 
   return NextResponse.next();

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -13,6 +13,12 @@ import type {
   GenerateSessionNoteTemplateOutput,
 } from "@/ai/flows/generate-session-note-template";
 
+/**
+ * Helper for calling AI API routes.
+ *
+ * @param url - API endpoint.
+ * @param body - Request payload.
+ */
 async function requestAI<T>(url: string, body: unknown): Promise<T> {
   try {
     const res = await fetch(url, {
@@ -33,6 +39,9 @@ async function requestAI<T>(url: string, body: unknown): Promise<T> {
   }
 }
 
+/**
+ * Generates insights for a therapy session.
+ */
 export async function generateSessionInsights(
   input: GenerateSessionInsightsInput,
 ): Promise<GenerateSessionInsightsOutput> {
@@ -42,12 +51,18 @@ export async function generateSessionInsights(
   );
 }
 
+/**
+ * Creates a draft report using the AI service.
+ */
 export async function generateReportDraft(
   input: GenerateReportDraftInput,
 ): Promise<GenerateReportDraftOutput> {
   return requestAI<GenerateReportDraftOutput>("/api/ai/report-draft", input);
 }
 
+/**
+ * Generates a session note template assisted by AI.
+ */
 export async function generateSessionNoteTemplate(
   input: GenerateSessionNoteTemplateInput,
 ): Promise<GenerateSessionNoteTemplateOutput> {

--- a/src/services/appointmentService.ts
+++ b/src/services/appointmentService.ts
@@ -1,5 +1,17 @@
 import type { AppointmentsByDate } from '@/types/appointment';
 
+/**
+ * Checks for scheduling conflicts against existing appointments.
+ *
+ * @param appointments - Map keyed by date containing appointments for that day.
+ * @param dateKey - Date identifier (YYYY-MM-DD).
+ * @param startTime - Proposed appointment start time (HH:mm).
+ * @param endTime - Proposed appointment end time (HH:mm).
+ * @param psychologistId - ID of the psychologist that will attend the patient.
+ * @param isBlockTime - Indicates if the slot is a blocking event.
+ * @returns `true` when there is a time overlap with another appointment.
+ */
+
 export function hasScheduleConflict(
   appointments: AppointmentsByDate,
   dateKey: string,

--- a/src/services/assessmentService.ts
+++ b/src/services/assessmentService.ts
@@ -4,6 +4,12 @@ import { db } from './firebase';
 import { FIRESTORE_COLLECTIONS } from '@/lib/firestore-collections';
 import type { Assessment } from '@/types/assessment';
 
+/**
+ * Creates a new assessment document in Firestore.
+ *
+ * @param data - Assessment data without id and timestamps.
+ * @returns The id of the newly created assessment.
+ */
 export async function createAssessment(data: Omit<Assessment, 'id' | 'createdAt' | 'completedAt'>): Promise<string> {
   const docRef = await addDoc(collection(db, FIRESTORE_COLLECTIONS.ASSESSMENTS), {
     ...data,
@@ -12,6 +18,12 @@ export async function createAssessment(data: Omit<Assessment, 'id' | 'createdAt'
   return docRef.id;
 }
 
+/**
+ * Updates an assessment with the submitted responses.
+ *
+ * @param assessmentId - The id of the assessment document.
+ * @param responses - Answers keyed by question id.
+ */
 export async function submitAssessmentResponses(assessmentId: string, responses: Record<string, unknown>): Promise<void> {
   await updateDoc(doc(db, FIRESTORE_COLLECTIONS.ASSESSMENTS, assessmentId), {
     responses,
@@ -20,6 +32,12 @@ export async function submitAssessmentResponses(assessmentId: string, responses:
   });
 }
 
+/**
+ * Retrieves all assessments assigned to a patient.
+ *
+ * @param patientId - Patient identifier.
+ * @returns List of assessments for the patient.
+ */
 export async function getAssessmentsByPatient(patientId: string): Promise<Assessment[]> {
   const q = query(collection(db, FIRESTORE_COLLECTIONS.ASSESSMENTS), where('patientId', '==', patientId));
   const snapshot = await getDocs(q);

--- a/src/services/authRole.ts
+++ b/src/services/authRole.ts
@@ -5,6 +5,9 @@ import { getIdTokenResult } from 'firebase/auth';
 
 export type UserRole = 'Admin' | 'Psychologist' | 'Secretary';
 
+/**
+ * Obtains the role of the currently authenticated user.
+ */
 export async function getCurrentUserRole(): Promise<UserRole | null> {
   const user = auth.currentUser;
   if (!user) return null;
@@ -17,6 +20,9 @@ export async function getCurrentUserRole(): Promise<UserRole | null> {
   }
 }
 
+/**
+ * Checks if the current user has one of the required roles.
+ */
 export async function checkUserRole(required: UserRole | UserRole[]): Promise<boolean> {
   const role = await getCurrentUserRole();
   if (!role) return false;

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -7,6 +7,7 @@ import { getMessaging, type Messaging } from 'firebase/messaging';
 // Para Functions, se for usar diretamente no cliente no futuro:
 // import { getFunctions, connectFunctionsEmulator, type Functions } from 'firebase/functions';
 
+/** Firebase configuration used to initialise the client SDK. */
 let firebaseConfig;
 const projectId = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
 
@@ -69,5 +70,8 @@ if (process.env.NODE_ENV === 'development') {
   }
 }
 
+/**
+ * Firebase app and service instances available to the application.
+ */
 export { app, auth, db, storage, messaging }; // Adicionar 'functions' aqui se for usá-las globalmente
     

--- a/src/services/googleCalendar.ts
+++ b/src/services/googleCalendar.ts
@@ -12,10 +12,16 @@ interface StoredToken {
   expiry_date?: number;
 }
 
+/**
+ * Key used to store Google OAuth tokens in localStorage.
+ */
 function tokenKey(userId: string): string {
   return `gcal_token_${userId}`;
 }
 
+/**
+ * Creates an OAuth2 client configured with environment variables.
+ */
 function createClient() {
   return new google.auth.OAuth2(
     process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID,
@@ -24,6 +30,9 @@ function createClient() {
   );
 }
 
+/**
+ * Returns an OAuth client with stored credentials loaded if available.
+ */
 export function getOAuthClient(userId: string) {
   const client = createClient();
   if (typeof window !== 'undefined') {
@@ -35,17 +44,26 @@ export function getOAuthClient(userId: string) {
   return client;
 }
 
+/**
+ * Checks if tokens for the user exist in localStorage.
+ */
 export function hasTokens(userId: string): boolean {
   if (typeof window === 'undefined') return false;
   return !!localStorage.getItem(tokenKey(userId));
 }
 
+/**
+ * Removes stored tokens for a given user.
+ */
 export function clearTokens(userId: string) {
   if (typeof window !== 'undefined') {
     localStorage.removeItem(tokenKey(userId));
   }
 }
 
+/**
+ * Generates the Google OAuth consent URL.
+ */
 export function getAuthUrl(userId: string): string {
   const client = getOAuthClient(userId);
   return client.generateAuthUrl({
@@ -55,6 +73,9 @@ export function getAuthUrl(userId: string): string {
   });
 }
 
+/**
+ * Exchanges an authorization code for access tokens.
+ */
 export async function exchangeCodeForTokens(userId: string, code: string) {
   const client = getOAuthClient(userId);
   const { tokens } = await client.getToken(code);
@@ -62,6 +83,9 @@ export async function exchangeCodeForTokens(userId: string, code: string) {
   return tokens;
 }
 
+/**
+ * Persists OAuth tokens locally and sets them on the client.
+ */
 export function setTokens(userId: string, tokens: StoredToken) {
   const client = getOAuthClient(userId);
   client.setCredentials(tokens);
@@ -70,6 +94,9 @@ export function setTokens(userId: string, tokens: StoredToken) {
   }
 }
 
+/**
+ * Inserts a new calendar event or updates an existing one.
+ */
 export async function insertOrUpdateEvent(userId: string, event: calendar_v3.Schema$Event) {
   const auth = getOAuthClient(userId);
   const calendar = google.calendar({ version: 'v3', auth });
@@ -89,6 +116,9 @@ export async function insertOrUpdateEvent(userId: string, event: calendar_v3.Sch
   return res.data;
 }
 
+/**
+ * Returns upcoming events from the user's primary calendar.
+ */
 export async function listUpcomingEvents(userId: string, maxResults = 10) {
   const auth = getOAuthClient(userId);
   const calendar = google.calendar({ version: 'v3', auth });

--- a/src/services/ics-generator.ts
+++ b/src/services/ics-generator.ts
@@ -3,7 +3,9 @@ import { type Appointment, type AppointmentsByDate } from '@/types/appointment';
 import { format } from 'date-fns';
 import { toDate } from 'date-fns-tz';
 
-// Function to format a date string (YYYY-MM-DD) and time string (HH:mm) into an ICS compatible UTC string (YYYYMMDDTHHMMSSZ)
+/**
+ * Formats a date and time in a given timezone into the UTC string used by ICS files.
+ */
 function formatToICSDateTime(dateString: string, timeString: string, timeZone: string = 'America/Sao_Paulo'): string {
   const dateTimeString = `${dateString}T${timeString}`; // e.g., "2024-08-15T10:00"
   
@@ -17,6 +19,9 @@ function formatToICSDateTime(dateString: string, timeString: string, timeZone: s
 }
 
 
+/**
+ * Generates a pseudo random UID for ICS events.
+ */
 function generateUID(length: number = 16): string {
   const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
   let result = '';
@@ -33,6 +38,9 @@ const psychologistNameMap: Record<string, string> = {
   // Add other known psychologist IDs and names here
 };
 
+/**
+ * Generates an iCalendar (.ics) string from the provided appointments.
+ */
 export function generateICS(appointmentsByDate: AppointmentsByDate, specificDate?: Date): string {
   let icsString = 'BEGIN:VCALENDAR\r\n';
   icsString += 'VERSION:2.0\r\n';

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -11,6 +11,9 @@ export interface Notification {
   link?: string;
 }
 
+/**
+ * Registers the current browser's FCM token for a user.
+ */
 export async function registerFcmToken(userId: string): Promise<string | null> {
   if (!messaging) return null;
   try {
@@ -30,6 +33,9 @@ export async function registerFcmToken(userId: string): Promise<string | null> {
   }
 }
 
+/**
+ * Subscribes to real-time notifications for a user.
+ */
 export function listenToNotifications(userId: string, callback: (n: Notification[]) => void): Unsubscribe {
   const q = query(collection(db, 'users', userId, 'notifications'), orderBy('date', 'desc'));
   return onSnapshot(q, snap => {

--- a/src/services/prontuarioService.ts
+++ b/src/services/prontuarioService.ts
@@ -7,6 +7,13 @@ export interface SessionNote {
   [key: string]: unknown;
 }
 
+/**
+ * Calls a GAS endpoint to generate a patient summary document.
+ *
+ * @param patientId - Identifier of the patient.
+ * @param notes - Notes to be included in the summary.
+ * @returns Success flag returned by the GAS script.
+ */
 export async function gerarProntuario(
   patientId: string,
   notes: SessionNote[],

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -13,21 +13,27 @@ export const mockTasksData: Task[] = [
   { id: "task5", title: "Atualizar documento de políticas da clínica", description: "Incorporar novas diretrizes de teleatendimento.", dueDate: "2024-08-01", assignedTo: "Admin", status: "Pendente", priority: "Média" },
 ];
 
-// Simula uma chamada de API para buscar todas as tarefas
+/**
+ * Retrieves all tasks (mocked).
+ */
 export async function getTasks(): Promise<Task[]> {
   // Simula um delay de rede
   await new Promise(resolve => setTimeout(resolve, 100));
   return [...mockTasksData]; // Retorna uma cópia para evitar mutações diretas no mock
 }
 
-// Simula uma chamada de API para buscar uma tarefa por ID
+/**
+ * Retrieves a task by id from the mock list.
+ */
 export async function getTaskById(id: string): Promise<Task | undefined> {
   // Simula um delay de rede
   await new Promise(resolve => setTimeout(resolve, 50));
   return mockTasksData.find(task => task.id === id);
 }
 
-// Simula uma chamada de API para buscar tarefas para uma data específica
+/**
+ * Returns tasks scheduled for a specific date (mocked).
+ */
 export async function getTasksForDate(date: Date): Promise<Task[]> {
   await new Promise(resolve => setTimeout(resolve, 80));
   return mockTasksData.filter(task => {


### PR DESCRIPTION
## Summary
- document service files with JSDoc
- add route constants and refactor navigation
- implement new `useAuth` hook and update layout
- apply session timeout on logout

## Testing
- `npm run typecheck` *(fails: Cannot find module 'firebase-admin' or its corresponding type declarations)*
- `npm run lint` *(fails: `next` command not found)*
- `npm test` *(fails: `firebase` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b837637a08324b5653400d6965673