### PR TITLE
Add missing Group type definition

### DIFF
--- a/src/types/group.ts
+++ b/src/types/group.ts
@@ -1,0 +1,9 @@
+export type Group = {
+  id: string;
+  name: string;
+  dayOfWeek: string; // ex: "monday", "tuesday", etc.
+  startTime: string; // ex: "14:00"
+  endTime: string;   // ex: "15:00"
+  psychologistId: string;
+  meetingAgenda?: string;
+};


### PR DESCRIPTION
## Summary
- create `Group` type definition in `src/types/group.ts`

## Testing
- `npx tsc --noEmit` for a test file importing the new type

------
https://chatgpt.com/codex/tasks/task_e_6853916d9c9483249bc89d825df4fc4b