### PR TITLE
Add hover effects to clickable containers

### DIFF
--- a/src/components/dashboard/stats-card.tsx
+++ b/src/components/dashboard/stats-card.tsx
@@ -15,7 +15,12 @@ interface StatsCardProps {
 
 function StatsCardComponent({ title, value, icon, trend, href }: StatsCardProps) {
   const cardContent = (
-    <Card className={cn("shadow-sm hover:shadow-md transition-shadow", href && "cursor-pointer")}>
+    <Card
+      className={cn(
+        "shadow-sm hover:shadow-md transition-shadow",
+        href && "cursor-pointer hover:bg-zinc-50 transition-colors"
+      )}
+    >
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle className="text-sm font-medium text-muted-foreground">{title}</CardTitle>
         {icon}

--- a/src/components/schedule/appointment-calendar.tsx
+++ b/src/components/schedule/appointment-calendar.tsx
@@ -242,7 +242,7 @@ function AppointmentCalendarComponent({ view, currentDate, filters, workingDaysO
       <PopoverTrigger asChild>
         <div
           className={cn(
-            "w-full p-1.5 rounded cursor-pointer shadow-sm transition-all leading-tight",
+            "w-full p-1.5 rounded cursor-pointer shadow-sm transition-colors leading-tight hover:bg-zinc-50",
             "flex items-center gap-1.5 text-xs",
             getStatusStyles(appt.status, appt.isGroupSession)
           )}

--- a/src/components/tasks/task-item.tsx
+++ b/src/components/tasks/task-item.tsx
@@ -79,9 +79,9 @@ function TaskItemComponent({ task }: TaskItemProps) {
             {getStatusIcon()}
           </div>
           <div className="flex-1">
-            <CardTitle 
+            <CardTitle
               className={cn(
-                "text-base font-semibold leading-tight cursor-pointer hover:text-accent", 
+                "text-base font-semibold leading-tight cursor-pointer hover:text-accent hover:bg-zinc-50 transition-colors",
                 task.status === "Concluída" && "line-through text-muted-foreground"
               )}
               onClick={() => router.push(`/tasks/edit/${task.id}`)} // Navegar ao clicar no título


### PR DESCRIPTION
## Summary
- highlight interactive dashboard and task cards
- emphasize clickable appointment entries

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852346e890083248eb7b421bed74f6b