### PR TITLE
Fix asChild usage in Button

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -48,7 +48,17 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     { className, variant, size, asChild = false, loading, quick, onClick, children, ...props },
     ref
   ) => {
-    const Comp = asChild ? Slot : "button"
+    const hasSingleValidChild =
+      React.Children.count(children) === 1 &&
+      React.isValidElement(children)
+
+    if (asChild && !hasSingleValidChild) {
+      console.error(
+        "Button with asChild expects a single React element child. Rendering a default <button> instead."
+      )
+    }
+
+    const Comp = asChild && hasSingleValidChild ? Slot : "button"
     const [checked, setChecked] = React.useState(false)
 
     const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {


### PR DESCRIPTION
## Summary
- improve Button component to safely handle incorrect `asChild` usage

## Testing
- `npm run lint` *(fails: many unrelated lint errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852377525e88324b05c1bd9d83ad6f3