### PR TITLE
Improve section dividers

### DIFF
--- a/src/app/(app)/notifications/page.tsx
+++ b/src/app/(app)/notifications/page.tsx
@@ -51,14 +51,14 @@ export default function NotificationsPage() {
         </div>
       </div>
 
-      <Card className="shadow-sm">
+      <Card className="shadow-sm border-t border-zinc-200 mt-4 pt-4">
         <CardHeader>
           <CardTitle className="font-headline">Notificações Recentes</CardTitle>
           <CardDescription>Mantenha-se atualizado com alertas e mensagens importantes.</CardDescription>
         </CardHeader>
         <CardContent>
           {notifications.length > 0 ? (
-            <div className="space-y-3">
+            <div className="space-y-3 divide-y divide-zinc-200">
               {notifications.map(notification => (
                 <NotificationItem key={notification.id} notification={notification} />
               ))}

--- a/src/app/(app)/resources/page.tsx
+++ b/src/app/(app)/resources/page.tsx
@@ -28,11 +28,11 @@ export default function ResourcesPage() {
         </Button>
       </div>
 
-      <Card className="shadow-sm">
+      <Card className="shadow-sm border-t border-zinc-200 mt-4 pt-4">
         <CardHeader>
           <CardTitle className="font-headline">Gerenciar PDFs, Guias e Documentos</CardTitle>
           <CardDescription>Carregue, gerencie e compartilhe recursos de forma segura.</CardDescription>
-          <div className="flex flex-col sm:flex-row gap-2 pt-4">
+          <div className="flex flex-col sm:flex-row gap-2 border-t border-zinc-200 mt-4 pt-4">
             <div className="relative flex-1">
               <Search className="absolute left-2.5 top-3 h-4 w-4 text-muted-foreground" />
               <Input placeholder="Buscar recursos..." className="pl-8" />

--- a/src/app/(app)/schedule/today/page.tsx
+++ b/src/app/(app)/schedule/today/page.tsx
@@ -363,7 +363,7 @@ export default function TodaySchedulePage() {
         </div>
       </div>
 
-      <div className="flex-grow overflow-auto border rounded-lg shadow-sm bg-card">
+      <div className="flex-grow overflow-auto border rounded-lg shadow-sm bg-card border-t border-zinc-200 mt-4 pt-4">
         <AppointmentCalendar 
             view={currentView} 
             currentDate={currentDate} 
@@ -372,7 +372,7 @@ export default function TodaySchedulePage() {
         />
       </div>
 
-      <Card className="shadow-sm">
+      <Card className="shadow-sm border-t border-zinc-200 mt-4 pt-4">
         <CardHeader>
           <CardTitle className="font-headline flex items-center">
             <CalendarDays className="mr-2 h-5 w-5 text-primary" />
@@ -399,7 +399,7 @@ export default function TodaySchedulePage() {
         </CardContent>
       </Card>
 
-      <Card className="shadow-sm">
+      <Card className="shadow-sm border-t border-zinc-200 mt-4 pt-4">
         <CardHeader>
           <CardTitle className="font-headline flex items-center">
             <CheckSquare className="mr-2 h-5 w-5 text-primary"/>
@@ -416,7 +416,7 @@ export default function TodaySchedulePage() {
                 </div>
             ))
           ) : tasksForCurrentDate.length > 0 ? (
-            <div className="space-y-3">
+            <div className="space-y-3 divide-y divide-zinc-200">
               {tasksForCurrentDate.map(task => (
                 <TaskItem key={task.id} task={task} />
               ))}

--- a/src/app/(app)/tasks/page.tsx
+++ b/src/app/(app)/tasks/page.tsx
@@ -43,7 +43,7 @@ export default function TasksPage() {
         </Button>
       </div>
 
-      <Card className="shadow-sm">
+      <Card className="shadow-sm border-t border-zinc-200 mt-4 pt-4">
         <CardHeader>
           <CardTitle className="font-headline">Lista de Tarefas</CardTitle>
           <CardDescription>Gerencie as tarefas registradas na aplicação.</CardDescription>
@@ -63,7 +63,7 @@ export default function TasksPage() {
                   <TableHead>Status</TableHead>
                 </TableRow>
               </TableHeader>
-              <TableBody>
+              <TableBody className="divide-y divide-zinc-200">
                 {tasks.map((task) => (
                   <TableRow key={task.id}>
                     <TableCell className="font-medium">


### PR DESCRIPTION
## Summary
- visually separate task sections with borders
- add dividers to task lists and calendar page
- style notifications and resources sections with top borders and item dividers

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685234423b848324bf95d28ac7a95425