### PR TITLE
Add breadcrumb navigation

### DIFF
--- a/src/components/layout/breadcrumb.tsx
+++ b/src/components/layout/breadcrumb.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import React from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { ChevronRight } from "lucide-react";
+import { cn } from "@/shared/utils";
+import { APP_ROUTES } from "@/lib/routes";
+
+const segmentLabelMap: Record<string, string> = {
+  dashboard: "Home",
+  patients: "Pacientes",
+  groups: "Grupos Terapêuticos",
+  "waiting-list": "Lista de Espera",
+  templates: "Modelos Inteligentes",
+  tasks: "Tarefas",
+  resources: "Recursos da Clínica",
+  analytics: "Análises",
+  schedule: "Agenda",
+  tools: "Ferramentas Clínicas",
+  settings: "Configurações",
+  "user-approvals": "Aprovação de Usuários",
+  "inventories-scales": "Inventários e Escalas",
+  profile: "Perfil",
+  new: "Novo",
+  edit: "Editar",
+};
+
+function formatSegment(segment: string): string {
+  return (
+    segmentLabelMap[segment] ||
+    segment
+      .replace(/-/g, " ")
+      .replace(/\b\w/g, (l) => l.toUpperCase())
+  );
+}
+
+export default function Breadcrumb({ className }: { className?: string }) {
+  const pathname = usePathname();
+  const segments = pathname
+    .split("/")
+    .filter(Boolean);
+
+  const crumbs = segments.map((segment, idx) => {
+    const href = "/" + segments.slice(0, idx + 1).join("/");
+    const label = formatSegment(segment);
+    return { href, label };
+  });
+
+  if (segments.length === 0) return null;
+
+  return (
+    <nav aria-label="Breadcrumb" className={cn("text-sm", className)}>
+      <ol className="flex items-center gap-1 text-muted-foreground">
+        <li>
+          <Link href={APP_ROUTES.dashboard} className="hover:underline">
+            Home
+          </Link>
+        </li>
+        {crumbs.map((crumb, idx) => (
+          <React.Fragment key={crumb.href}>
+            <ChevronRight className="h-4 w-4" />
+            {idx === crumbs.length - 1 ? (
+              <span className="text-foreground font-medium">{crumb.label}</span>
+            ) : (
+              <Link href={crumb.href} className="hover:underline">
+                {crumb.label}
+              </Link>
+            )}
+          </React.Fragment>
+        ))}
+      </ol>
+    </nav>
+  );
+}
+

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -17,6 +17,7 @@ import {
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Search, Bell, UserCircle, Settings, LogOut, Moon, Sun } from "lucide-react";
 import Link from "next/link";
+import Breadcrumb from "@/components/layout/breadcrumb";
 // import { useTheme } from "next-themes"; // Assuming next-themes is installed for theme toggling
 
 export default function AppHeader() {
@@ -36,7 +37,8 @@ export default function AppHeader() {
   return (
     <header className="sticky top-0 z-10 flex h-16 items-center gap-4 border-b bg-background/80 backdrop-blur-sm px-4 md:px-6">
       <SidebarTrigger className="md:hidden" />
-      <div className="flex-1">
+      <div className="flex-1 overflow-hidden">
+        <Breadcrumb className="truncate" />
         {/* Optional: Global Search can go here */}
         {/* <form className="relative ml-auto flex-1 sm:flex-initial">
           <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />


### PR DESCRIPTION
## Summary
- add a dynamic breadcrumb component
- display breadcrumb in the header

## Testing
- `npm test` *(fails: `firebase` not found)*
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_684b84aaee7c8324a183b6066f112b29