### PR TITLE
Improve button clarity with icons

### DIFF
--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -41,8 +41,13 @@ export default function ChatWindow() {
             <Users className="h-3 w-3 mr-1" /> {onlineUsers.length} online
           </div>
         </div>
-        <Button variant="ghost" size="icon" onClick={closeChat} className="h-7 w-7" aria-label="Fechar chat">
-          <X className="h-4 w-4" />
+        <Button
+          variant="ghost"
+          onClick={closeChat}
+          className="flex items-center gap-2 text-sm font-medium"
+          aria-label="Fechar chat"
+        >
+          <X className="h-4 w-4" /> Fechar
         </Button>
       </CardHeader>
 

--- a/src/components/clinical-formulation/QuickNoteForm.tsx
+++ b/src/components/clinical-formulation/QuickNoteForm.tsx
@@ -4,6 +4,7 @@
 import React, { useState, useEffect } from 'react'; // Adicionado useState e useEffect
 import { Dialog, DialogContent, DialogHeader, DialogFooter, DialogTitle, DialogDescription, DialogClose } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { X, PlusCircle, Pencil } from 'lucide-react';
 import { useClinicalStore } from '@/stores/clinicalStore';
 
 const QuickNoteForm: React.FC = () => {
@@ -42,13 +43,20 @@ const QuickNoteForm: React.FC = () => {
             <p>Se você vê isto, o diálogo está abrindo.</p>
         </div>
         
-        <DialogFooter>
+        <DialogFooter className="gap-2">
           <DialogClose asChild>
             {/* closeQuickNoteForm já é chamado por handleOpenChange */}
-            <Button type="button" variant="outline">Cancelar</Button>
+            <Button type="button" variant="outline" className="flex items-center gap-2 text-sm font-medium">
+              <X className="h-4 w-4" /> Cancelar
+            </Button>
           </DialogClose>
-          <Button type="button" className="bg-accent hover:bg-accent/90 text-accent-foreground" onClick={closeQuickNoteForm}>
-            {noteToEdit ? "Salvar (Simples)" : "Adicionar (Simples)"}
+          <Button
+            type="button"
+            className="bg-accent hover:bg-accent/90 text-accent-foreground flex items-center gap-2 text-sm font-medium"
+            onClick={closeQuickNoteForm}
+          >
+            {noteToEdit ? <Pencil className="h-4 w-4" /> : <PlusCircle className="h-4 w-4" />}
+            {noteToEdit ? "Salvar" : "Adicionar"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/clinical-formulation/QuickNotesPanel.tsx
+++ b/src/components/clinical-formulation/QuickNotesPanel.tsx
@@ -37,12 +37,22 @@ const QuickNotesPanel: React.FC = () => {
             Observações e lembretes.
           </CardDescription>
         </div>
-        <div className="flex items-center">
-            <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => openQuickNoteForm()} aria-label="Adicionar Nova Anotação Rápida">
-                <PlusCircle className="h-4 w-4" />
+        <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              className="flex items-center gap-2 text-sm font-medium"
+              onClick={() => openQuickNoteForm()}
+              aria-label="Adicionar Nova Anotação Rápida"
+            >
+                <PlusCircle className="h-4 w-4" /> Nova Nota
             </Button>
-            <Button variant="ghost" size="icon" className="h-7 w-7" onClick={toggleQuickNotesPanelVisibility} aria-label="Fechar painel de anotações rápidas">
-                <X className="h-4 w-4" />
+            <Button
+              variant="ghost"
+              className="flex items-center gap-2 text-sm font-medium"
+              onClick={toggleQuickNotesPanelVisibility}
+              aria-label="Fechar painel de anotações rápidas"
+            >
+                <X className="h-4 w-4" /> Fechar
             </Button>
         </div>
       </CardHeader>

--- a/src/components/layout/TabsBar.tsx
+++ b/src/components/layout/TabsBar.tsx
@@ -169,8 +169,12 @@ export default function TabsBar() {
 
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="icon" className="h-8 w-8 flex-shrink-0 ml-1" title="Adicionar Nova Aba">
-              <PlusCircle className="h-4 w-4" />
+            <Button
+              variant="outline"
+              className="flex items-center gap-2 text-sm font-medium h-8 flex-shrink-0 ml-1"
+              title="Adicionar Nova Aba"
+            >
+              <PlusCircle className="h-4 w-4" /> Nova Aba
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start">

--- a/src/components/patients/patient-list-item.tsx
+++ b/src/components/patients/patient-list-item.tsx
@@ -94,11 +94,15 @@ function PatientListItemComponent({ patient }: PatientListItemProps) {
               </Link>
             </Button>
             <AlertDialog>
-              <AlertDialogTrigger asChild>
-                <Button variant="ghost" size="icon" className="h-8 w-8 text-destructive hover:text-destructive hover:bg-destructive/10" aria-label={`Excluir paciente ${patient.name}`}>
-                  <Trash2 className="h-4 w-4" />
+            <AlertDialogTrigger asChild>
+                <Button
+                  variant="ghost"
+                  className="flex items-center gap-2 text-sm font-medium text-destructive hover:text-destructive hover:bg-destructive/10 h-8"
+                  aria-label={`Excluir paciente ${patient.name}`}
+                >
+                  <Trash2 className="h-4 w-4" /> Excluir
                 </Button>
-              </AlertDialogTrigger>
+            </AlertDialogTrigger>
               <AlertDialogContent>
                 <AlertDialogHeader>
                   <AlertDialogTitle>Excluir Paciente Permanentemente?</AlertDialogTitle>
@@ -115,9 +119,14 @@ function PatientListItemComponent({ patient }: PatientListItemProps) {
                 </AlertDialogFooter>
               </AlertDialogContent>
             </AlertDialog>
-            <Button variant="ghost" size="icon" asChild className="h-8 w-8" aria-label={`Ver detalhes de ${patient.name}`}>
-              <Link href={`/patients/${patient.id}`}>
-                <ChevronRight className="h-5 w-5" />
+            <Button
+              variant="ghost"
+              asChild
+              className="flex items-center gap-2 text-sm font-medium h-8"
+              aria-label={`Ver detalhes de ${patient.name}`}
+            >
+              <Link href={`/patients/${patient.id}`} className="flex items-center gap-2">
+                <ChevronRight className="h-5 w-5" /> Abrir
               </Link>
             </Button>
           </div>

--- a/src/components/patients/session-note-card.tsx
+++ b/src/components/patients/session-note-card.tsx
@@ -133,11 +133,15 @@ function SessionNoteCardComponent({ note, patientName, therapistName = "Psicólo
           </div>
           <div className="flex gap-1">
             <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon" aria-label={`Gerar documento a partir da anotação de ${formattedDate}`}>
-                  <FilePlus2 className="h-4 w-4" />
+            <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  className="flex items-center gap-2 text-sm font-medium"
+                  aria-label={`Gerar documento a partir da anotação de ${formattedDate}`}
+                >
+                  <FilePlus2 className="h-4 w-4" /> Documento
                 </Button>
-              </DropdownMenuTrigger>
+            </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
                 <DropdownMenuLabel>Gerar Rascunho de Documento</DropdownMenuLabel>
                 <DropdownMenuSeparator />
@@ -146,11 +150,19 @@ function SessionNoteCardComponent({ note, patientName, therapistName = "Psicólo
                 <DropdownMenuItem onClick={() => handleGenerateReport("session_summary")}>Resumo da Sessão</DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
-            <Button variant="ghost" size="icon" aria-label={`Editar anotação de ${formattedDate}`}>
-              <Edit className="h-4 w-4" />
+            <Button
+              variant="ghost"
+              className="flex items-center gap-2 text-sm font-medium"
+              aria-label={`Editar anotação de ${formattedDate}`}
+            >
+              <Edit className="h-4 w-4" /> Editar
             </Button>
-            <Button variant="ghost" size="icon" className="text-destructive hover:text-destructive" aria-label={`Excluir anotação de ${formattedDate}`}>
-              <Trash2 className="h-4 w-4" />
+            <Button
+              variant="ghost"
+              className="flex items-center gap-2 text-sm font-medium text-destructive hover:text-destructive"
+              aria-label={`Excluir anotação de ${formattedDate}`}
+            >
+              <Trash2 className="h-4 w-4" /> Excluir
             </Button>
           </div>
         </div>

--- a/src/components/resources/resource-card.tsx
+++ b/src/components/resources/resource-card.tsx
@@ -63,21 +63,37 @@ function ResourceCardComponent({ resource, isGlobalList = false }: ResourceCardP
       </CardContent>
       <CardFooter className="border-t pt-3">
         <div className="flex w-full justify-end gap-1.5">
-          <Button variant="ghost" size="icon" className="h-7 w-7" aria-label={`Baixar recurso ${resource.name}`}>
-            <Download className="h-4 w-4" />
+          <Button
+            variant="ghost"
+            className="flex items-center gap-2 text-sm font-medium"
+            aria-label={`Baixar recurso ${resource.name}`}
+          >
+            <Download className="h-4 w-4" /> Baixar
           </Button>
           {isGlobalList && (
             <>
-              <Button variant="ghost" size="icon" className="h-7 w-7" aria-label={`Compartilhar recurso ${resource.name}`}>
-                <Share2 className="h-4 w-4" />
+              <Button
+                variant="ghost"
+                className="flex items-center gap-2 text-sm font-medium"
+                aria-label={`Compartilhar recurso ${resource.name}`}
+              >
+                <Share2 className="h-4 w-4" /> Compartilhar
               </Button>
-              <Button variant="ghost" size="icon" className="h-7 w-7" aria-label={`Editar recurso ${resource.name}`}>
-                <Edit className="h-4 w-4" />
+              <Button
+                variant="ghost"
+                className="flex items-center gap-2 text-sm font-medium"
+                aria-label={`Editar recurso ${resource.name}`}
+              >
+                <Edit className="h-4 w-4" /> Editar
               </Button>
             </>
           )}
-          <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive hover:text-destructive" aria-label={`Excluir recurso ${resource.name}`}>
-            <Trash2 className="h-4 w-4" />
+          <Button
+            variant="ghost"
+            className="flex items-center gap-2 text-sm font-medium text-destructive hover:text-destructive"
+            aria-label={`Excluir recurso ${resource.name}`}
+          >
+            <Trash2 className="h-4 w-4" /> Excluir
           </Button>
         </div>
       </CardFooter>

--- a/src/components/tasks/task-item.tsx
+++ b/src/components/tasks/task-item.tsx
@@ -95,8 +95,13 @@ function TaskItemComponent({ task }: TaskItemProps) {
           </div>
           <div className="flex flex-col items-end gap-1">
             <Badge variant={getPriorityBadgeVariant()} className="text-xs">{task.priority}</Badge>
-             <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => setIsExpanded(!isExpanded)} aria-label="Expandir/Recolher detalhes da tarefa">
-                <ChevronsUpDown className="h-4 w-4" />
+             <Button
+                variant="ghost"
+                className="flex items-center gap-2 text-sm font-medium h-7"
+                onClick={() => setIsExpanded(!isExpanded)}
+                aria-label="Expandir/Recolher detalhes da tarefa"
+             >
+                <ChevronsUpDown className="h-4 w-4" /> Detalhes
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add icons and labels for Quick Notes actions
- update Quick Note modal actions with icons
- show icon+text on resource card actions
- convert chat close button to include label
- update TabsBar add button
- show icon+text on patient list item actions
- update session note card actions
- show text label on task expand toggle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852345f7c9883249abad35b62480cc6