### PR TITLE
Fix layout typing and not-found navigation

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,11 +15,7 @@ const headLinks = [
   { href: "https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700&display=swap", rel: "stylesheet", itemKey: "google-fonts-space-grotesk" },
 ];
 
-export default function RootLayout({
-  children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   usePageView();
   const router = useRouter();
 

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,14 +1,16 @@
+"use client";
+
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { useRouter } from "next/navigation";
 
 export default function NotFoundPage() {
+  const router = useRouter();
   return (
     <div className="flex flex-col items-center justify-center min-h-screen text-center p-4 space-y-4">
       <h1 className="text-4xl font-headline font-bold">404 - Página Não Encontrada</h1>
       <p className="text-muted-foreground">Não conseguimos encontrar a página que você procurava.</p>
-      <Button asChild>
-        <Link href="/">Voltar para o início</Link>
-      </Button>
+      <Button onClick={() => router.push("/")}>Voltar para a página inicial</Button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- type RootLayout children prop more explicitly
- improve NotFound page with client-side router push

## Testing
- `npm test` *(fails: Jest não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68523a40f46083248bb8cc6285e3952b