### PR TITLE
Add static legal pages

### DIFF
--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function PrivacyPolicyPage() {
+  return (
+    <div className="flex flex-col items-center min-h-screen p-4 space-y-6 bg-gradient-to-br from-background to-secondary">
+      <div className="w-full max-w-2xl space-y-4">
+        <h1 className="text-3xl font-headline font-bold text-center">Política de Privacidade</h1>
+        <p className="text-muted-foreground">
+          Sua privacidade é prioridade no PsiGuard. Todas as informações coletadas
+          são utilizadas exclusivamente para oferecer e aprimorar nossos serviços.
+        </p>
+        <p className="text-muted-foreground">
+          Mantemos seus dados protegidos de acordo com a Lei Geral de Proteção de
+          Dados (LGPD) e não compartilhamos suas informações pessoais com terceiros
+          sem o seu consentimento.
+        </p>
+        <p className="text-muted-foreground">
+          Ao utilizar o PsiGuard, você concorda com o tratamento de dados descrito
+          nesta política. Em caso de dúvidas, entre em contato com nossa equipe de
+          suporte.
+        </p>
+      </div>
+      <Button asChild className="bg-accent text-accent-foreground hover:bg-accent/90">
+        <Link href="/">Voltar para a Página Inicial</Link>
+      </Button>
+    </div>
+  );
+}

--- a/src/app/terms-of-service/page.tsx
+++ b/src/app/terms-of-service/page.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function TermsOfServicePage() {
+  return (
+    <div className="flex flex-col items-center min-h-screen p-4 space-y-6 bg-gradient-to-br from-background to-secondary">
+      <div className="w-full max-w-2xl space-y-4">
+        <h1 className="text-3xl font-headline font-bold text-center">Termos de Serviço</h1>
+        <p className="text-muted-foreground">
+          Ao acessar e utilizar o PsiGuard, você concorda em cumprir estes termos.
+          O serviço é fornecido no estado em que se encontra e pode ser alterado
+          ou interrompido a qualquer momento.
+        </p>
+        <p className="text-muted-foreground">
+          É sua responsabilidade manter suas credenciais seguras e garantir que o
+          uso da plataforma esteja em conformidade com as leis aplicáveis.
+        </p>
+        <p className="text-muted-foreground">
+          Reservamo-nos o direito de atualizar estes termos periodicamente. O uso
+          contínuo do PsiGuard após mudanças implica sua concordância com as novas
+          condições.
+        </p>
+      </div>
+      <Button asChild className="bg-accent text-accent-foreground hover:bg-accent/90">
+        <Link href="/">Voltar para a Página Inicial</Link>
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Privacy Policy page
- add Terms of Service page

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm run typecheck` *(fails: ')' expected)*
- `npm test` *(fails: download failed, status 403: Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684b8598f1d48324bfe39cbb5536ecab