### PR TITLE
Add custom error pages

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen text-center p-4 space-y-4">
+      <h1 className="text-4xl font-headline font-bold">Algo deu errado</h1>
+      <p className="text-muted-foreground">Ocorreu um erro inesperado. Tente novamente mais tarde.</p>
+      <div className="flex gap-2">
+        <Button onClick={() => reset()}>Tentar novamente</Button>
+        <Button asChild variant="ghost">
+          <Link href="/">Voltar para o início</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function NotFoundPage() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen text-center p-4 space-y-4">
+      <h1 className="text-4xl font-headline font-bold">404 - Página Não Encontrada</h1>
+      <p className="text-muted-foreground">Não conseguimos encontrar a página que você procurava.</p>
+      <Button asChild>
+        <Link href="/">Voltar para o início</Link>
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `src/app/not-found.tsx` for a friendly 404 page
- add `src/app/error.tsx` to show a 500 error message and retry option

## Testing
- `npm run lint` *(fails: Definition for rule '@next/next/link-passhref' was not found)*
- `npm run typecheck` *(fails: TS1005 errors in dashboard page)*
- `npm test` *(fails: Request failed with status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_684b855a165083249f0bb0d155593466