### PR TITLE
Fix GlobalError button asChild markup

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -21,9 +21,7 @@ export default function GlobalError({
       <p className="text-muted-foreground">Ocorreu um erro inesperado. Tente novamente mais tarde.</p>
       <div className="flex gap-2">
         <Button onClick={() => reset()}>Tentar novamente</Button>
-        <Button asChild variant="ghost">
-          <Link href="/">Voltar para o início</Link>
-        </Button>
+        <Button asChild variant="ghost"><Link href="/">Voltar para o início</Link></Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- fix `<Button asChild>` markup in `GlobalError`

## Testing
- `npm test` *(fails: Jest não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68535c40b1448324ad2e77eac466b348