### PR TITLE
Enable all Jest suites

### DIFF
--- a/__tests__/firestore-rules.test.ts
+++ b/__tests__/firestore-rules.test.ts
@@ -4,7 +4,7 @@ import fetch from 'node-fetch';
 
 let testEnv: Awaited<ReturnType<typeof initializeTestEnvironment>>;
 
-describe.skip('Firestore security rules', () => {
+describe('Firestore security rules', () => {
 
 beforeAll(async () => {
   const hostPort = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8083';

--- a/__tests__/patients.rules.test.ts
+++ b/__tests__/patients.rules.test.ts
@@ -28,7 +28,7 @@ function getAuthedDb(auth: { sub: string; role: string }): Firestore {
   return testEnv.authenticatedContext(auth.sub, auth).firestore();
 }
 
-describe.skip('Patient Rules Tests', () => {
+describe('Patient Rules Tests', () => {
 
   test('owner can read and write patient document', async () => {
     const auth = { uid: 'user1' };


### PR DESCRIPTION
## Summary
- ensure test suites run by removing `.skip`

## Testing
- `npm test` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6852de771d0083249af41b94dfc183ac