### PR TITLE
Improve accessibility features across UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
         "date-fns-tz": "^3.1.3",
+        "dompurify": "^3.2.6",
         "dotenv": "^16.5.0",
         "firebase": "^11.9.1",
         "firebase-admin": "^13.4.0",
@@ -9011,6 +9012,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
@@ -12524,6 +12532,15 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dot-prop": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
     "date-fns-tz": "^3.1.3",
+    "dompurify": "^3.2.6",
     "dotenv": "^16.5.0",
     "firebase": "^11.9.1",
     "firebase-admin": "^13.4.0",

--- a/src/components/cards/common/CardLabel.tsx
+++ b/src/components/cards/common/CardLabel.tsx
@@ -15,6 +15,7 @@ const CardLabel: React.FC<CardLabelProps> = ({ tags }) => {
         <span
           key={index}
           className="inline-flex items-center rounded-full bg-blue-500/10 px-2 py-0.5 text-xs font-medium text-blue-700 dark:text-blue-300"
+          aria-label={`Tipo de cartão: ${tag}`}
         >
           {tag}
         </span>

--- a/src/components/cards/common/CardRouter.tsx
+++ b/src/components/cards/common/CardRouter.tsx
@@ -13,8 +13,12 @@ const CardRouter: React.FC<CardRouterProps> = ({ card }) => {
     return <Component card={card} />;
   }
 
-  const Generic = cardTypeRegistry['generic']?.component || (() => <div>Generic Card</div>);
-  return <Generic card={card} />;
+  if (cardTypeRegistry['generic']?.component) {
+    const Generic = cardTypeRegistry['generic'].component;
+    return <Generic card={card} />;
+  }
+
+  return <p>Tipo de card não reconhecido.</p>;
 };
 
 export default CardRouter;

--- a/src/components/cards/common/CardToolbar.tsx
+++ b/src/components/cards/common/CardToolbar.tsx
@@ -18,7 +18,7 @@ const CardToolbar: React.FC<CardToolbarProps> = ({ onEdit, onArchive, onDelete }
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="w-6 h-6">
+        <Button variant="ghost" size="icon" className="w-6 h-6" aria-label="Opções do cartão">
           <MoreVertical className="w-3 h-3" />
         </Button>
       </DropdownMenuTrigger>

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -1,7 +1,7 @@
 
 "use client";
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { X, Users } from 'lucide-react';
@@ -13,6 +13,16 @@ import { Avatar, AvatarFallback, AvatarImage } from '../ui/avatar';
 
 export default function ChatWindow() {
   const { isChatOpen, closeChat, currentChatId, onlineUsers, currentUser } = useChatStore();
+
+  useEffect(() => {
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        closeChat();
+      }
+    };
+    document.addEventListener('keydown', handleEsc);
+    return () => document.removeEventListener('keydown', handleEsc);
+  }, [closeChat]);
 
   if (!isChatOpen || !currentUser?.uid) {
     return null;
@@ -31,12 +41,13 @@ export default function ChatWindow() {
         "transition-all duration-300 ease-in-out",
         isChatOpen ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10 pointer-events-none"
       )}
-      role="log"
-      aria-live="polite"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="chat-title"
     >
       <CardHeader className="flex flex-row items-center justify-between p-3 border-b">
         <div>
-          <CardTitle className="text-base font-semibold font-headline">Chat Global da Clínica</CardTitle>
+          <CardTitle id="chat-title" className="text-base font-semibold font-headline">Chat Global da Clínica</CardTitle>
           <div className="flex items-center text-xs text-muted-foreground">
             <Users className="h-3 w-3 mr-1" /> {onlineUsers.length} online
           </div>

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -72,7 +72,7 @@ export default function MessageInput({ chatId }: MessageInputProps) {
         className="flex-1 resize-none min-h-[40px] max-h-[120px] text-sm rounded-lg"
         rows={1}
         disabled={!currentUser?.uid || isSending}
-        aria-label="Campo de mensagem do chat"
+        aria-label="Digite sua mensagem"
       />
       <Button
         type="submit"

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import React from 'react';
+import DOMPurify from 'dompurify';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { formatDistanceToNow } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
@@ -45,7 +46,10 @@ export default function MessageItem({ message, isOwnMessage }: MessageItemProps)
         {!isOwnMessage && (
           <p className="text-xs font-semibold mb-0.5 text-accent">{message.senderName}</p>
         )}
-        <p className="whitespace-pre-wrap break-words">{message.text}</p>
+        <p
+          className="whitespace-pre-wrap break-words"
+          dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(message.text) }}
+        />
         <p className={cn("text-xs mt-1", isOwnMessage ? "text-primary-foreground/70 text-right" : "text-muted-foreground text-left")}>
           {formattedTimestamp}
         </p>

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -18,11 +18,10 @@ export default function MessageList({ chatId }: MessageListProps) {
   const currentUser = useChatStore((state) => state.currentUser);
   const scrollAreaRef = useRef<HTMLDivElement>(null);
   const viewportRef = useRef<HTMLDivElement>(null);
+  const endRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (viewportRef.current) {
-      viewportRef.current.scrollTop = viewportRef.current.scrollHeight;
-    }
+    endRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
   if (loading) {
@@ -65,6 +64,7 @@ export default function MessageList({ chatId }: MessageListProps) {
             isOwnMessage={msg.senderId === currentUser?.uid}
           />
         ))}
