### PR TITLE
Add checks for single child in Slot-based components

### DIFF
--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -107,11 +107,22 @@ FormLabel.displayName = "FormLabel"
 const FormControl = React.forwardRef<
   React.ElementRef<typeof Slot>,
   React.ComponentPropsWithoutRef<typeof Slot>
->(({ ...props }, ref) => {
+>(({ children, ...props }, ref) => {
   const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
 
+  const hasSingleValidChild =
+    React.Children.count(children) === 1 && React.isValidElement(children)
+
+  if (!hasSingleValidChild) {
+    console.error(
+      "FormControl expects a single React element child. Rendering a <div> wrapper instead."
+    )
+  }
+
+  const Comp = hasSingleValidChild ? Slot : "div"
+
   return (
-    <Slot
+    <Comp
       ref={ref}
       id={formItemId}
       aria-describedby={
@@ -121,7 +132,9 @@ const FormControl = React.forwardRef<
       }
       aria-invalid={!!error}
       {...props}
-    />
+    >
+      {children}
+    </Comp>
   )
 })
 FormControl.displayName = "FormControl"

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -571,7 +571,16 @@ const SidebarMenuButton = React.forwardRef<HTMLButtonElement, SidebarMenuButtonP
       ...otherParentProps
     } = rawProps;
 
-    const Comp = ownAsChildProp ? Slot : "button";
+    const hasSingleValidChild =
+      React.Children.count(children) === 1 && React.isValidElement(children)
+
+    if (ownAsChildProp && !hasSingleValidChild) {
+      console.error(
+        "SidebarMenuButton with asChild expects a single React element child. Rendering a <button> instead."
+      )
+    }
+
+    const Comp = ownAsChildProp && hasSingleValidChild ? Slot : "button";
     
     const { asChild: asChildFromParent, ...finalDomProps } = otherParentProps;
 


### PR DESCRIPTION
## Summary
- safeguard `FormControl` and `SidebarMenuButton` against invalid children when using `asChild`
- avoid runtime `React.Children.only` errors by falling back to regular elements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852946b8e4883248d7eb190c20193bc