### PR TITLE
Add script to help recover from Turbopack issues

### DIFF
--- a/scripts/recover.sh
+++ b/scripts/recover.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script attempts to fix Turbopack/PostCSS issues
+# by clearing dependencies and reinstalling.
+# It also demonstrates how to run Next.js using Webpack.
+
+# Step 1: clean install artifacts
+rm -rf node_modules package-lock.json .next
+
+# Step 2: reinstall dependencies
+npm install
+
+# Step 3: run Next.js with Webpack for verification
+npx next dev -p 3000 &
+PID=$!
+# Give the server time to start
+sleep 10
+curl -I http://localhost:3000 || true
+kill $PID
+
+echo "If the server runs without errors, update package.json to remove --turbopack."
+


### PR DESCRIPTION
## Summary
- add a helper script that cleans dependencies, reinstalls, and runs the dev server with Webpack to aid in debugging Turbopack CSS issues

## Testing
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:8083)*

------
https://chatgpt.com/codex/tasks/task_e_6852f4bd07f88324bb671d92aaf9684d