### PR TITLE
Fix clipboard copy errors

### DIFF
--- a/src/components/patients/session-note-card.tsx
+++ b/src/components/patients/session-note-card.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import React, { useState, useCallback, useMemo } from 'react';
+import { copyToClipboard } from '@/utils/copyToClipboard';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Brain, FileText, Tag, Lightbulb, BarChart3, Edit, Trash2, AlertTriangleIcon, CheckCircle, ShieldAlert, FilePlus2 } from "lucide-react";
@@ -107,7 +108,7 @@ function SessionNoteCardComponent({ note, patientName, therapistName = "Psicólo
 
   const handleCopyReportDraft = useCallback(() => {
     if (reportDraft) {
-      navigator.clipboard.writeText(reportDraft);
+      copyToClipboard(reportDraft);
       toast({ title: "Rascunho Copiado", description: "O conteúdo do rascunho foi copiado para a área de transferência." });
     }
   }, [reportDraft, toast]);

--- a/src/components/ui/copy-button.tsx
+++ b/src/components/ui/copy-button.tsx
@@ -3,6 +3,7 @@
 import { Clipboard, Check } from "lucide-react";
 import React from "react";
 import { Button } from "@/components/ui/button";
+import { copyToClipboard } from "@/utils/copyToClipboard";
 
 interface CopyButtonProps {
   value: string;
@@ -14,9 +15,11 @@ export default function CopyButton({ value, className }: CopyButtonProps) {
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(value);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
+      const success = await copyToClipboard(value);
+      if (success) {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      }
     } catch (e) {
       console.error("Failed to copy", e);
     }

--- a/src/utils/copyToClipboard.ts
+++ b/src/utils/copyToClipboard.ts
@@ -1,0 +1,28 @@
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return true
+    } catch (err) {
+      console.warn('navigator.clipboard.writeText failed', err)
+    }
+  }
+
+  const textArea = document.createElement('textarea')
+  textArea.value = text
+  textArea.style.position = 'fixed'
+  textArea.style.left = '0'
+  textArea.style.top = '0'
+  textArea.style.opacity = '0'
+  document.body.appendChild(textArea)
+  textArea.focus()
+  textArea.select()
+  let success = false
+  try {
+    success = document.execCommand('copy')
+  } catch (err) {
+    console.error('Fallback copy failed', err)
+  }
+  document.body.removeChild(textArea)
+  return success
+}


### PR DESCRIPTION
## Summary
- add helper to copy text with fallback
- use clipboard helper in copy button and session note card

## Testing
- `npm test` *(fails: Jest não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_6852da1e71808324a2ddd6ac5092e6f1