### PR TITLE
Improve accessibility and data handling

### DIFF
--- a/src/components/admin/sessions-per-psychologist-chart.tsx
+++ b/src/components/admin/sessions-per-psychologist-chart.tsx
@@ -27,7 +27,11 @@ const chartConfig = {
 
 export function SessionsPerPsychologistChart({ data }: SessionsPerPsychologistChartProps) {
   if (!data || data.length === 0) {
-    return <p className="text-center text-sm text-muted-foreground">Sem dados de sessões por psicólogo.</p>;
+    return (
+      <p className="text-center text-sm text-muted-foreground">
+        Nenhuma sessão registrada.
+      </p>
+    );
   }
 
   return (

--- a/src/components/analytics/detailed-occupancy-table.tsx
+++ b/src/components/analytics/detailed-occupancy-table.tsx
@@ -1,7 +1,98 @@
-// Este componente foi integrado diretamente na página de Relatórios e Análises
-// (/analytics) como parte da aba "Desempenho e Operações".
-// Não é mais necessário como um componente separado.
+"use client";
 
-export default function DetailedOccupancyTableDisabled() {
-  return null;
+import { useMemo, useState } from "react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+export interface OccupancyRow {
+  id: string;
+  day: string;
+  date: string;
+  psychologist: string;
+  totalSlots: number;
+  bookedSlots: number;
+  blockedSlots: number;
+  occupancy: string;
+}
+
+interface DetailedOccupancyTableProps {
+  dados?: OccupancyRow[];
+}
+
+const PAGE_SIZE = 10;
+
+export default function DetailedOccupancyTable({ dados }: DetailedOccupancyTableProps) {
+  const [page, setPage] = useState(0);
+
+  if (!dados || dados.length === 0) {
+    return <p className="text-sm text-muted-foreground">Nenhuma ocupação registrada.</p>;
+  }
+
+  const pageCount = Math.ceil(dados.length / PAGE_SIZE);
+
+  const pageData = useMemo(() => {
+    const start = page * PAGE_SIZE;
+    return dados.slice(start, start + PAGE_SIZE);
+  }, [dados, page]);
+
+  return (
+    <div className="overflow-x-auto">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Dia</TableHead>
+            <TableHead>Data</TableHead>
+            <TableHead>Psicólogo(a)</TableHead>
+            <TableHead className="text-center">Total Horários</TableHead>
+            <TableHead className="text-center">Agendados</TableHead>
+            <TableHead className="text-center">Bloqueados</TableHead>
+            <TableHead className="text-right">Ocupação</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {pageData.map((linha) => (
+            <TableRow key={linha.id}>
+              <TableCell>{linha.day}</TableCell>
+              <TableCell>{linha.date}</TableCell>
+              <TableCell>{linha.psychologist}</TableCell>
+              <TableCell className="text-center">{linha.totalSlots}</TableCell>
+              <TableCell className="text-center">{linha.bookedSlots}</TableCell>
+              <TableCell className="text-center">{linha.blockedSlots}</TableCell>
+              <TableCell className="text-right">
+                <Badge>{linha.occupancy}</Badge>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      {pageCount > 1 && (
+        <div className="flex justify-end gap-2 mt-2">
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={page === 0}
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+          >
+            Anterior
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={page === pageCount - 1}
+            onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
+          >
+            Próxima
+          </Button>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/src/components/consent-modal.tsx
+++ b/src/components/consent-modal.tsx
@@ -1,7 +1,7 @@
 
 "use client";
 
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogFooter, DialogTitle } from '@/components/ui/dialog';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Button } from '@/components/ui/button';
@@ -16,19 +16,43 @@ export default function ConsentModal({ uid }: ConsentModalProps) {
   const [open, setOpen] = useState(true);
   const [checked, setChecked] = useState(false);
 
+  useEffect(() => {
+    if (open) {
+      const modal = document.getElementById('consent-modal');
+      modal?.focus();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    const esc = (e: KeyboardEvent) => e.key === 'Escape' && closeModal();
+    window.addEventListener('keydown', esc);
+    return () => window.removeEventListener('keydown', esc);
+  }, [closeModal]);
+
+  const closeModal = useCallback(() => setOpen(false), []);
+
   const handleConfirm = async () => {
     if (!checked) return;
     await setDoc(doc(db, 'users', uid), { consentAt: serverTimestamp() }, { merge: true });
-    setOpen(false);
+    closeModal();
   };
 
   return (
     <Dialog open={open}>
-      <DialogContent className="max-w-md">
+      <DialogContent
+        id="consent-modal"
+        role="dialog"
+        aria-labelledby="consent-title"
+        aria-describedby="consent-text"
+        tabIndex={-1}
+        className="max-w-md"
+      >
         <DialogHeader>
-          <DialogTitle className="font-headline">Consentimento</DialogTitle>
+          <DialogTitle id="consent-title" className="font-headline">
+            Consentimento
+          </DialogTitle>
         </DialogHeader>
-        <div className="space-x-2 flex items-center py-4">
+        <div id="consent-text" className="space-x-2 flex items-center py-4">
           <Checkbox id="consent" checked={checked} onCheckedChange={(v) => setChecked(!!v)} />
           <label htmlFor="consent" className="text-sm">Aceito política de privacidade</label>
         </div>


### PR DESCRIPTION
## Summary
- focus modal and close with ESC key
- update fallback message in psychologist sessions chart
- reintroduce detailed occupancy table with pagination

## Testing
- `npm run typecheck` *(fails: Cannot find module 'react' or types)*
- `npm test` *(fails: Jest não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68523ac0ad20832485b48b19267dd3d2