### PR TITLE
Fix asChild usage in dashboard footer

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -190,13 +190,11 @@ export default function DashboardPage() {
               )}
             </CardContent>
             <CardFooter>
-              <Button variant="outline" size="sm" asChild>
-                <span className="inline-flex w-full justify-center items-center">
-                  <Link href="/notifications">
-                    Ver Todas Notificações
-                  </Link>
-                </span>
-              </Button>
+              <Link href="/notifications" className="w-full">
+                <Button variant="outline" size="sm" className="w-full">
+                  Ver Todas Notificações
+                </Button>
+              </Link>
             </CardFooter>
           </Card>
         </div>


### PR DESCRIPTION
## Summary
- remove nested span inside button and wrap button with link to avoid Slot errors

## Testing
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:8083)*
- `npm run lint` *(fails with numerous lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685388e6a498832485943ef27369befe