### PR TITLE
Fix stray quote in MatrixCardForm

### DIFF
--- a/src/components/cards/Matrix/MatrixCardForm.tsx
+++ b/src/components/cards/Matrix/MatrixCardForm.tsx
@@ -31,7 +31,7 @@ const MatrixCardForm: React.FC = () => {
   };
 
   return (
-    <form className="space-y-4" onSubmit={handleSubmit}">
+    <form className="space-y-4" onSubmit={handleSubmit}>
       {matrix.map((row, rowIndex) => (
         <div key={rowIndex} className="flex gap-2">
           {row.map((value, colIndex) => (


### PR DESCRIPTION
## Summary
- fix closing form tag in `MatrixCardForm`

## Testing
- `npm install`
- `npm run typecheck` *(fails: cannot find module 'firebase-functions' and many other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6852ddf828008324b54d86f1ce8c4a04