### PR TITLE
Fix Next.js Link children

### DIFF
--- a/src/app/403/page.tsx
+++ b/src/app/403/page.tsx
@@ -7,7 +7,9 @@ export default function ForbiddenPage() {
       <h1 className="text-4xl font-headline font-bold">403 - Acesso Negado</h1>
       <p className="text-muted-foreground">Você não tem permissão para acessar esta página.</p>
       <Button asChild>
-        <Link href="/login">Ir para Login</Link>
+        <Link href="/login">
+          <span>Ir para Login</span>
+        </Link>
       </Button>
     </div>
   );

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -8,7 +8,9 @@ export default function NotFoundPage() {
     <div className="flex flex-col items-center justify-center min-h-screen text-center p-4 space-y-4">
       <h1 className="text-4xl font-headline font-bold">404 - Página Não Encontrada</h1>
       <p className="text-muted-foreground">Não conseguimos encontrar a página que você procurava.</p>
-      <Link href="/" className={buttonVariants()}>Voltar para a página inicial</Link>
+      <Link href="/" className={buttonVariants()}>
+        <span>Voltar para a página inicial</span>
+      </Link>
     </div>
   );
 }

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -22,7 +22,9 @@ export default function PrivacyPolicyPage() {
         </p>
       </div>
       <Button asChild className="bg-accent text-accent-foreground hover:bg-accent/90">
-        <Link href="/">Voltar para a Página Inicial</Link>
+        <Link href="/">
+          <span>Voltar para a Página Inicial</span>
+        </Link>
       </Button>
     </div>
   );

--- a/src/app/terms-of-service/page.tsx
+++ b/src/app/terms-of-service/page.tsx
@@ -22,7 +22,9 @@ export default function TermsOfServicePage() {
         </p>
       </div>
       <Button asChild className="bg-accent text-accent-foreground hover:bg-accent/90">
-        <Link href="/">Voltar para a Página Inicial</Link>
+        <Link href="/">
+          <span>Voltar para a Página Inicial</span>
+        </Link>
       </Button>
     </div>
   );


### PR DESCRIPTION
## Summary
- wrap `<Link>` text children in `<span>` to avoid React.Children.only errors

## Testing
- `npm test --silent` *(fails: connect ECONNREFUSED 127.0.0.1:8083)*

------
https://chatgpt.com/codex/tasks/task_e_6853658654048324a723a1e6f7f40f9e