### PR TITLE
Fix clinicalStore import statements

### DIFF
--- a/src/app/clinical-map/[patientId]/[tabId]/page.tsx
+++ b/src/app/clinical-map/[patientId]/[tabId]/page.tsx
@@ -4,7 +4,7 @@
 import React, { useEffect } from 'react';
 import { useParams } from 'next/navigation';
 import FormulationMapWrapper from '@/components/clinical-formulation/FormulationMap';
-import useClinicalStore from '@/stores/clinicalStore';
+import { useClinicalStore } from '@/stores/clinicalStore';
 import { APP_ROUTES } from '@/lib/routes'; // Ensure APP_ROUTES is correctly imported if used
 import { mockPatient } from '@/app/(app)/patients/[id]/page'; // Ensure mockPatient is correctly imported if used
 

--- a/src/components/cards/ABC/ABCCardNode.tsx
+++ b/src/components/cards/ABC/ABCCardNode.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Edit3Icon, Trash2Icon, PaletteIcon, LinkIcon as LinkIconLucide, ExternalLinkIcon, Users } from 'lucide-react';
-import useClinicalStore from '@/stores/clinicalStore';
+import { useClinicalStore } from '@/stores/clinicalStore';
 import type { ABCCardData, ABCCardColor } from '@/types/clinicalTypes';
 import { cn } from '@/shared/utils';
 import { highlightKeywords } from '@/utils/highlightKeywords';

--- a/src/components/cards/ABC/ABCForm.tsx
+++ b/src/components/cards/ABC/ABCForm.tsx
@@ -4,7 +4,7 @@
 import React, { useState, useEffect } from 'react'; // Adicionado useState e useEffect
 import { Dialog, DialogContent, DialogHeader, DialogFooter, DialogTitle, DialogDescription, DialogClose } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import useClinicalStore from '@/stores/clinicalStore';
