### PR TITLE
Add breadcrumb navigation

### DIFF
--- a/src/components/layout/breadcrumb.tsx
+++ b/src/components/layout/breadcrumb.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { ChevronRight } from "lucide-react";
+
+const segmentLabels: Record<string, string> = {
+  dashboard: "Home",
+  patients: "Pacientes",
+  new: "Novo Paciente",
+  groups: "Grupos Terapêuticos",
+  "waiting-list": "Lista de Espera",
+  templates: "Modelos Inteligentes",
+  tasks: "Tarefas",
+  resources: "Recursos",
+  analytics: "Análises",
+  tools: "Ferramentas",
+  settings: "Configurações",
+  notifications: "Notificações",
+  chat: "Chat",
+  admin: "Admin",
+};
+
+function getLabel(segment: string) {
+  if (segmentLabels[segment]) return segmentLabels[segment];
+  return segment
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (l) => l.toUpperCase());
+}
+
+export default function Breadcrumb() {
+  const pathname = usePathname();
+
+  const segments = pathname
+    .split("/")
+    .filter((seg) => seg.length > 0 && seg !== "dashboard");
+
+  const crumbs = segments.map((segment, index) => {
+    const href = "/" + ["dashboard", ...segments.slice(0, index + 1)].join("/");
+    return {
+      href,
+      label: getLabel(segment),
+    };
+  });
+
+  return (
+    <nav aria-label="Breadcrumb" className="text-sm text-muted-foreground">
+      <ol className="flex items-center gap-1">
+        <li>
+          <Link href="/dashboard" className="hover:underline">
+            Home
+          </Link>
+        </li>
+        {crumbs.map((crumb, idx) => (
+          <li key={idx} className="flex items-center gap-1">
+            <ChevronRight className="size-4" />
+            {idx === crumbs.length - 1 ? (
+              <span className="text-foreground">{crumb.label}</span>
+            ) : (
+              <Link href={crumb.href} className="hover:underline">
+                {crumb.label}
+              </Link>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Search, Bell, UserCircle, Settings, LogOut, Moon, Sun } from "lucide-react";
+import Breadcrumb from "@/components/layout/breadcrumb";
 import Link from "next/link";
 // import { useTheme } from "next-themes"; // Assuming next-themes is installed for theme toggling
 
@@ -37,6 +38,7 @@ export default function AppHeader() {
     <header className="sticky top-0 z-10 flex h-16 items-center gap-4 border-b bg-background/80 backdrop-blur-sm px-4 md:px-6">
       <SidebarTrigger className="md:hidden" />
       <div className="flex-1">
+        <Breadcrumb />
         {/* Optional: Global Search can go here */}
         {/* <form className="relative ml-auto flex-1 sm:flex-initial">
           <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />


### PR DESCRIPTION
## Summary
- build breadcrumb component using Next.js routing
- show breadcrumbs in the header for easier navigation

## Testing
- `npm test` *(fails: `firebase` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b841d09a4832490391eb956422044