### PR TITLE
Enhance typography for improved readability

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -98,6 +98,9 @@ body {
   body {
     @apply bg-background text-foreground;
   }
+  h3, h4 {
+    @apply tracking-wide;
+  }
 }
 
 /* Custom React Flow Handle Styles */

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,7 +26,7 @@ export default function LandingPage() {
         <h2 className="text-5xl md:text-6xl font-headline font-bold mb-6 text-foreground">
           Capacitando Profissionais de Saúde Mental
         </h2>
-        <p className="text-xl text-muted-foreground max-w-2xl mb-10">
+        <p className="text-xl text-muted-foreground max-w-2xl mb-10 leading-relaxed">
           Thalamus oferece uma plataforma segura, intuitiva e aprimorada por IA para gerenciar seu consultório de psicologia, para que você possa focar no que mais importa: seus pacientes.
         </p>
         <Button size="lg" asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -6,16 +6,16 @@ export default function PrivacyPolicyPage() {
     <div className="flex flex-col items-center min-h-screen p-4 space-y-6 bg-gradient-to-br from-background to-secondary">
       <div className="w-full max-w-2xl space-y-4">
         <h1 className="text-3xl font-headline font-bold text-center">Política de Privacidade Thalamus</h1>
-        <p className="text-muted-foreground">
+        <p className="text-muted-foreground leading-relaxed">
           Sua privacidade é prioridade no Thalamus. Todas as informações coletadas
           são utilizadas exclusivamente para oferecer e aprimorar nossos serviços.
         </p>
-        <p className="text-muted-foreground">
+        <p className="text-muted-foreground leading-relaxed">
           Mantemos seus dados protegidos de acordo com a Lei Geral de Proteção de
           Dados (LGPD) e não compartilhamos suas informações pessoais com terceiros
           sem o seu consentimento.
         </p>
-        <p className="text-muted-foreground">
+        <p className="text-muted-foreground leading-relaxed">
           Ao utilizar o Thalamus, você concorda com o tratamento de dados descrito
           nesta política. Em caso de dúvidas, entre em contato com nossa equipe de
           suporte.

--- a/src/app/terms-of-service/page.tsx
+++ b/src/app/terms-of-service/page.tsx
@@ -6,16 +6,16 @@ export default function TermsOfServicePage() {
     <div className="flex flex-col items-center min-h-screen p-4 space-y-6 bg-gradient-to-br from-background to-secondary">
       <div className="w-full max-w-2xl space-y-4">
         <h1 className="text-3xl font-headline font-bold text-center">Termos de Serviço Thalamus</h1>
-        <p className="text-muted-foreground">
+        <p className="text-muted-foreground leading-relaxed">
           Ao acessar e utilizar o Thalamus, você concorda em cumprir estes termos.
           O serviço é fornecido no estado em que se encontra e pode ser alterado
           ou interrompido a qualquer momento.
         </p>
-        <p className="text-muted-foreground">
+        <p className="text-muted-foreground leading-relaxed">
           É sua responsabilidade manter suas credenciais seguras e garantir que o
           uso da plataforma esteja em conformidade com as leis aplicáveis.
         </p>
-        <p className="text-muted-foreground">
+        <p className="text-muted-foreground leading-relaxed">
           Reservamo-nos o direito de atualizar estes termos periodicamente. O uso
           contínuo do Thalamus após mudanças implica sua concordância com as novas
           condições.

--- a/src/components/resources/resource-card.tsx
+++ b/src/components/resources/resource-card.tsx
@@ -54,7 +54,7 @@ function ResourceCardComponent({ resource, isGlobalList = false }: ResourceCardP
         )}
       </CardHeader>
       <CardContent className="flex-grow text-xs text-muted-foreground space-y-1">
-        <p>Tipo: <Badge variant="outline" className="uppercase">{resource.type}</Badge></p>
+        <p>Tipo: <Badge variant="outline" className="uppercase tracking-wide">{resource.type}</Badge></p>
         <p>Tamanho: {resource.size}</p>
         {dateToDisplay && <p>{dateLabel}: {format(new Date(dateToDisplay), "P", { locale: ptBR })}</p>}
         {isGlobalList && resource.sharedWith !== undefined && (


### PR DESCRIPTION
## Summary
- add tracking to `h3` and `h4` elements
- apply relaxed line height to longer paragraphs on main and policy pages
- widen tracking on uppercase resource type badges

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685234507a4c83248da54b725c1d33c9