### PR TITLE
Fix key usage in assessment page

### DIFF
--- a/src/app/my-assessments/[id]/page.tsx
+++ b/src/app/my-assessments/[id]/page.tsx
@@ -38,7 +38,7 @@ export default function AssessmentResponsePage({ params }: { params: { id: strin
       </CardHeader>
       <CardContent className="space-y-4">
         {questions.map((q, idx) => (
-          <div key={q} className="space-y-2">
+          <div key={idx} className="space-y-2">
             <p className="font-medium">{q}</p>
             <Textarea
               value={answers[idx] || ''}


### PR DESCRIPTION
## Summary
- fix React list key for questions in `/src/app/my-assessments/[id]/page.tsx`

## Testing
- `npm test` *(fails: Jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68535af1d77c8324b6151f7a309d048f