### PR TITLE
Handle missing Jest gracefully

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "jest",
+    "test": "scripts/run-tests.sh",
     "test:rules": "firebase emulators:exec --project=demo-project \"npx jest --selectProjects firestore\"",
     "jest": "jest",
     "backup": "node scripts/backup.js"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ ! -x "node_modules/.bin/jest" ]; then
+  echo "Jest não encontrado. Execute 'npm install' para instalar as dependências." >&2
+  exit 1
+fi
+
+npx jest


### PR DESCRIPTION
## Summary
- add a shell script that checks for local Jest before running tests
- call this script from the `npm test` script in `package.json`

## Testing
- `npm test` *(fails: Jest não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68523229cc9c8324ab53615ddd213cca