### PR TITLE
Fix `asChild` Link usage

### DIFF
--- a/src/app/(app)/assessments/page.tsx
+++ b/src/app/(app)/assessments/page.tsx
@@ -24,12 +24,16 @@ export default function AssessmentsPage() {
         <div className="flex gap-2">
           <Button variant="outline" asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
             <Link href="/assessments/templates/new">
-              <PlusCircle className="mr-2 h-4 w-4" /> Criar Novo Modelo
+              <span>
+                <PlusCircle className="mr-2 h-4 w-4" /> Criar Novo Modelo
+              </span>
             </Link>
           </Button>
           <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
             <Link href="/assessments/assign">
-              <ClipboardList className="mr-2 h-4 w-4" /> Atribuir Avaliação
+              <span>
+                <ClipboardList className="mr-2 h-4 w-4" /> Atribuir Avaliação
+              </span>
             </Link>
           </Button>
         </div>

--- a/src/app/(app)/groups/[id]/page.tsx
+++ b/src/app/(app)/groups/[id]/page.tsx
@@ -178,7 +178,9 @@ export default function GroupDetailPage({ params }: { params: { id: string } }) 
         <div className="flex gap-2">
             <Button variant="outline" asChild>
                 <Link href={`/groups/edit/${currentGroup.id}`}>
-                    <Edit className="mr-2 h-4 w-4"/> Editar Grupo
+                    <span>
+                        <Edit className="mr-2 h-4 w-4"/> Editar Grupo
+                    </span>
                 </Link>
             </Button>
              <AlertDialog>
@@ -253,7 +255,9 @@ export default function GroupDetailPage({ params }: { params: { id: string } }) 
         <CardFooter>
             <Button variant="outline" asChild>
                 <Link href={`/groups/edit/${currentGroup.id}?tab=participants`}>
-                    <Settings className="mr-2 h-4 w-4"/> Gerenciar Participantes
+                    <span>
+                        <Settings className="mr-2 h-4 w-4"/> Gerenciar Participantes
+                    </span>
                 </Link>
             </Button>
         </CardFooter>
@@ -273,7 +277,9 @@ export default function GroupDetailPage({ params }: { params: { id: string } }) 
          <CardFooter>
             <Button variant="outline" asChild>
                 <Link href={`/groups/edit/${currentGroup.id}?tab=details`}>
-                    <Edit className="mr-2 h-4 w-4"/> Editar Descrição
+                    <span>
+                        <Edit className="mr-2 h-4 w-4"/> Editar Descrição
+                    </span>
                 </Link>
             </Button>
         </CardFooter>
@@ -294,7 +300,9 @@ export default function GroupDetailPage({ params }: { params: { id: string } }) 
          <CardFooter>
             <Button variant="outline" asChild>
                 <Link href={`/groups/edit/${currentGroup.id}?tab=agenda`}>
-                    <Edit className="mr-2 h-4 w-4"/> Editar Roteiro
+                    <span>
+                        <Edit className="mr-2 h-4 w-4"/> Editar Roteiro
+                    </span>
                 </Link>
             </Button>
         </CardFooter>
@@ -368,7 +376,9 @@ export default function GroupDetailPage({ params }: { params: { id: string } }) 
                     {resource.type === "link" && resource.url ? (
                          <Button variant="outline" size="sm" asChild>
                             <a href={resource.url} target="_blank" rel="noopener noreferrer">
-                                <LinkIcon className="mr-1.5 h-3.5 w-3.5" /> Acessar Link
+                                <span>
+                                  <LinkIcon className="mr-1.5 h-3.5 w-3.5" /> Acessar Link
+                                </span>
                             </a>
                         </Button>
                     ) : (

--- a/src/app/(app)/groups/page.tsx
+++ b/src/app/(app)/groups/page.tsx
@@ -86,7 +86,9 @@ export default function TherapeuticGroupsPage() {
         </div>
         <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
           <Link href="/groups/new">
-            <PlusCircle className="mr-2 h-4 w-4" /> Criar Novo Grupo
+            <span>
+              <PlusCircle className="mr-2 h-4 w-4" /> Criar Novo Grupo
+            </span>
           </Link>
         </Button>
       </div>
@@ -144,12 +146,16 @@ export default function TherapeuticGroupsPage() {
                           <DropdownMenuContent align="end">
                             <DropdownMenuItem asChild>
                               <Link href={`/schedule/new?groupId=${group.id}&type=group`}>
-                                <CalendarPlus className="mr-2 h-4 w-4" /> Agendar Sessão Avulsa
+                                <span>
+                                  <CalendarPlus className="mr-2 h-4 w-4" /> Agendar Sessão Avulsa
+                                </span>
                               </Link>
                             </DropdownMenuItem>
                             <DropdownMenuItem asChild>
                               <Link href={`/groups/edit/${group.id}`}>
-                                <Edit className="mr-2 h-4 w-4" /> Editar Grupo
+                                <span>
+                                  <Edit className="mr-2 h-4 w-4" /> Editar Grupo
+                                </span>
                               </Link>
                             </DropdownMenuItem>
                             <DropdownMenuItem className="text-destructive focus:text-destructive focus:bg-destructive/10">
@@ -170,7 +176,9 @@ export default function TherapeuticGroupsPage() {
               <p className="mt-1 text-sm text-muted-foreground">Comece criando um novo grupo.</p>
                <Button asChild className="mt-4 bg-accent hover:bg-accent/90 text-accent-foreground">
                   <Link href="/groups/new">
-                    <PlusCircle className="mr-2 h-4 w-4" /> Criar Novo Grupo
+                    <span>
+                      <PlusCircle className="mr-2 h-4 w-4" /> Criar Novo Grupo
+                    </span>
                   </Link>
                 </Button>
             </div>

--- a/src/app/(app)/inventories-scales/page.tsx
+++ b/src/app/(app)/inventories-scales/page.tsx
@@ -25,12 +25,16 @@ export default function InventoriesScalesPage() {
         <div className="flex gap-2">
           <Button variant="outline" asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
             <Link href="/inventories-scales/templates/new">
-              <PlusCircle className="mr-2 h-4 w-4" /> Criar Novo Modelo
+              <span>
+                <PlusCircle className="mr-2 h-4 w-4" /> Criar Novo Modelo
+              </span>
             </Link>
           </Button>
           <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
             <Link href="/inventories-scales/assign">
-              <ClipboardList className="mr-2 h-4 w-4" /> Atribuir Inventário/Escala
+              <span>
+                <ClipboardList className="mr-2 h-4 w-4" /> Atribuir Inventário/Escala
+              </span>
             </Link>
           </Button>
         </div>

--- a/src/app/(app)/patients/[id]/page.tsx
+++ b/src/app/(app)/patients/[id]/page.tsx
@@ -16,7 +16,9 @@ export default function PatientDetailPagePlaceholder() {
       </p>
       <Button variant="outline" asChild>
         <Link href="/patients">
-          <ArrowLeft className="mr-2 h-4 w-4" /> Voltar para Pacientes
+          <span>
+            <ArrowLeft className="mr-2 h-4 w-4" /> Voltar para Pacientes
+          </span>
         </Link>
       </Button>
     </div>

--- a/src/app/(app)/patients/page.tsx
+++ b/src/app/(app)/patients/page.tsx
@@ -41,7 +41,9 @@ export default function PatientsPage() {
         </div>
         <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
           <Link href="/patients/new">
-            <UserPlus className="mr-2 h-4 w-4" /> Adicionar Novo Paciente
+            <span>
+              <UserPlus className="mr-2 h-4 w-4" /> Adicionar Novo Paciente
+            </span>
           </Link>
         </Button>
       </div>
@@ -81,7 +83,9 @@ export default function PatientsPage() {
               action={
                 <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
                   <Link href={APP_ROUTES.newPatient}>
-                    <UserPlus className="mr-2 h-4 w-4" /> Adicionar Novo Paciente
+                    <span>
+                      <UserPlus className="mr-2 h-4 w-4" /> Adicionar Novo Paciente
+                    </span>
                   </Link>
                 </Button>
               }

--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -161,17 +161,23 @@ export default function ProfilePage() {
         <CardFooter className="flex flex-col sm:flex-row justify-center gap-3 p-6 border-t">
           <Button variant="default" asChild className="w-full sm:w-auto bg-accent hover:bg-accent/90 text-accent-foreground">
             <Link href="/settings?tab=account">
-              <Edit className="mr-2 h-4 w-4" /> Editar Perfil
+              <span>
+                <Edit className="mr-2 h-4 w-4" /> Editar Perfil
+              </span>
             </Link>
           </Button>
           <Button variant="outline" asChild className="w-full sm:w-auto">
             <Link href="/settings?tab=account"> {/* Placeholder: eventually /profile/change-password */}
-              <Lock className="mr-2 h-4 w-4" /> Alterar Senha
+              <span>
+                <Lock className="mr-2 h-4 w-4" /> Alterar Senha
+              </span>
             </Link>
           </Button>
            <Button variant="outline" asChild className="w-full sm:w-auto">
             <Link href="/settings?tab=notifications">
-              <Bell className="mr-2 h-4 w-4" /> Preferências de Notificação
+              <span>
+                <Bell className="mr-2 h-4 w-4" /> Preferências de Notificação
+              </span>
             </Link>
           </Button>
         </CardFooter>

--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -212,7 +212,9 @@ export default function SchedulePage() {
         </div>
         <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
           <Link href="/schedule/new">
-            <PlusCircle className="mr-2 h-4 w-4" /> Novo Agendamento
+            <span>
+              <PlusCircle className="mr-2 h-4 w-4" /> Novo Agendamento
+            </span>
           </Link>
         </Button>
       </div>
@@ -288,8 +290,10 @@ export default function SchedulePage() {
                 </DropdownMenuContent>
                 </DropdownMenu>
                  <Button variant="outline" size="sm" asChild className="w-full sm:w-auto">
-                    <Link href={`/schedule/new?isBlockTime=true&date=${format(currentDate, 'yyyy-MM-dd')}`}>
-                        <ShieldAlert className="mr-1.5 h-3.5 w-3.5" /> Bloquear Horário
+                    <Link href={`/schedule/new?isBlockTime=true&date=${format(currentDate, 'yyyy-MM-dd')}` }>
+                        <span>
+                          <ShieldAlert className="mr-1.5 h-3.5 w-3.5" /> Bloquear Horário
+                        </span>
                     </Link>
                  </Button>
             </div>

--- a/src/app/(app)/schedule/today/page.tsx
+++ b/src/app/(app)/schedule/today/page.tsx
@@ -243,7 +243,9 @@ export default function TodaySchedulePage() {
         </div>
         <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
           <Link href="/schedule/new">
-            <PlusCircle className="mr-2 h-4 w-4" /> Novo Agendamento
+            <span>
+              <PlusCircle className="mr-2 h-4 w-4" /> Novo Agendamento
+            </span>
           </Link>
         </Button>
       </div>

--- a/src/app/(app)/tasks/page.tsx
+++ b/src/app/(app)/tasks/page.tsx
@@ -38,7 +38,9 @@ export default function TasksPage() {
         </div>
         <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
           <Link href="/tasks/new">
-            <PlusCircle className="mr-2 h-4 w-4" /> Nova Tarefa
+            <span>
+              <PlusCircle className="mr-2 h-4 w-4" /> Nova Tarefa
+            </span>
           </Link>
         </Button>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -68,8 +68,10 @@ export default function LandingPage() {
             <div className="flex flex-col sm:flex-row gap-4">
               <Button size="lg" asChild className="bg-accent hover:bg-accent/90 text-accent-foreground text-lg px-8 py-6">
                 <Link href="/signup">
-                  Comece Agora (Grátis por 14 dias)
-                  <ArrowRight className="ml-2 h-5 w-5" />
+                  <span>
+                    Comece Agora (Grátis por 14 dias)
+                    <ArrowRight className="ml-2 h-5 w-5" />
+                  </span>
                 </Link>
               </Button>
               {/* <Button size="lg" variant="outline" className="text-lg px-8 py-6">
@@ -133,8 +135,10 @@ export default function LandingPage() {
             </p>
             <Button size="lg" asChild className="bg-accent hover:bg-accent/90 text-accent-foreground text-lg px-8 py-6">
               <Link href="/signup">
-                Experimente o Thalamus Gratuitamente
-                <ArrowRight className="ml-2 h-5 w-5" />
+                <span>
+                  Experimente o Thalamus Gratuitamente
+                  <ArrowRight className="ml-2 h-5 w-5" />
+                </span>
               </Link>
             </Button>
           </div>

--- a/src/components/assessments/assessment-card.tsx
+++ b/src/components/assessments/assessment-card.tsx
@@ -89,7 +89,9 @@ function AssessmentCardComponent({ assessment, showPatientInfo = false }: Assess
           {assessment.status === "Completed" && (
             <Button variant="outline" size="sm" asChild>
               <Link href={`/inventories-scales/${assessment.id}/results`}>
-                <BarChart2 className="mr-2 h-4 w-4" /> Ver Resultados
+                <span>
+                  <BarChart2 className="mr-2 h-4 w-4" /> Ver Resultados
+                </span>
               </Link>
             </Button>
           )}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -64,14 +64,18 @@ export default function AppHeader() {
             <DropdownMenuSeparator />
             <DropdownMenuItem asChild>
               <Link href="/profile">
-                <UserCircle className="mr-2 h-4 w-4" />
-                <span>Perfil</span>
+                <span>
+                  <UserCircle className="mr-2 h-4 w-4" />
+                  <span>Perfil</span>
+                </span>
               </Link>
             </DropdownMenuItem>
             <DropdownMenuItem asChild>
               <Link href="/settings">
-                <Settings className="mr-2 h-4 w-4" />
-                <span>Configurações</span>
+                <span>
+                  <Settings className="mr-2 h-4 w-4" />
+                  <span>Configurações</span>
+                </span>
               </Link>
             </DropdownMenuItem>
             <DropdownMenuSeparator />

--- a/src/components/patients/patient-list-item.tsx
+++ b/src/components/patients/patient-list-item.tsx
@@ -88,9 +88,11 @@ function PatientListItemComponent({ patient }: PatientListItemProps) {
           <div className="flex items-center gap-1 sm:gap-2">
             <Button variant="outline" size="sm" asChild className="h-8 px-2 sm:px-3" aria-label={`Editar perfil de ${patient.name}`}>
               <Link href={`/patients/${patient.id}/edit`}>
-                <Edit3 className="h-3.5 w-3.5 sm:mr-1" />
-                <span className="hidden sm:inline">Editar</span>
-                <span className="sr-only sm:hidden">Editar perfil de {patient.name}</span>
+                <span>
+                  <Edit3 className="h-3.5 w-3.5 sm:mr-1" />
+                  <span className="hidden sm:inline">Editar</span>
+                  <span className="sr-only sm:hidden">Editar perfil de {patient.name}</span>
+                </span>
               </Link>
             </Button>
             <AlertDialog>
@@ -126,7 +128,9 @@ function PatientListItemComponent({ patient }: PatientListItemProps) {
               aria-label={`Ver detalhes de ${patient.name}`}
             >
               <Link href={`/patients/${patient.id}`} className="flex items-center gap-2">
-                <ChevronRight className="h-5 w-5" /> Abrir
+                <span>
+                  <ChevronRight className="h-5 w-5" /> Abrir
+                </span>
               </Link>
             </Button>
           </div>

--- a/src/components/schedule/appointment-calendar.tsx
+++ b/src/components/schedule/appointment-calendar.tsx
@@ -275,21 +275,27 @@ function AppointmentCalendarComponent({ view, currentDate, filters, workingDaysO
               {appt.isGroupSession && appt.groupId && (
                   <Button size="sm" variant="outline" asChild className="w-full">
                       <Link href={`/groups/${appt.groupId}`}>
-                          <UsersIcon className="mr-1.5 h-3.5 w-3.5"/> Ver Detalhes do Grupo
+                          <span>
+                            <UsersIcon className="mr-1.5 h-3.5 w-3.5"/> Ver Detalhes do Grupo
+                          </span>
                       </Link>
                   </Button>
               )}
               {!appt.isGroupSession && appt.patientId && (
                   <Button size="sm" variant="outline" asChild className="w-full">
-                      <Link href={`/patients/${appt.patientId}?tab=notes&date=${format(dayDate, "yyyy-MM-dd")}`}>
-                          <FileText className="mr-1.5 h-3.5 w-3.5"/> Iniciar Anotação
+                      <Link href={`/patients/${appt.patientId}?tab=notes&date=${format(dayDate, "yyyy-MM-dd")}` }>
+                          <span>
+                            <FileText className="mr-1.5 h-3.5 w-3.5"/> Iniciar Anotação
+                          </span>
                       </Link>
                   </Button>
               )}
               <div className="flex gap-2 w-full">
                   <Button size="sm" variant="outline" asChild className="flex-1">
-                    <Link href={appt.isGroupSession ? `/groups/edit/${appt.groupId}` : `/schedule/edit/${appt.id}`}>
-                      <Edit className="mr-1.5 h-3.5 w-3.5"/> {appt.isGroupSession ? "Gerenciar Grupo" : "Editar"}
+                    <Link href={appt.isGroupSession ? `/groups/edit/${appt.groupId}` : `/schedule/edit/${appt.id}` }>
+                      <span>
+                        <Edit className="mr-1.5 h-3.5 w-3.5"/> {appt.isGroupSession ? "Gerenciar Grupo" : "Editar"}
+                      </span>
                     </Link>
                   </Button>
                   {!appt.isGroupSession && (
@@ -379,7 +385,9 @@ function AppointmentCalendarComponent({ view, currentDate, filters, workingDaysO
                             .map(appt => renderAppointmentPopover(appt, dayDate))
                         }
                         <Button variant="ghost" size="icon" className="absolute bottom-0 right-0 h-6 w-6 opacity-0 hover:opacity-100 focus:opacity-100 transition-opacity" asChild>
-                           <Link href={`/schedule/new?date=${format(dayDate, "yyyy-MM-dd")}&time=${timeSlot}`}><PlusCircle className="h-4 w-4" /><span className="sr-only">Adicionar</span></Link>
+                           <Link href={`/schedule/new?date=${format(dayDate, "yyyy-MM-dd")}&time=${timeSlot}`}>
+                             <span><PlusCircle className="h-4 w-4" /><span className="sr-only">Adicionar</span></span>
+                           </Link>
                         </Button>
                     </div>
                 ))}
@@ -389,7 +397,9 @@ function AppointmentCalendarComponent({ view, currentDate, filters, workingDaysO
             <div className="mt-1 space-y-1 text-xs overflow-y-auto flex-grow p-1">
                 {dayAppointments.map(appt => renderAppointmentPopover(appt, dayDate))}
                  <Button variant="ghost" size="icon" className="absolute bottom-1 right-1 h-7 w-7 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity" asChild>
-                  <Link href={`/schedule/new?date=${format(dayDate, "yyyy-MM-dd")}`}><PlusCircle className="h-5 w-5" /><span className="sr-only">Adicionar</span></Link>
+                  <Link href={`/schedule/new?date=${format(dayDate, "yyyy-MM-dd")}`}>
+                    <span><PlusCircle className="h-5 w-5" /><span className="sr-only">Adicionar</span></span>
+                  </Link>
                 </Button>
             </div>
         )}

--- a/src/components/tasks/task-item.tsx
+++ b/src/components/tasks/task-item.tsx
@@ -117,7 +117,9 @@ function TaskItemComponent({ task }: TaskItemProps) {
           {task.patientId && (
             <Button variant="link" size="sm" className="p-0 h-auto text-accent text-xs" asChild>
               <Link href={`/patients/${task.patientId}`}>
-                <LinkIcon className="mr-1 h-3.5 w-3.5" /> Ver Paciente Relacionado
+                <span>
+                  <LinkIcon className="mr-1 h-3.5 w-3.5" /> Ver Paciente Relacionado
+                </span>
               </Link>
             </Button>
           )}
@@ -127,7 +129,9 @@ function TaskItemComponent({ task }: TaskItemProps) {
       <CardFooter className="p-3 border-t flex justify-end gap-1.5">
           <Button variant="outline" size="sm" asChild>
             <Link href={`/tasks/edit/${task.id}`}>
-              <Edit className="mr-1.5 h-3.5 w-3.5" /> Editar
+              <span>
+                <Edit className="mr-1.5 h-3.5 w-3.5" /> Editar
+              </span>
             </Link>
           </Button>
           <AlertDialog>


### PR DESCRIPTION
## Summary
- ensure children of `asChild` components are a single element
- wrap icon and text pairs in `<span>` when used with `<Link>`

## Testing
- `npm run lint` *(fails: `next lint` missing modules or lint errors)*
- `npm test` *(fails: connect ECONNREFUSED to 127.0.0.1:8083)*

------
https://chatgpt.com/codex/tasks/task_e_68534f0a91e083249713ef6c9409ca9d