### PR TITLE
Improve accessibility and validations

### DIFF
--- a/src/components/clinical-tools/ChainAnalysisBuilder.tsx
+++ b/src/components/clinical-tools/ChainAnalysisBuilder.tsx
@@ -1,28 +1,89 @@
 
 "use client";
 
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
-import { Workflow } from 'lucide-react'; // Changed from BarChartSteps to Workflow
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Workflow, Plus } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
 
 interface ChainAnalysisBuilderProps {
   tabId: string;
 }
 
 export default function ChainAnalysisBuilder({ tabId }: ChainAnalysisBuilderProps) {
+  const [steps, setSteps] = useState([{ vulnerability: '', trigger: '', behavior: '' }]);
+  const inputRefs = useRef<Array<HTMLInputElement | null>>([]);
+  const { toast } = useToast();
+
+  const addStep = () => {
+    setSteps((prev) => [...prev, { vulnerability: '', trigger: '', behavior: '' }]);
+    setTimeout(() => {
+      const lastIndex = inputRefs.current.length - 1;
+      inputRefs.current[lastIndex]?.focus();
+    }, 0);
+  };
+
+  const handleChange = (index: number, field: keyof (typeof steps)[0], value: string) => {
+    setSteps(prev => prev.map((s, i) => i === index ? { ...s, [field]: value } : s));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const hasEmpty = steps.some(step => !step.vulnerability || !step.trigger || !step.behavior);
+    if (hasEmpty) {
+      toast({ title: 'Preencha todos os campos obrigatórios.' , variant: 'destructive' });
+      return;
+    }
+    toast({ title: 'Análise em cadeia salva', description: `Passos: ${steps.length}` });
+  };
+
   return (
     <Card className="h-full flex flex-col">
       <CardHeader>
         <CardTitle className="font-headline flex items-center">
-          <Workflow className="mr-2 h-6 w-6 text-primary" /> {/* Changed icon here */}
+          <Workflow className="mr-2 h-6 w-6 text-primary" />
           Análise em Cadeia (DBT)
         </CardTitle>
-        <CardDescription>Ferramenta para Análise em Cadeia - Em Desenvolvimento (Aba ID: {tabId})</CardDescription>
+        <CardDescription>Aba ID: {tabId}</CardDescription>
       </CardHeader>
-      <CardContent className="flex-grow flex items-center justify-center">
-        <p className="text-muted-foreground">
-          Funcionalidade de Análise em Cadeia será implementada aqui.
-        </p>
+      <CardContent className="flex-grow overflow-auto">
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {steps.map((step, idx) => (
+            <div key={idx} className="border rounded p-4 space-y-4">
+              <Input
+                ref={el => (inputRefs.current[idx] = el)}
+                tabIndex={idx * 3 + 1}
+                autoFocus={idx === steps.length - 1 && steps.length > 1}
+                placeholder="Vulnerabilidade" required
+                value={step.vulnerability}
+                onChange={(e) => handleChange(idx, 'vulnerability', e.target.value)}
+              />
+              <Input
+                tabIndex={idx * 3 + 2}
+                placeholder="Gatilho" required
+                value={step.trigger}
+                onChange={(e) => handleChange(idx, 'trigger', e.target.value)}
+              />
+              <Textarea
+                tabIndex={idx * 3 + 3}
+                placeholder="Comportamento" required
+                value={step.behavior}
+                onChange={(e) => handleChange(idx, 'behavior', e.target.value)}
+              />
+            </div>
+          ))}
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" onClick={addStep}>
+              <Plus className="h-4 w-4 mr-1" /> Adicionar Passo
+            </Button>
+            <Button type="submit" className="bg-accent text-accent-foreground">
+              Salvar
+            </Button>
+          </div>
+        </form>
       </CardContent>
     </Card>
   );

--- a/src/components/clinical-tools/HexaflexTool.tsx
+++ b/src/components/clinical-tools/HexaflexTool.tsx
@@ -3,26 +3,42 @@
 
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
-import { Wand2 } from 'lucide-react'; // Using Wand2 as a placeholder icon
+import { Wand2 } from 'lucide-react';
 
 interface HexaflexToolProps {
   tabId: string;
 }
 
+const PROCESSES = [
+  'Defusão',
+  'Aceitação',
+  'Presença',
+  'Eu Contexto',
+  'Valores',
+  'Ação'
+];
+
 export default function HexaflexTool({ tabId }: HexaflexToolProps) {
   return (
-    <Card className="h-full flex flex-col">
+    <Card className="h-full flex flex-col" aria-label="Ferramenta Hexaflex">
       <CardHeader>
         <CardTitle className="font-headline flex items-center">
-          <Wand2 className="mr-2 h-6 w-6 text-primary" />
+          <Wand2 className="mr-2 h-6 w-6 text-primary" aria-hidden="true" />
           Hexaflex (ACT)
         </CardTitle>
-        <CardDescription>Ferramenta Hexaflex - Em Desenvolvimento (Aba ID: {tabId})</CardDescription>
+        <CardDescription>Aba ID: {tabId}</CardDescription>
       </CardHeader>
-      <CardContent className="flex-grow flex items-center justify-center">
-        <p className="text-muted-foreground">
-          Funcionalidade da ferramenta Hexaflex será implementada aqui.
-        </p>
+      <CardContent className="flex-grow grid grid-cols-2 sm:grid-cols-3 gap-4 place-items-center">
+        {PROCESSES.map((p) => (
+          <div
+            key={p}
+            className="w-20 h-20 rounded-full bg-muted flex items-center justify-center text-center text-sm p-2"
+            role="img"
+            aria-label={p}
+          >
+            {p}
+          </div>
+        ))}
       </CardContent>
     </Card>
   );

--- a/src/components/dashboard/dashboard-weekly-schedule.tsx
+++ b/src/components/dashboard/dashboard-weekly-schedule.tsx
@@ -9,6 +9,7 @@ import Link from "next/link";
 import AppointmentCalendar, { type AppointmentsByDate, getInitialMockAppointments } from "@/components/schedule/appointment-calendar";
 import { format, startOfWeek, addDays, subDays } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
+import { eachDayOfInterval } from 'date-fns';
 
 export default function DashboardWeeklySchedule() {
   const [currentDate, setCurrentDate] = useState<Date | null>(null);
@@ -60,6 +61,17 @@ export default function DashboardWeeklySchedule() {
     // dateFrom and dateTo are implicitly handled by the week view of AppointmentCalendar
   };
 
+  const sessionsThisWeek = React.useMemo(() => {
+    if (!currentDate) return [] as any[];
+    const start = startOfWeek(currentDate, { weekStartsOn: 1 });
+    const end = addDays(start, 6);
+    const days = eachDayOfInterval({ start, end });
+    return days.flatMap(d => {
+      const key = format(d, 'yyyy-MM-dd');
+      return appointmentsData[key] || [];
+    });
+  }, [currentDate, appointmentsData]);
+
   return (
     <Card className="shadow-sm">
       <CardHeader className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2">
@@ -81,14 +93,20 @@ export default function DashboardWeeklySchedule() {
           </Button>
         </div>
       </CardHeader>
-      <CardContent className="h-[500px] p-0 sm:p-1 md:p-2"> {/* Adjusted padding for denser view */}
-        <AppointmentCalendar
-          view="Week"
-          currentDate={currentDate}
-          filters={dashboardFilters} // Pass simplified or default filters
-          onAppointmentsUpdate={handleAppointmentsUpdate}
-        />
-      </CardContent>
+      {sessionsThisWeek.length ? (
+        <CardContent className="h-[500px] p-0 sm:p-1 md:p-2"> {/* Adjusted padding for denser view */}
+          <AppointmentCalendar
+            view="Week"
+            currentDate={currentDate}
+            filters={dashboardFilters}
+            onAppointmentsUpdate={handleAppointmentsUpdate}
+          />
+        </CardContent>
+      ) : (
+        <CardContent className="h-[200px] flex items-center justify-center">
+          <p>Sem sessões esta semana.</p>
+        </CardContent>
+      )}
     </Card>
   );
 }

--- a/src/components/dashboard/occupancy-chart.tsx
+++ b/src/components/dashboard/occupancy-chart.tsx
@@ -25,11 +25,20 @@ const chartConfig = {
   },
 } satisfies ChartConfig
 
-export function OccupancyChart() {
+export function OccupancyChart({ data = chartData }: { data?: typeof chartData }) {
+  if (!data || data.length === 0) {
+    return <p>Sem dados para exibir.</p>;
+  }
+
   return (
-    <ChartContainer config={chartConfig} className="min-h-[200px] w-full h-[300px]">
+    <ChartContainer
+      config={chartConfig}
+      className="min-h-[200px] w-full h-[300px]"
+      role="img"
+      aria-label="Gráfico de ocupação de salas"
+    >
       <ResponsiveContainer width="100%" height="100%">
-        <BarChart data={chartData} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+        <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
             <CartesianGrid strokeDasharray="3 3" vertical={false} />
           <XAxis
             dataKey="month"

--- a/src/components/dashboard/performance-chart.tsx
+++ b/src/components/dashboard/performance-chart.tsx
@@ -53,11 +53,17 @@ const chartConfig = {
   },
 } satisfies ChartConfig
 
-export function PerformanceChart() {
+export function PerformanceChart({ data = chartData }: { data?: typeof chartData }) {
+  if (!data || data.length === 0) {
+    return <p>Sem dados para exibir.</p>;
+  }
+
   return (
      <ChartContainer
         config={chartConfig}
         className="mx-auto aspect-square max-h-[300px]"
+        role="img"
+        aria-label="Distribuição de sessões por profissional"
       >
         <PieChart>
           <ChartTooltip
@@ -65,7 +71,7 @@ export function PerformanceChart() {
             content={<ChartTooltipContent hideLabel />}
           />
           <Pie
-            data={chartData}
+            data={data}
             dataKey="sessions"
             nameKey="psychologist"
             innerRadius={60}

--- a/src/components/dashboard/problem-distribution-chart.tsx
+++ b/src/components/dashboard/problem-distribution-chart.tsx
@@ -46,10 +46,14 @@ const chartConfig = {
   },
 } satisfies ChartConfig
 
-export function ProblemDistributionChart() {
+export function ProblemDistributionChart({ data = chartData }: { data?: typeof chartData }) {
+  if (!data || data.length === 0) {
+    return <p>Sem dados para exibir.</p>;
+  }
+
   const totalCases = React.useMemo(() => {
-    return chartData.reduce((acc, curr) => acc + curr.count, 0)
-  }, [])
+    return data.reduce((acc, curr) => acc + curr.count, 0)
+  }, [data])
 
   return (
     <ChartContainer
@@ -57,19 +61,19 @@ export function ProblemDistributionChart() {
       className="mx-auto aspect-square max-h-[300px]"
     >
       <ResponsiveContainer width="100%" height="100%">
-        <PieChart>
+        <PieChart role="img" aria-label="Distribuição de problemas por tipo">
           <ChartTooltip
             cursor={false}
             content={<ChartTooltipContent hideLabel />}
           />
           <Pie
-            data={chartData}
+            data={data}
             dataKey="count"
             nameKey="problem"
             innerRadius={60}
             strokeWidth={5}
           >
-            {chartData.map((entry, index) => (
+            {data.map((entry, index) => (
               <Cell key={`cell-${index}`} fill={entry.fill} />
             ))}
              <Label

--- a/src/components/dashboard/recent-activity-item.tsx
+++ b/src/components/dashboard/recent-activity-item.tsx
@@ -10,9 +10,12 @@ interface RecentActivityItemProps {
 
 function RecentActivityItemComponent({ icon, description, time }: RecentActivityItemProps) {
   return (
-    <div className="flex items-start space-x-3 p-3 hover:bg-secondary/30 rounded-md transition-colors">
-      <span className="flex-shrink-0 text-muted-foreground mt-1">{icon}</span>
-      <div className="flex-1">
+    <div
+      className="flex items-start space-x-3 p-3 hover:bg-secondary/30 rounded-md transition-colors"
+      aria-label={`${description} em ${time}`}
+    >
+      <span className="flex-shrink-0 text-muted-foreground mt-1" aria-hidden="true">{icon}</span>
+      <div className="flex-1 text-foreground">
         <p className="text-sm">{description}</p>
         <p className="text-xs text-muted-foreground">{time}</p>
       </div>

--- a/src/components/dashboard/sessions-trend-chart.tsx
+++ b/src/components/dashboard/sessions-trend-chart.tsx
@@ -20,12 +20,21 @@ const chartConfig = {
   },
 } satisfies ChartConfig;
 
-export function SessionsTrendChart() {
+export function SessionsTrendChart({ data = chartData }: { data?: typeof chartData }) {
+  if (!data || data.length === 0) {
+    return <p>Sem dados para exibir.</p>;
+  }
+
   return (
-    <ChartContainer config={chartConfig} className="min-h-[200px] w-full h-full">
+    <ChartContainer
+      config={chartConfig}
+      className="min-h-[200px] w-full h-full"
+      role="img"
+      aria-label="Tendência de sessões mensais"
+    >
       <ResponsiveContainer width="100%" height="100%">
         <LineChart
-          data={chartData}
+          data={data}
           margin={{
             top: 5,
             right: 10,

--- a/src/components/dashboard/stats-card.tsx
+++ b/src/components/dashboard/stats-card.tsx
@@ -35,9 +35,15 @@ function StatsCardComponent({ title, value, icon, trend, href }: StatsCardProps)
   );
 
   if (href) {
-    return <Link href={href} className="block">{cardContent}</Link>;
+    return (
+      <div role="region" aria-label={`${title}: ${value}`} className="block">
+        <Link href={href}>{cardContent}</Link>
+      </div>
+    );
   }
-  return cardContent;
+  return (
+    <div role="region" aria-label={`${title}: ${value}`}>{cardContent}</div>
+  );
 }
 
 const StatsCard = React.memo(StatsCardComponent);

--- a/src/components/forms/appointment-form.tsx
+++ b/src/components/forms/appointment-form.tsx
@@ -265,7 +265,7 @@ export default function AppointmentForm({ appointmentData }: AppointmentFormProp
   return (
     <Card className="shadow-lg">
       <Form {...form}>
-        <form role="form" onSubmit={form.handleSubmit(onSubmit)}>
+        <form role="form" aria-busy={isLoading} onSubmit={form.handleSubmit(onSubmit)}>
           <CardHeader>
             <CardTitle className="font-headline text-xl">
               {appointmentData?.id ? "Editar Agendamento" : (isBlockTime ? "Bloquear Horário na Agenda" : "Novo Agendamento")}
@@ -617,9 +617,13 @@ export default function AppointmentForm({ appointmentData }: AppointmentFormProp
             )}
           </CardContent>
           <CardFooter className="flex justify-end">
-            <Button type="submit" className="bg-accent hover:bg-accent/90 text-accent-foreground" disabled={isLoading}>
+            <Button
+              type="submit"
+              className="bg-accent hover:bg-accent/90 text-accent-foreground"
+              disabled={isLoading || !form.formState.isValid}
+            >
               <Save className="mr-2 h-4 w-4" />
-              {isLoading ? (appointmentData?.id ? "Salvando..." : (isBlockTime ? "Bloqueando..." : "Agendando...")) : 
+              {isLoading ? (appointmentData?.id ? "Salvando..." : (isBlockTime ? "Bloqueando..." : "Agendando...")) :
                 (appointmentData?.id ? "Salvar Alterações" : (isBlockTime ? "Criar Bloqueio" : "Criar Agendamento"))}
             </Button>
           </CardFooter>

--- a/src/components/schedule/appointment-calendar.tsx
+++ b/src/components/schedule/appointment-calendar.tsx
@@ -453,7 +453,7 @@ function AppointmentCalendarComponent({ view, currentDate, filters, workingDaysO
                     </div>
                 ))}
             </div>
-            <div className="flex-1 flex overflow-x-auto">
+            <div className="flex-1 flex overflow-x-auto" tabIndex={0}>
                 <div className={cn("flex min-w-max", view === "Week" && "md:min-w-full", "flex-grow")}>
                      {daysToRender.map((day, index) => (
                        <div key={`day-wrapper-${index}`} className={cn("flex-1", view === "Week" ? "min-w-[140px] sm:min-w-[160px] md:min-w-0" : "", "flex flex-col")}>


### PR DESCRIPTION
## Summary
- add functional ChainAnalysisBuilder form with validation
- enhance HexaflexTool accessibility
- show weekly schedule message when there are no sessions
- mark charts as role=img and handle empty data
- add aria labels and regions to dashboard elements
- prevent invalid appointment form submissions
- make schedule scroll keyboard accessible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68523d62138c832482825b7c98c22977