### PR TITLE
fix: make root layout server component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import './globals.css'; // Manter esta importação
 
 // Removido: Toaster, usePageView, headLinks e lógica relacionada.


### PR DESCRIPTION
## Summary
- remove `"use client"` directive from root layout

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find modules)*
- `npm test` *(fails: Jest não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68535ae73c58832494ff7fa2b457164b