### PR TITLE
Add modular clinical card map

### DIFF
--- a/src/app/(app)/patients/[id]/page.tsx
+++ b/src/app/(app)/patients/[id]/page.tsx
@@ -53,6 +53,8 @@ import ChainAnalysisBuilder from '@/components/clinical-tools/ChainAnalysisBuild
 import ActMatrixBuilder from '@/components/clinical-tools/ActMatrixBuilder';
 import HexaflexTool from '@/components/clinical-tools/HexaflexTool';
 import { useClinicalStore } from '@/stores/clinicalStore';
+import MapCanvas from '@/components/map/MapCanvas';
+import MapPanelContainer from '@/components/map/MapPanelContainer';
 
 
 const FormulationMapWrapper = dynamic(() => import("@/components/clinical-formulation/FormulationMap"), {
@@ -648,6 +650,7 @@ export default function PatientDetailPage() {
           <TabsTrigger value="overview"><HomeIconLucide className="mr-1.5 h-4 w-4"/>Visão Geral</TabsTrigger>
           <TabsTrigger value="caseStudy"><Brain className="mr-1.5 h-4 w-4"/>O Coração Clínico</TabsTrigger>
           <TabsTrigger value="timeline"><HistoryIcon className="mr-1.5 h-4 w-4"/>Linha do Tempo</TabsTrigger>
+          <TabsTrigger value="formulations"><Lightbulb className="mr-1.5 h-4 w-4"/>Formulações</TabsTrigger>
           <TabsTrigger value="assessments"><ClipboardList className="mr-1.5 h-4 w-4"/>Avaliações</TabsTrigger>
           <TabsTrigger value="resources"><Share2 className="mr-1.5 h-4 w-4"/>Recursos</TabsTrigger>
           <TabsTrigger value="documents"><FileArchive className="mr-1.5 h-4 w-4"/>Documentos</TabsTrigger>
@@ -767,6 +770,11 @@ export default function PatientDetailPage() {
                 <CardHeader><CardTitle className="font-headline">Linha do Tempo do Paciente</CardTitle></CardHeader>
                 <CardContent><PatientTimeline patientId={patient.id} /></CardContent>
             </Card>
+        </TabsContent>
+
+        <TabsContent value="formulations" className="mt-6 relative">
+            <MapCanvas cards={clinicalStore.cards} />
+            <MapPanelContainer />
         </TabsContent>
 
         <TabsContent value="assessments" className="mt-6 space-y-6">

--- a/src/components/cards/common/CardRouter.tsx
+++ b/src/components/cards/common/CardRouter.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import type { BaseCard } from '@/types/cards';
+import { cardTypeRegistry } from '@/constants/cardRegistry';
+
+interface CardRouterProps {
+  card: BaseCard;
+}
+
+const CardRouter: React.FC<CardRouterProps> = ({ card }) => {
+  const entry = (cardTypeRegistry as any)[card.type];
+  if (entry && entry.component) {
+    const Component = entry.component;
+    return <Component card={card} />;
+  }
+
+  const Generic = cardTypeRegistry['generic']?.component || (() => <div>Generic Card</div>);
+  return <Generic card={card} />;
+};
+
+export default CardRouter;

--- a/src/components/map/MapCanvas.tsx
+++ b/src/components/map/MapCanvas.tsx
@@ -1,0 +1,36 @@
+'use client';
+import React, { useMemo } from 'react';
+import ReactFlow, { MiniMap, Controls, Background } from 'reactflow';
+import 'reactflow/dist/style.css';
+import CardRouter from '@/components/cards/common/CardRouter';
+import type { BaseCard } from '@/types/cards';
+
+const nodeTypes = {
+  card: ({ data }: any) => <CardRouter card={data.card} />,
+};
+
+interface MapCanvasProps {
+  cards: BaseCard[];
+}
+
+const MapCanvas: React.FC<MapCanvasProps> = ({ cards }) => {
+  const nodes = useMemo(() =>
+    cards.map((card, idx) => ({
+      id: card.id,
+      type: 'card',
+      position: { x: idx * 180, y: 0 },
+      data: { card },
+    })), [cards]);
+
+  return (
+    <div className="w-full h-[600px]">
+      <ReactFlow nodes={nodes} edges={[]} nodeTypes={nodeTypes} fitView zoomOnScroll>
+        <MiniMap />
+        <Controls />
+        <Background />
+      </ReactFlow>
+    </div>
+  );
+};
+
+export default MapCanvas;

--- a/src/constants/cardRegistry.ts
+++ b/src/constants/cardRegistry.ts
@@ -1,0 +1,38 @@
+import React from "react";
+import ABCCardNode from '@/components/cards/ABC/ABCCardNode';
+import ChainCardNode from '@/components/cards/Chain/ChainCardNode';
+import MatrixCardNode from '@/components/cards/Matrix/MatrixCardNode';
+import ABCForm from '@/components/cards/ABC/ABCForm';
+import ChainForm from '@/components/cards/Chain/ChainCardForm';
+import MatrixForm from '@/components/cards/Matrix/MatrixCardForm';
+
+export const cardTypeRegistry = {
+  abc: {
+    label: 'Modelo ABC',
+    color: 'bg-blue-100',
+    icon: '🧠',
+    form: ABCForm,
+    component: ABCCardNode,
+  },
+  chain: {
+    label: 'Cadeia Comportamental',
+    color: 'bg-green-100',
+    icon: '🔗',
+    form: ChainForm,
+    component: ChainCardNode,
+  },
+  matrix: {
+    label: 'Matriz ACT',
+    color: 'bg-purple-100',
+    icon: '🔳',
+    form: MatrixForm,
+    component: MatrixCardNode,
+  },
+  generic: {
+    label: 'Genérico',
+    color: 'bg-gray-100',
+    icon: '📄',
+    form: undefined,
+    component: () => <div>Generic Card</div>,
+  },
+};

--- a/src/stores/clinicalStore.ts
+++ b/src/stores/clinicalStore.ts
@@ -1,9 +1,8 @@
 // src/stores/clinicalStore.ts
 
 import { create } from "zustand";
+import type { BaseCard, Label } from "@/types/cards";
 import type {
-  BaseCard,
-  Label,
   ClinicalTab,
   ClinicalTabType,
   TabSpecificFormulationData,

--- a/src/types/cards/abc.ts
+++ b/src/types/cards/abc.ts
@@ -1,0 +1,8 @@
+import { BaseCard } from './base';
+
+export interface ABCCard extends BaseCard {
+  type: 'abc';
+  antecedent: string;
+  behavior: string;
+  consequence: string;
+}

--- a/src/types/cards/base.ts
+++ b/src/types/cards/base.ts
@@ -1,0 +1,10 @@
+export interface BaseCard {
+  id: string;
+  type: string;
+  title: string;
+  sessionNumber?: number;
+  sessionDate?: string;
+  archived?: boolean;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/types/cards/chain.ts
+++ b/src/types/cards/chain.ts
@@ -1,0 +1,13 @@
+import { BaseCard } from './base';
+
+export interface ChainCard extends BaseCard {
+  type: 'chain';
+  vulnerability: string;
+  trigger: string;
+  thought: string;
+  emotion: { name: string; intensity: number };
+  behavior: string;
+  consequenceImmediate: string;
+  consequenceLongTerm: string;
+  interventionPoints: string[];
+}

--- a/src/types/cards/index.ts
+++ b/src/types/cards/index.ts
@@ -1,0 +1,4 @@
+export * from './base';
+export * from './abc';
+export * from './chain';
+export * from './matrix';

--- a/src/types/cards/matrix.ts
+++ b/src/types/cards/matrix.ts
@@ -1,0 +1,9 @@
+import { BaseCard } from './base';
+
+export interface MatrixCard extends BaseCard {
+  type: 'matrix';
+  awayMoves: string[];
+  towardMoves: string[];
+  thoughts: string[];
+  sensations: string[];
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,3 +13,4 @@ export interface Task {
   patientId?: string;
 }
 export * from './assessment';
+export * from './cards';


### PR DESCRIPTION
## Summary
- define new card types under `src/types/cards`
- add global card registry and card router
- implement a simple `MapCanvas` using ReactFlow
- show new "Formulações" tab in patient page with map canvas
- wire clinical store to new card types

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68521b5b9168832488231a2e5e1355e2