### PR TITLE
Add independent utility modules

### DIFF
--- a/__tests__/crypto-utils.test.ts
+++ b/__tests__/crypto-utils.test.ts
@@ -1,0 +1,12 @@
+import { encrypt, decrypt } from '../src/lib/crypto-utils'
+
+const key = Buffer.alloc(32, 0)
+
+describe('crypto-utils', () => {
+  it('encrypts and decrypts a string', () => {
+    const text = 'hello world'
+    const result = encrypt(text, key)
+    const decrypted = decrypt(result, key)
+    expect(decrypted).toBe(text)
+  })
+})

--- a/__tests__/schedule-utils.test.ts
+++ b/__tests__/schedule-utils.test.ts
@@ -1,0 +1,18 @@
+import { addAppointment, hasConflict } from '../src/lib/schedule-utils'
+
+describe('schedule utils', () => {
+  const existing = [
+    { start: new Date('2024-01-01T10:00:00Z'), end: new Date('2024-01-01T11:00:00Z') }
+  ]
+
+  it('detects conflicts', () => {
+    const candidate = { start: new Date('2024-01-01T10:30:00Z'), end: new Date('2024-01-01T11:30:00Z') }
+    expect(hasConflict(existing, candidate)).toBe(true)
+  })
+
+  it('adds appointment when no conflict', () => {
+    const candidate = { start: new Date('2024-01-01T11:30:00Z'), end: new Date('2024-01-01T12:30:00Z') }
+    const updated = addAppointment(existing, candidate)
+    expect(updated.length).toBe(2)
+  })
+})

--- a/docs/storage-granular-example.rules
+++ b/docs/storage-granular-example.rules
@@ -1,0 +1,19 @@
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    function isAdmin() {
+      return request.auth.token.role == 'Admin';
+    }
+    function isPsychologist() {
+      return request.auth.token.role == 'Psychologist';
+    }
+    match /patient_files/{patientId}/{fileName} {
+      function isAssignedToPatient(patientId) {
+        return request.auth.token.assignedPatients != null &&
+          request.auth.token.assignedPatients.hasAny([patientId]);
+      }
+      allow read, write: if request.auth != null &&
+        (isAdmin() || (isPsychologist() && isAssignedToPatient(patientId)));
+    }
+  }
+}

--- a/src/lib/crypto-utils.ts
+++ b/src/lib/crypto-utils.ts
@@ -1,0 +1,33 @@
+import crypto from 'crypto'
+
+const ALGORITHM = 'aes-256-gcm'
+
+export interface EncryptionResult {
+  ciphertext: string
+  iv: string
+  tag: string
+}
+
+export function encrypt(text: string, key: Buffer): EncryptionResult {
+  const iv = crypto.randomBytes(12)
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv)
+  const ciphertext = Buffer.concat([cipher.update(text, 'utf8'), cipher.final()])
+  const tag = cipher.getAuthTag()
+  return {
+    ciphertext: ciphertext.toString('base64'),
+    iv: iv.toString('base64'),
+    tag: tag.toString('base64'),
+  }
+}
+
+export function decrypt(result: EncryptionResult, key: Buffer): string {
+  const iv = Buffer.from(result.iv, 'base64')
+  const tag = Buffer.from(result.tag, 'base64')
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv)
+  decipher.setAuthTag(tag)
+  const plaintext = Buffer.concat([
+    decipher.update(Buffer.from(result.ciphertext, 'base64')),
+    decipher.final(),
+  ])
+  return plaintext.toString('utf8')
+}

--- a/src/lib/schedule-utils.ts
+++ b/src/lib/schedule-utils.ts
@@ -1,0 +1,17 @@
+export interface Appointment {
+  start: Date
+  end: Date
+}
+
+export function hasConflict(existing: Appointment[], candidate: Appointment): boolean {
+  return existing.some(appt =>
+    (candidate.start < appt.end && candidate.end > appt.start)
+  )
+}
+
+export function addAppointment(existing: Appointment[], candidate: Appointment): Appointment[] {
+  if (hasConflict(existing, candidate)) {
+    throw new Error('Conflicting appointment')
+  }
+  return [...existing, candidate]
+}


### PR DESCRIPTION
## Summary
- implement AES crypto helpers
- add schedule conflict check utilities
- document sample granular access rule
- test encryption and schedule helpers

## Testing
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:8082)*

------
https://chatgpt.com/codex/tasks/task_e_684bfccd98b083249f42cfc2b2f05de9