### PR TITLE
docs: add troubleshooting for Turbopack errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,14 @@ Para obter `FIREBASE_CLIENT_EMAIL` e `FIREBASE_PRIVATE_KEY`:
     ```
 
 Consulte [docs/blueprint.md](docs/blueprint.md) para uma visão geral das funcionalidades planejadas.
+
+## Solucao de Problemas
+
+Erros genéricos como **"An unexpected Turbopack error occurred"** costumam estar relacionados a configurações de ambiente ou dependências ausentes. Caso se depare com essa mensagem ao rodar `npm run dev`, verifique os pontos abaixo:
+
+1. Execute `npm install` para garantir que todas as dependências estejam instaladas.
+2. Confirme se está utilizando uma versão do **Node.js** compatível (18 ou superior).
+3. Copie `env.example` para `.env.local` e preencha as variáveis necessárias.
+4. Apague a pasta `.next` (cache do Next.js) e tente novamente: `rm -rf .next && npm run dev`.
+5. Observe o log completo gerado pelo `next dev` para identificar possíveis mensagens adicionais de erro.
+


### PR DESCRIPTION
## Summary
- document how to resolve common Turbopack errors when running `next dev`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852d30970008324b182b90be4482c29