+        <div ref={endRef} />
       </div>
     </ScrollArea>
   );

--- a/src/components/clinical-formulation/EdgeLabelModal.tsx
+++ b/src/components/clinical-formulation/EdgeLabelModal.tsx
@@ -80,9 +80,14 @@ const EdgeLabelModal: React.FC = () => {
 
   return (
     <Dialog open={isLabelEdgeModalOpen} onOpenChange={(open) => { if (!open) closeLabelEdgeModal(); }}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent
+        className="sm:max-w-md"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="label-title"
+      >
         <DialogHeader>
-          <DialogTitle className="font-headline">Rotular Conexão</DialogTitle>
+          <DialogTitle id="label-title" className="font-headline">Rotular Conexão</DialogTitle>
           <DialogDescription>
             Como estes dois elementos se relacionam?
           </DialogDescription>
@@ -90,7 +95,7 @@ const EdgeLabelModal: React.FC = () => {
         <div className="py-4 space-y-2">
           <Label htmlFor="connection-label-select">Tipo de Relação</Label>
           <Select onValueChange={(value) => setSelectedLabel(value as ConnectionLabel['label'])} value={selectedLabel}>
-            <SelectTrigger id="connection-label-select">
+            <SelectTrigger id="connection-label-select" autoFocus>
               <SelectValue placeholder="Selecione um rótulo" />
             </SelectTrigger>
             <SelectContent>

--- a/src/components/clinical-formulation/FormulationGuidePanel.tsx
+++ b/src/components/clinical-formulation/FormulationGuidePanel.tsx
@@ -29,7 +29,7 @@ const FormulationGuidePanel: React.FC = () => {
             <X className="h-4 w-4" />
         </Button>
       </CardHeader>
-      <CardContent className="p-0 flex-grow overflow-auto min-w-0">
+      <CardContent className="p-0 flex-grow overflow-auto min-w-0" id="panel-content">
         <ScrollArea className="h-full p-3">
           {formulationGuideQuestions.length === 0 ? (
             <p className="text-xs text-muted-foreground text-center py-4">Nenhuma pergunta guia configurada.</p>

--- a/src/components/clinical-formulation/FormulationMap.tsx
+++ b/src/components/clinical-formulation/FormulationMap.tsx
@@ -366,7 +366,15 @@ const FormulationMap: React.FC = () => {
               <Button variant="outline" size="icon" className={commonButtonClass} onClick={toggleSchemaPanelVisibility} title={isSchemaPanelVisible ? "Ocultar Painel de Esquemas" : "Mostrar Painel de Esquemas"}>
                 {isSchemaPanelVisible ? <PanelLeftClose className={commonIconClass} /> : <ListTree className={commonIconClass} />}
               </Button>
-              <Button variant="outline" size="icon" className={commonButtonClass} onClick={toggleFormulationGuidePanelVisibility} title={isFormulationGuidePanelVisible ? "Ocultar Guia de Formulação" : "Mostrar Guia de Formulação"}>
+              <Button
+                variant="outline"
+                size="icon"
+                className={commonButtonClass}
+                onClick={toggleFormulationGuidePanelVisibility}
+                title={isFormulationGuidePanelVisible ? "Ocultar Guia de Formulação" : "Mostrar Guia de Formulação"}
+                aria-expanded={isFormulationGuidePanelVisible}
+                aria-controls="panel-content"
+              >
                  {isFormulationGuidePanelVisible ? <PanelLeftClose className={commonIconClass} /> : <FormulationGuideIcon className={commonIconClass} />}
               </Button>
               <Button variant="outline" size="icon" className={commonButtonClass} onClick={toggleQuickNotesPanelVisibility} title={isQuickNotesPanelVisible ? "Ocultar Painel de Notas Rápidas" : "Mostrar Painel de Notas Rápidas"}>


### PR DESCRIPTION
## Summary
- ensure card labels include descriptive aria-labels
- show fallback message for unknown card types
- label card toolbar icon button
- sanitize rendered chat messages
- auto-scroll chat views
- allow closing chat via Escape key and mark chat window as dialog
- label chat message input
- add accessibility attrs to edge label modal and formulation guide panel controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68523c989324832488439f8353acc7c5