### PR TITLE
Fix missing store import

### DIFF
--- a/src/app/(app)/patients/[id]/page.tsx
+++ b/src/app/(app)/patients/[id]/page.tsx
@@ -52,6 +52,7 @@ import { gerarProntuario } from "@/services/prontuarioService";
 import ChainAnalysisBuilder from '@/components/clinical-tools/ChainAnalysisBuilder';
 import ActMatrixBuilder from '@/components/clinical-tools/ActMatrixBuilder';
 import HexaflexTool from '@/components/clinical-tools/HexaflexTool';
+import { useClinicalStore } from '@/stores/clinicalStore';
 
 
 const FormulationMapWrapper = dynamic(() => import("@/components/clinical-formulation/FormulationMap"), {


### PR DESCRIPTION
## Summary
- import `useClinicalStore` in patient details page

## Testing
- `npm run typecheck` *(fails: Parameter implicit any, missing modules)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851aac6cab083248b9eeee61fae07cb