+import { useClinicalStore } from '@/stores/clinicalStore';
 
 const ABCForm: React.FC = () => {
   const { isABCFormOpen, closeABCForm, editingCardId } = useClinicalStore();

--- a/src/components/clinical-formulation/EdgeLabelModal.tsx
+++ b/src/components/clinical-formulation/EdgeLabelModal.tsx
@@ -6,7 +6,7 @@ import { Dialog, DialogContent, DialogHeader, DialogFooter, DialogTitle, DialogD
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Label } from '@/components/ui/label';
-import useClinicalStore from '@/stores/clinicalStore';
+import { useClinicalStore } from '@/stores/clinicalStore';
 import type { ConnectionLabel } from '@/types/clinicalTypes';
 import { nanoid } from 'nanoid';
 import type { Edge, Connection } from 'reactflow';

--- a/src/components/clinical-formulation/FormulationGuidePanel.tsx
+++ b/src/components/clinical-formulation/FormulationGuidePanel.tsx
@@ -8,7 +8,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { HelpCircle, X } from 'lucide-react'; // Adicionado X
-import useClinicalStore from '@/stores/clinicalStore';
+import { useClinicalStore } from '@/stores/clinicalStore';
 
 const FormulationGuidePanel: React.FC = () => {
   const { formulationGuideQuestions, formulationGuideAnswers, toggleFormulationQuestionAnswer, toggleFormulationGuidePanelVisibility } = useClinicalStore();

--- a/src/components/clinical-formulation/FormulationMap.tsx
+++ b/src/components/clinical-formulation/FormulationMap.tsx
@@ -22,7 +22,7 @@ import ReactFlow, {
 } from 'reactflow';
 import 'reactflow/dist/style.css';
 
-import useClinicalStore, { allCardColors } from '@/stores/clinicalStore';
+import { useClinicalStore, allCardColors } from '@/stores/clinicalStore';
 import ABCCardNode from './ABCCardNode';
 import SchemaNode from './SchemaNode';
 import NodeContextMenu from './NodeContextMenu';

--- a/src/components/clinical-formulation/InsightPanel.tsx
+++ b/src/components/clinical-formulation/InsightPanel.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Brain, LightbulbIcon } from 'lucide-react';
-import useClinicalStore from '@/stores/clinicalStore';
+import { useClinicalStore } from '@/stores/clinicalStore';
 import { Badge } from '@/components/ui/badge';
 
 const InsightPanel: React.FC = () => {

--- a/src/components/clinical-formulation/NodeContextMenu.tsx
+++ b/src/components/clinical-formulation/NodeContextMenu.tsx
@@ -15,7 +15,7 @@ import {
   DropdownMenuPortal,
 } from '@/components/ui/dropdown-menu';
 import { Edit, Trash2, Palette, Link2, Check, Unlink, Users as UsersIcon, Tag } from 'lucide-react';
-import useClinicalStore from '@/stores/clinicalStore';
+import { useClinicalStore } from '@/stores/clinicalStore';
 import type { ClinicalNodeType, ABCCardColor, SchemaData, ABCCardData } from '@/types/clinicalTypes';
 import { cn } from '@/shared/utils';
 

--- a/src/components/clinical-formulation/QuickNoteForm.tsx
+++ b/src/components/clinical-formulation/QuickNoteForm.tsx
@@ -4,7 +4,7 @@
 import React, { useState, useEffect } from 'react'; // Adicionado useState e useEffect
 import { Dialog, DialogContent, DialogHeader, DialogFooter, DialogTitle, DialogDescription, DialogClose } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import useClinicalStore from '@/stores/clinicalStore';
+import { useClinicalStore } from '@/stores/clinicalStore';
 
 const QuickNoteForm: React.FC = () => {
   const {

--- a/src/components/clinical-formulation/QuickNotesPanel.tsx
+++ b/src/components/clinical-formulation/QuickNotesPanel.tsx
@@ -6,7 +6,7 @@ import { CardHeader, CardTitle, CardDescription, CardContent } from '@/component
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { StickyNote, Edit, Trash2, PlusCircle, Link as LinkIcon, X } from 'lucide-react'; // Adicionado X
-import useClinicalStore from '@/stores/clinicalStore';
+import { useClinicalStore } from '@/stores/clinicalStore';
 import { formatDistanceToNow } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import {

--- a/src/components/clinical-formulation/SchemaForm.tsx
+++ b/src/components/clinical-formulation/SchemaForm.tsx
@@ -10,7 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
-import useClinicalStore from '@/stores/clinicalStore';
+import { useClinicalStore } from '@/stores/clinicalStore';
 import type { SchemaData } from '@/types/clinicalTypes';
 
 const schemaFormValidationSchema = z.object({

--- a/src/components/clinical-formulation/SchemaNode.tsx
+++ b/src/components/clinical-formulation/SchemaNode.tsx
@@ -6,7 +6,7 @@ import { Handle, Position, NodeProps } from 'reactflow';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Link2Icon } from 'lucide-react';
-import useClinicalStore from '@/stores/clinicalStore';
+import { useClinicalStore } from '@/stores/clinicalStore';
 import type { SchemaData } from '@/types/clinicalTypes';
 import { cn } from '@/shared/utils';
 

--- a/src/components/clinical-formulation/SchemaPanel.tsx
+++ b/src/components/clinical-formulation/SchemaPanel.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { PlusCircleIcon, Trash2Icon, Link2Icon, ChevronDownIcon, ChevronUpIcon, EditIcon, Unlink, X } from 'lucide-react'; // Adicionado X
-import useClinicalStore from '@/stores/clinicalStore';
+import { useClinicalStore } from '@/stores/clinicalStore';
 import type { SchemaData } from '@/types/clinicalTypes';
 import { Badge } from '../ui/badge';
 

--- a/src/components/layout/TabsBar.tsx
+++ b/src/components/layout/TabsBar.tsx
@@ -13,7 +13,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { PlusCircle, X, Edit2, Brain, Workflow, ListTree, Wand2 } from 'lucide-react'; // Changed BarChartSteps to Workflow
-import useClinicalStore from '@/stores/clinicalStore';
+import { useClinicalStore } from '@/stores/clinicalStore';
 import type { ClinicalTab, ClinicalTabType } from '@/types/clinicalTypes';
 import { cn } from '@/shared/utils';
 import {

--- a/src/components/map/MapPanelContainer.tsx
+++ b/src/components/map/MapPanelContainer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import useClinicalStore from '@/stores/clinicalStore';
+import { useClinicalStore } from '@/stores/clinicalStore';
 
 // Placeholder components (create these files)
 const HexaflexPanel: React.FC = () => (


### PR DESCRIPTION
## Summary
- fix imports of `useClinicalStore` to use named export

## Testing
- `npm test` *(fails: jest not found)*
- `npm run typecheck` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6851706a1498832480703dd8b7a6d1d9