### PR TITLE
Fix missing key warnings

### DIFF
--- a/src/components/dashboard/problem-distribution-chart.tsx
+++ b/src/components/dashboard/problem-distribution-chart.tsx
@@ -73,8 +73,8 @@ export function ProblemDistributionChart({ data = chartData }: { data?: typeof c
             innerRadius={60}
             strokeWidth={5}
           >
-            {data.map((entry, index) => (
-              <Cell key={`cell-${index}`} fill={entry.fill} />
+            {data.map((entry) => (
+              <Cell key={entry.problem} fill={entry.fill} />
             ))}
              <Label
               content={({ viewBox }) => {

--- a/src/components/layout/sidebar-nav.tsx
+++ b/src/components/layout/sidebar-nav.tsx
@@ -125,7 +125,7 @@ export default function SidebarNav({ currentPath, userRole = "Admin" }: SidebarN
 
       if (item.href && item.href !== "#" && visibleSubItems.length > 0) {
          return (
-            <SidebarMenuItem key={`${item.label}-${index}-group`}>
+            <SidebarMenuItem key={item.href || item.label}>
               <ButtonComponent
                 asChild
                 isActive={
@@ -153,7 +153,7 @@ export default function SidebarNav({ currentPath, userRole = "Admin" }: SidebarN
       }
        if (visibleSubItems.length > 0) {
         return (
-            <SidebarMenuItem key={`${item.label}-${index}-group`}>
+            <SidebarMenuItem key={item.href || item.label}>
                  <ButtonComponent
                     isActive={isActive}
                     tooltip={(state as string) === "collapsed" ? item.label : undefined}
@@ -172,7 +172,7 @@ export default function SidebarNav({ currentPath, userRole = "Admin" }: SidebarN
 
     if (!item.href || item.href === "#") {
          return (
-            <SidebarMenuItem key={`${item.label}-${index}`}>
+            <SidebarMenuItem key={item.href || item.label}>
                 <ButtonComponent
                     isActive={isActive}
                     tooltip={state === "collapsed" ? item.label : undefined}
@@ -187,7 +187,7 @@ export default function SidebarNav({ currentPath, userRole = "Admin" }: SidebarN
     }
 
     return (
-      <SidebarMenuItem key={`${item.label}-${index}`}>
+      <SidebarMenuItem key={item.href || item.label}>
         <ButtonComponent
           asChild
           isActive={isActive}

--- a/src/components/schedule/appointment-calendar.tsx
+++ b/src/components/schedule/appointment-calendar.tsx
@@ -372,8 +372,8 @@ function AppointmentCalendarComponent({ view, currentDate, filters, workingDaysO
         
         { (view === "Week" || view === "Day") && isWorkingDay && (
             <div className="flex-grow relative">
-                {timeSlots.map((timeSlot, tsIndex) => (
-                    <div key={tsIndex} className={cn(ROW_HEIGHT_CLASS, "border-b relative p-1 flex flex-col gap-0.5 overflow-hidden")}>
+                {timeSlots.map((timeSlot) => (
+                    <div key={timeSlot} className={cn(ROW_HEIGHT_CLASS, "border-b relative p-1 flex flex-col gap-0.5 overflow-hidden")}> 
                         {dayAppointments
                             .filter(appt => appt.startTime.startsWith(timeSlot.substring(0,2))) 
                             .map(appt => renderAppointmentPopover(appt, dayDate))
@@ -456,7 +456,7 @@ function AppointmentCalendarComponent({ view, currentDate, filters, workingDaysO
             <div className="flex-1 flex overflow-x-auto" tabIndex={0}>
                 <div className={cn("flex min-w-max", view === "Week" && "md:min-w-full", "flex-grow")}>
                      {daysToRender.map((day, index) => (
-                       <div key={`day-wrapper-${index}`} className={cn("flex-1", view === "Week" ? "min-w-[140px] sm:min-w-[160px] md:min-w-0" : "", "flex flex-col")}>
+                       <div key={day.toISOString()} className={cn("flex-1", view === "Week" ? "min-w-[140px] sm:min-w-[160px] md:min-w-0" : "", "flex flex-col")}> 
                            {renderDayTimelineCell(day, true, `${view.toLowerCase()}-${index}`)}
                        </div>
                     ))}


### PR DESCRIPTION
## Summary
- use entry problem as key in chart cells
- use more stable keys in AppointmentCalendar lists
- simplify SidebarNav keys

## Testing
- `npm run lint` *(fails: FormDescription and others unused)*
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:8083)*

------
https://chatgpt.com/codex/tasks/task_e_68533deb00a08324ab0a6d11af2c5767