### PR TITLE
Disable auth via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Para obter `FIREBASE_CLIENT_EMAIL` e `FIREBASE_PRIVATE_KEY`:
 -   `NEXT_PUBLIC_GAS_PRONTUARIO_URL`: URL do script Google Apps Script para geração de prontuários.
 -   `NEXT_PUBLIC_GOOGLE_CLIENT_ID`, `NEXT_PUBLIC_GOOGLE_CLIENT_SECRET`, `NEXT_PUBLIC_GOOGLE_REDIRECT_URI`: Para integração com o Google Calendar (opcional).
 -   `NEXT_PUBLIC_FIREBASE_VAPID_KEY`: Chave VAPID para Firebase Cloud Messaging (Web Push). Encontrada no Console do Firebase -> Configurações do Projeto -> Cloud Messaging -> Web configuration -> Web Push certificates.
+-   `NEXT_PUBLIC_DISABLE_AUTH`: Quando definido como `true`, desativa temporariamente a tela de login e a verificação de autenticação nas rotas protegidas.
 
 ## Importante sobre Segurança
 

--- a/env.example
+++ b/env.example
@@ -28,6 +28,9 @@ FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nYOUR_PRIVATE_KEY_CONTENT_HERE
 # Para Cloud Workstations ou similar, certifique-se de que os emuladores estão configurados com host: "0.0.0.0" no firebase.json.
 NEXT_PUBLIC_FIREBASE_EMULATOR_HOST="localhost"
 
+# Defina como 'true' para desabilitar temporariamente a autenticação e a tela de login
+NEXT_PUBLIC_DISABLE_AUTH="false"
+
 # Outras Variáveis (exemplos)
 # NEXT_PUBLIC_GAS_PRONTUARIO_URL="" # URL para Google Apps Script
 # NEXT_PUBLIC_GOOGLE_CLIENT_ID=""

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,10 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
 export function middleware(request: NextRequest) {
+  if (process.env.NEXT_PUBLIC_DISABLE_AUTH === 'true') {
+    console.debug('Auth disabled via env, skipping middleware.');
+    return NextResponse.next();
+  }
   const { pathname } = request.nextUrl;
   // Skip middleware for static assets and API routes
   if (pathname.startsWith('/api') || pathname.startsWith('/_next')) {


### PR DESCRIPTION
## Summary
- add `NEXT_PUBLIC_DISABLE_AUTH` environment variable
- skip auth middleware when `NEXT_PUBLIC_DISABLE_AUTH` is true
- document the new variable in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68523c28f5648324b43ec73f0b0babf7