### PR TITLE
Switch Not Found button to navigation link

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,16 +1,14 @@
 "use client";
 
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { useRouter } from "next/navigation";
+import { buttonVariants } from "@/components/ui/button";
 
 export default function NotFoundPage() {
-  const router = useRouter();
   return (
     <div className="flex flex-col items-center justify-center min-h-screen text-center p-4 space-y-4">
       <h1 className="text-4xl font-headline font-bold">404 - Página Não Encontrada</h1>
       <p className="text-muted-foreground">Não conseguimos encontrar a página que você procurava.</p>
-      <Button onClick={() => router.push("/")}>Voltar para a página inicial</Button>
+      <Link href="/" className={buttonVariants()}>Voltar para a página inicial</Link>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace button navigation with link in `not-found` page

## Testing
- `npm test` *(fails: Jest não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_685360915f348324a9c794679ea487ee