### PR TITLE
Implement Firebase session cookie login

### DIFF
--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { auth as adminAuth } from 'firebase-admin';
+
+export async function POST(request: Request) {
+  try {
+    const { idToken } = await request.json();
+    if (!idToken) {
+      return NextResponse.json({ error: 'Missing idToken' }, { status: 400 });
+    }
+    const expiresIn = 60 * 60 * 24 * 5 * 1000; // 5 days
+    const decoded = await adminAuth().verifyIdToken(idToken);
+    const sessionCookie = await adminAuth().createSessionCookie(idToken, { expiresIn });
+    const userRecord = await adminAuth().getUser(decoded.uid);
+    const role = userRecord.customClaims?.role || 'Psychologist';
+    const session = { user: { uid: decoded.uid, role } };
+    const response = NextResponse.json({ success: true });
+    response.cookies.set('session', JSON.stringify(session), {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: expiresIn / 1000,
+      path: '/',
+    });
+    return response;
+  } catch (e) {
+    console.error('Login API error', e);
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/src/app/api/logout/route.ts
+++ b/src/app/api/logout/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+
+export async function POST() {
+  const response = NextResponse.json({ success: true });
+  response.cookies.set('session', '', {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: 0,
+    path: '/',
+  });
+  return response;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,6 +25,7 @@ export default function RootLayout({
   const router = useRouter();
   useSessionTimeout(async () => {
     await signOut(auth);
+    await fetch('/api/logout', { method: 'POST' });
     router.push("/login");
   });
   return (


### PR DESCRIPTION
## Summary
- add API route to create session cookies after login
- add API route for logging out
- persist Firebase Auth based on Remember Me and call the new login API
- clear session cookie on inactivity timeout

## Testing
- `npm test`
- `npm run typecheck` *(fails: src/app/(app)/dashboard/page.tsx errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e17700e388324b34d633d1a8821bc