### PR TITLE
Fix Next config and temp button styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Plataforma web para gestão de clínicas de psicologia, com agenda integrada, pr
 ### Comandos úteis
 
 - `npm run dev` &mdash; inicia o servidor Next.js em modo desenvolvimento na porta `9003` (geralmente com Turbopack).
+- `npm run dev -- --no-turbo -p 9004` &mdash; executa o servidor usando Webpack ao invés do Turbopack, na porta `9004`, para facilitar a exibição de erros no terminal.
 - `npm run genkit:dev` &mdash; executa os fluxos de IA em modo de desenvolvimento.
 - `npm run typecheck` &mdash; verifica os tipos TypeScript.
 - `npm run lint` &mdash; executa o ESLint.

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,13 +3,6 @@ import type { NextConfig } from 'next';
 
 /** @type {import('next').NextConfig} */
 const nextConfig: NextConfig = {
-  experimental: {
-    serverActions: true,
-    allowedDevOrigins: [
-      'http://localhost:9004',
-      'https://9004-firebase-studio-1749490048431.cluster-duylic2g3fbzerqpzxxbw6helm.cloudworkstations.dev',
-    ],
-  },
   typescript: {
     ignoreBuildErrors: true,
   },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 
 "use client";
 
-import { Button, buttonVariants } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Brain, ShieldCheck, Users } from "lucide-react";
 import Link from "next/link";
@@ -17,7 +16,7 @@ export default function LandingPage() {
             <h1 className="text-3xl font-headline font-bold text-primary">Thalamus</h1>
           </div>
           <nav>
-            <Link className={buttonVariants({ className: 'ml-2' })} href={APP_ROUTES.dashboard}>Acessar Painel</Link>
+            <Link className="ml-2 px-4 py-2 bg-primary text-white rounded" href={APP_ROUTES.dashboard}>Acessar Painel</Link>
           </nav>
         </div>
       </header>
@@ -29,7 +28,7 @@ export default function LandingPage() {
         <p className="text-xl text-muted-foreground max-w-2xl mb-10">
           Thalamus oferece uma plataforma segura, intuitiva e aprimorada por IA para gerenciar seu consultório de psicologia, para que você possa focar no que mais importa: seus pacientes.
         </p>
-        <Link className={buttonVariants({ size: 'lg', className: 'bg-accent hover:bg-accent/90 text-accent-foreground' })} href={APP_ROUTES.dashboard}>Comece Agora</Link>
+        <Link className="ml-2 px-4 py-2 bg-primary text-white rounded" href={APP_ROUTES.dashboard}>Comece Agora</Link>
       </main>
 
       <section className="py-16 bg-card">


### PR DESCRIPTION
## Summary
- clean up Next.js config
- temporarily replace `buttonVariants` on the landing page with plain Tailwind classes
- document how to run the dev server without Turbopack

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm run typecheck` *(fails: several type errors)*
- `npm test` *(fails: firestore tests require emulators)*

------
https://chatgpt.com/codex/tasks/task_e_6852e377fb0083249bbce22d07684861