### PR TITLE
Add troubleshooting note for React.Children.only error

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,4 +132,5 @@ Erros genéricos como **"An unexpected Turbopack error occurred"** costumam esta
 3. Copie `env.example` para `.env.local` e preencha as variáveis necessárias.
 4. Apague a pasta `.next` (cache do Next.js) e tente novamente: `rm -rf .next && npm run dev`.
 5. Observe o log completo gerado pelo `next dev` para identificar possíveis mensagens adicionais de erro.
+6. Se encontrar a mensagem **"React.Children.only expected to receive a single React element child"**, verifique se componentes como `Button`, `FormControl` ou `SidebarMenuButton` (quando usados com `asChild`) recebem **apenas um** elemento React filho. Envolva múltiplos elementos em uma tag `<div>` ou `<span>` caso necessário.
 


### PR DESCRIPTION
## Summary
- document how to fix the `React.Children.only expected to receive a single React element child` error

## Testing
- `npm test` *(fails: Jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853551cab048324b3c4f67393af56ee