### PR TITLE
Fix accessibility messages

### DIFF
--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -158,6 +158,8 @@ const FormMessage = React.forwardRef<
     <p
       ref={ref}
       id={formMessageId}
+      role="alert"
+      aria-live="polite"
       className={cn("text-sm font-medium text-destructive", className)}
       {...props}
     >


### PR DESCRIPTION
## Summary
- improve screen reader support for form errors by adding `role="alert"` and `aria-live="polite"`

## Testing
- `npm run lint` *(fails: Definition for rule '@next/next/link-passhref' was not found)*
- `npm test` *(fails to download Firebase emulator: domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684b858a8e34832481f2857b0012178d