### PR TITLE
Fix missing accessible label for login checkbox

### DIFF
--- a/src/components/forms/auth/login-form.tsx
+++ b/src/components/forms/auth/login-form.tsx
@@ -130,6 +130,7 @@ export default function LoginForm() {
                 <FormItem className="flex flex-row items-start space-x-3 space-y-0">
                   <FormControl>
                     <Checkbox
+                      aria-label="Lembrar-me"
                       checked={field.value}
                       onCheckedChange={field.onChange}
                     />


### PR DESCRIPTION
## Summary
- add `aria-label` to the "remember me" checkbox on the login form

## Testing
- `npm test`
- `npm run lint` *(fails: various lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e15c7fe4c83249f32f17a5b766daa