### PR TITLE
Force IPv4 for Firebase emulators

### DIFF
--- a/__tests__/firestore-rules.test.ts
+++ b/__tests__/firestore-rules.test.ts
@@ -6,7 +6,7 @@ import fetch from 'node-fetch';
 let testEnv: Awaited<ReturnType<typeof initializeTestEnvironment>>;
 
 beforeAll(async () => {
-  const hostPort = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8082';
+  const hostPort = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8083';
   const [host, portStr] = hostPort.split(':');
   const port = parseInt(portStr, 10);
 

--- a/__tests__/patients.rules.test.ts
+++ b/__tests__/patients.rules.test.ts
@@ -6,7 +6,7 @@ import fetch from 'node-fetch';
 let testEnv: Awaited<ReturnType<typeof initializeTestEnvironment>>;
 
 beforeAll(async () => {
-  const hostPort = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8082';
+  const hostPort = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8083';
   const [host, portStr] = hostPort.split(':');
   const port = parseInt(portStr, 10);
 

--- a/firebase.json
+++ b/firebase.json
@@ -3,9 +3,25 @@
     "rules": "firestore.rules"
   },
   "emulators": {
+    "hub": {
+      "host": "127.0.0.1",
+      "port": 4400
+    },
+    "logging": {
+      "host": "127.0.0.1",
+      "port": 4500
+    },
+    "auth": {
+      "host": "127.0.0.1",
+      "port": 9099
+    },
     "firestore": {
       "host": "127.0.0.1",
       "port": 8083
+    },
+    "storage": {
+      "host": "127.0.0.1",
+      "port": 9199
     },
     "ui": {
       "host": "127.0.0.1",


### PR DESCRIPTION
## Summary
- use explicit IPv4 host for all emulators
- update rule tests to default to port `8083`

## Testing
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:8083)*

------
https://chatgpt.com/codex/tasks/task_e_684df1c73c0c8324adadd2b1c783ee1f