### PR TITLE
Fix layout overflow with Tailwind utilities

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -88,7 +88,7 @@ export default function AppLayout({ children }: AppLayoutProps) {
       </Sidebar>
       <SidebarInset className="flex flex-col h-screen"> {/* Garante que SidebarInset possa usar toda a altura */}
         <AppHeader />
-        <main className="flex-1 p-4 md:p-6 lg:p-8 overflow-auto flex flex-col"> {/* Adicionado flex flex-col */}
+        <main className="flex-1 p-4 md:p-6 lg:p-8 overflow-auto min-w-0 flex flex-col"> {/* Adicionado flex flex-col */}
           {children}
         </main>
         <ChatFloatingButton />

--- a/src/app/(app)/patients/[id]/page.tsx
+++ b/src/app/(app)/patients/[id]/page.tsx
@@ -675,7 +675,7 @@ export default function PatientDetailPage() {
         <TabsContent value="overview" className="mt-6 space-y-6">
           <Card>
             <CardHeader><CardTitle className="font-headline">Informações Gerais</CardTitle></CardHeader>
-            <CardContent className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+            <CardContent className="grid md:grid-cols-2 lg:grid-cols-3 gap-6 min-w-0 overflow-auto">
               <InfoDisplay label="Data de Nascimento" value={formattedDob} icon={CalendarDays} />
               <InfoDisplay label="Psicólogo(a) Designado(a)" value={patient.assignedPsychologist} icon={UsersIconLucide} />
               <InfoDisplay label="Endereço" value={patient.address || "Não informado"} icon={HomeIconLucide} />
@@ -822,7 +822,7 @@ export default function PatientDetailPage() {
                 </CardHeader>
                 <CardContent>
                     {assessments.length > 0 ? (
-                        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+                        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4 min-w-0 overflow-auto">
                             {assessments.map(asm => <AssessmentCard key={asm.id} assessment={asm} />)}
                         </div>
                     ) : <p className="text-muted-foreground">Nenhuma avaliação ou inventário atribuído.</p>}
@@ -854,7 +854,7 @@ export default function PatientDetailPage() {
                 </CardHeader>
                  <CardContent>
                     {patientResources.length > 0 ? (
-                        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+                        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4 min-w-0 overflow-auto">
                         {patientResources.map(res => <ResourceCard key={res.id} resource={res} isGlobalList={false}/>)}
                         </div>
                     ) : <p className="text-muted-foreground">Nenhum recurso compartilhado com este paciente ainda.</p>}
@@ -938,7 +938,7 @@ export default function PatientDetailPage() {
 
                     <Card className="bg-muted/20 p-4">
                         <CardTitle className="text-lg font-semibold mb-2">Enviar Anamnese para o Paciente Preencher</CardTitle>
-                        <div className="grid sm:grid-cols-2 gap-4 mb-3">
+                        <div className="grid sm:grid-cols-2 gap-4 mb-3 min-w-0 overflow-auto">
                              <div className="space-y-1">
                                 <Label htmlFor="anamnesisTemplate">Modelo de Anamnese</Label>
                                 <Select value={selectedAnamnesisTemplateIdToSent} onValueChange={setSelectedAnamnesisTemplateIdToSent}>

--- a/src/components/clinical-formulation/FormulationGuidePanel.tsx
+++ b/src/components/clinical-formulation/FormulationGuidePanel.tsx
@@ -29,7 +29,7 @@ const FormulationGuidePanel: React.FC = () => {
             <X className="h-4 w-4" />
         </Button>
       </CardHeader>
-      <CardContent className="p-0 flex-grow overflow-hidden">
+      <CardContent className="p-0 flex-grow overflow-auto min-w-0">
         <ScrollArea className="h-full p-3">
           {formulationGuideQuestions.length === 0 ? (
             <p className="text-xs text-muted-foreground text-center py-4">Nenhuma pergunta guia configurada.</p>

--- a/src/components/clinical-formulation/FormulationMap.tsx
+++ b/src/components/clinical-formulation/FormulationMap.tsx
@@ -514,21 +514,21 @@ const FormulationMap: React.FC = () => {
           {/* 
           // Panels are kept commented out as per debugging steps
           {isSchemaPanelVisible && (
-            <Panel position="top-left" className="!m-0 p-0 shadow-xl border rounded-lg bg-card w-72 h-[calc(100%-5rem)] flex flex-col">
+            <Panel position="top-left" className="!m-0 p-0 shadow-xl border rounded-lg bg-card w-72 h-[calc(100%-5rem)] flex flex-col min-w-0 overflow-auto">
                 <SchemaPanel />
             </Panel>
           )}
           {isFormulationGuidePanelVisible && (
-            <Panel position="top-right" className="!m-0 p-0 shadow-xl border rounded-lg bg-card w-72 h-[calc(100%-5rem)] flex flex-col">
+            <Panel position="top-right" className="!m-0 p-0 shadow-xl border rounded-lg bg-card w-72 h-[calc(100%-5rem)] flex flex-col min-w-0 overflow-auto">
                 <FormulationGuidePanel />
             </Panel>
           )}
           {isQuickNotesPanelVisible && (
-             <Panel position="bottom-right" className="!m-0 p-0 shadow-xl border rounded-lg bg-card w-72 h-2/5 max-h-[400px] flex flex-col">
+             <Panel position="bottom-right" className="!m-0 p-0 shadow-xl border rounded-lg bg-card w-72 h-2/5 max-h-[400px] flex flex-col min-w-0 overflow-auto">
                 <QuickNotesPanel />
             </Panel>
           )}
-          <Panel position="bottom-left" className="!m-0 p-0 shadow-xl border rounded-lg bg-card w-72 h-2/5 max-h-[400px] flex flex-col">
+          <Panel position="bottom-left" className="!m-0 p-0 shadow-xl border rounded-lg bg-card w-72 h-2/5 max-h-[400px] flex flex-col min-w-0 overflow-auto">
             <InsightPanel />
           </Panel> 
           */}

--- a/src/components/clinical-formulation/InsightPanel.tsx
+++ b/src/components/clinical-formulation/InsightPanel.tsx
@@ -23,7 +23,7 @@ const InsightPanel: React.FC = () => {
           Observações e padrões identificados pela IA ou pelo profissional.
         </CardDescription>
       </CardHeader>
-      <CardContent className="p-0 flex-grow overflow-hidden">
+      <CardContent className="p-0 flex-grow overflow-auto min-w-0">
         <ScrollArea className="h-full p-4">
           {/* {isLoadingInsights && <p className="text-sm text-muted-foreground">Gerando insights...</p>} */}
           {!insights || insights.length === 0 || (insights.length === 1 && insights[0] === "Clique em 'Gerar Insights' para análise.") ? (

--- a/src/components/clinical-formulation/QuickNotesPanel.tsx
+++ b/src/components/clinical-formulation/QuickNotesPanel.tsx
@@ -46,7 +46,7 @@ const QuickNotesPanel: React.FC = () => {
             </Button>
         </div>
       </CardHeader>
-      <CardContent className="p-0 flex-grow overflow-hidden">
+      <CardContent className="p-0 flex-grow overflow-auto min-w-0">
         <ScrollArea className="h-full p-3">
           {quickNotes.length === 0 ? (
             <p className="text-xs text-muted-foreground text-center py-4">Nenhuma anotação rápida adicionada.</p>

--- a/src/components/clinical-formulation/SchemaPanel.tsx
+++ b/src/components/clinical-formulation/SchemaPanel.tsx
@@ -40,7 +40,7 @@ const SchemaPanel: React.FC = () => {
             <X className="h-4 w-4" />
         </Button>
       </CardHeader>
-      <CardContent className="p-3 flex-grow overflow-hidden flex flex-col">
+      <CardContent className="p-3 flex-grow overflow-auto flex flex-col min-w-0">
         <div className="flex gap-2 mb-2">
           <Input
             type="text"

--- a/src/components/layout/app-layout.tsx
+++ b/src/components/layout/app-layout.tsx
@@ -88,7 +88,7 @@ export default function AppLayout({ children }: AppLayoutProps) {
       </Sidebar>
       <SidebarInset>
         <AppHeader />
-        <main className="flex-1 p-4 md:p-6 lg:p-8 overflow-auto">
+        <main className="flex-1 p-4 md:p-6 lg:p-8 overflow-auto min-w-0">
           {children}
         </main>
         <ChatFloatingButton />

--- a/src/components/map/MapPanelContainer.tsx
+++ b/src/components/map/MapPanelContainer.tsx
@@ -4,13 +4,13 @@ import HexaflexPanel from './panels/HexaflexPanel';
 
 // Placeholder components for other panels
 const ChainAnalysisPanel: React.FC = () => (
-  <div className="p-4 border-l border-border bg-background w-72 overflow-y-auto">
+  <div className="p-4 border-l border-border bg-background w-72 min-w-0 overflow-auto">
     <h3 className="text-lg font-semibold mb-4">Painel de Análise em Cadeia (Placeholder)</h3>
     <p className="text-muted-foreground">Este é um painel placeholder para a Análise em Cadeia.</p>
   </div>
 );
 const ActMatrixPanel: React.FC = () => (
-  <div className="p-4 border-l border-border bg-background w-72 overflow-y-auto">
+  <div className="p-4 border-l border-border bg-background w-72 min-w-0 overflow-auto">
     <h3 className="text-lg font-semibold mb-4">Painel da Matriz ACT (Placeholder)</h3>
     <p className="text-muted-foreground">Este é um painel placeholder para a Matriz ACT.</p>
   </div>

--- a/src/components/map/panels/HexaflexPanel.tsx
+++ b/src/components/map/panels/HexaflexPanel.tsx
@@ -39,7 +39,7 @@ const HexaflexPanel: React.FC = () => {
   const currentSection = SECTIONS.find(s => s.key === activeSection);
 
   return (
-    <div className="p-4 border-l border-border bg-background w-80 pointer-events-auto overflow-y-auto flex">
+    <div className="p-4 border-l border-border bg-background w-80 pointer-events-auto overflow-auto min-w-0 flex">
       <div className="relative w-56 h-56 rounded-full border flex-shrink-0 mx-auto">
         {SECTIONS.map((s, idx) => (
           <button


### PR DESCRIPTION
## Summary
- avoid overflow in app layout and patient page columns
- allow scrolling in formulation side panels
- keep side panel containers from expanding

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685233d8f6308324b816b21f81b8769e