### PR TITLE
Wrap icon/link children in asChild buttons

### DIFF
--- a/src/app/(app)/assessments/page.tsx
+++ b/src/app/(app)/assessments/page.tsx
@@ -24,15 +24,17 @@ export default function AssessmentsPage() {
         <div className="flex gap-2">
           <Button variant="outline" asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
             <Link href="/assessments/templates/new">
-              <span>
-                <PlusCircle className="mr-2 h-4 w-4" /> Criar Novo Modelo
+              <span className="inline-flex items-center gap-2">
+                <PlusCircle className="h-4 w-4" />
+                Criar Novo Modelo
               </span>
             </Link>
           </Button>
           <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
             <Link href="/assessments/assign">
-              <span>
-                <ClipboardList className="mr-2 h-4 w-4" /> Atribuir Avaliação
+              <span className="inline-flex items-center gap-2">
+                <ClipboardList className="h-4 w-4" />
+                Atribuir Avaliação
               </span>
             </Link>
           </Button>

--- a/src/app/(app)/groups/[id]/page.tsx
+++ b/src/app/(app)/groups/[id]/page.tsx
@@ -178,7 +178,10 @@ export default function GroupDetailPage({ params }: { params: { id: string } }) 
         <div className="flex gap-2">
             <Button variant="outline" asChild>
                 <Link href={`/groups/edit/${currentGroup.id}`}>
-                    <Edit className="mr-2 h-4 w-4"/> Editar Grupo
+                    <span className="inline-flex items-center gap-2">
+                        <Edit className="h-4 w-4" />
+                        Editar Grupo
+                    </span>
                 </Link>
             </Button>
              <AlertDialog>
@@ -253,7 +256,10 @@ export default function GroupDetailPage({ params }: { params: { id: string } }) 
         <CardFooter>
             <Button variant="outline" asChild>
                 <Link href={`/groups/edit/${currentGroup.id}?tab=participants`}>
-                    <Settings className="mr-2 h-4 w-4"/> Gerenciar Participantes
+                    <span className="inline-flex items-center gap-2">
+                        <Settings className="h-4 w-4" />
+                        Gerenciar Participantes
+                    </span>
                 </Link>
             </Button>
         </CardFooter>
@@ -273,7 +279,10 @@ export default function GroupDetailPage({ params }: { params: { id: string } }) 
          <CardFooter>
             <Button variant="outline" asChild>
                 <Link href={`/groups/edit/${currentGroup.id}?tab=details`}>
-                    <Edit className="mr-2 h-4 w-4"/> Editar Descrição
+                    <span className="inline-flex items-center gap-2">
+                        <Edit className="h-4 w-4" />
+                        Editar Descrição
+                    </span>
                 </Link>
             </Button>
         </CardFooter>
@@ -294,7 +303,10 @@ export default function GroupDetailPage({ params }: { params: { id: string } }) 
          <CardFooter>
             <Button variant="outline" asChild>
                 <Link href={`/groups/edit/${currentGroup.id}?tab=agenda`}>
-                    <Edit className="mr-2 h-4 w-4"/> Editar Roteiro
+                    <span className="inline-flex items-center gap-2">
+                        <Edit className="h-4 w-4" />
+                        Editar Roteiro
+                    </span>
                 </Link>
             </Button>
         </CardFooter>
@@ -368,7 +380,10 @@ export default function GroupDetailPage({ params }: { params: { id: string } }) 
                     {resource.type === "link" && resource.url ? (
                          <Button variant="outline" size="sm" asChild>
                             <a href={resource.url} target="_blank" rel="noopener noreferrer">
-                                <LinkIcon className="mr-1.5 h-3.5 w-3.5" /> Acessar Link
+                                <span className="inline-flex items-center gap-2">
+                                    <LinkIcon className="h-3.5 w-3.5" />
+                                    Acessar Link
+                                </span>
                             </a>
                         </Button>
                     ) : (

--- a/src/app/(app)/groups/page.tsx
+++ b/src/app/(app)/groups/page.tsx
@@ -86,8 +86,9 @@ export default function TherapeuticGroupsPage() {
         </div>
         <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
           <Link href="/groups/new">
-            <span>
-              <PlusCircle className="mr-2 h-4 w-4" /> Criar Novo Grupo
+            <span className="inline-flex items-center gap-2">
+              <PlusCircle className="h-4 w-4" />
+              Criar Novo Grupo
             </span>
           </Link>
         </Button>
@@ -146,15 +147,17 @@ export default function TherapeuticGroupsPage() {
                           <DropdownMenuContent align="end">
                             <DropdownMenuItem asChild>
                               <Link href={`/schedule/new?groupId=${group.id}&type=group`}>
-                                <span>
-                                  <CalendarPlus className="mr-2 h-4 w-4" /> Agendar Sessão Avulsa
+                                <span className="inline-flex items-center gap-2">
+                                  <CalendarPlus className="h-4 w-4" />
+                                  Agendar Sessão Avulsa
                                 </span>
                               </Link>
                             </DropdownMenuItem>
                             <DropdownMenuItem asChild>
                               <Link href={`/groups/edit/${group.id}`}>
-                                <span>
-                                  <Edit className="mr-2 h-4 w-4" /> Editar Grupo
+                                <span className="inline-flex items-center gap-2">
+                                  <Edit className="h-4 w-4" />
+                                  Editar Grupo
                                 </span>
                               </Link>
                             </DropdownMenuItem>
@@ -176,11 +179,12 @@ export default function TherapeuticGroupsPage() {
               <p className="mt-1 text-sm text-muted-foreground">Comece criando um novo grupo.</p>
                <Button asChild className="mt-4 bg-accent hover:bg-accent/90 text-accent-foreground">
                   <Link href="/groups/new">
-                    <span>
-                      <PlusCircle className="mr-2 h-4 w-4" /> Criar Novo Grupo
+                    <span className="inline-flex items-center gap-2">
+                      <PlusCircle className="h-4 w-4" />
+                      Criar Novo Grupo
                     </span>
                   </Link>
-                </Button>
+               </Button>
             </div>
            )}
         </CardContent>

--- a/src/app/(app)/notifications/page.tsx
+++ b/src/app/(app)/notifications/page.tsx
@@ -44,8 +44,11 @@ export default function NotificationsPage() {
                 <CheckCheck className="mr-2 h-4 w-4" /> Marcar Todas como Lidas
             </Button>
             <Button variant="outline" asChild>
-                <Link href="/settings?tab=notifications"> 
-                    <Settings className="mr-2 h-4 w-4" /> Config. de Notificações
+                <Link href="/settings?tab=notifications">
+                    <span className="inline-flex items-center gap-2">
+                        <Settings className="h-4 w-4" />
+                        Config. de Notificações
+                    </span>
                 </Link>
             </Button>
         </div>

--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -163,21 +163,24 @@ export default function ProfilePage() {
           <Button variant="default" asChild className="w-full sm:w-auto bg-accent hover:bg-accent/90 text-accent-foreground">
             <Link href="/settings?tab=account">
               <span className="inline-flex items-center gap-2">
-                <Edit className="mr-2 h-4 w-4" /> Editar Perfil
+                <Edit className="h-4 w-4" />
+                Editar Perfil
               </span>
             </Link>
           </Button>
           <Button variant="outline" asChild className="w-full sm:w-auto">
             <Link href="/settings?tab=account">
               <span className="inline-flex items-center gap-2">
-                <Lock className="mr-2 h-4 w-4" /> Alterar Senha
+                <Lock className="h-4 w-4" />
+                Alterar Senha
               </span>
             </Link>
           </Button>
            <Button variant="outline" asChild className="w-full sm:w-auto">
             <Link href="/settings?tab=notifications">
               <span className="inline-flex items-center gap-2">
-                <Bell className="mr-2 h-4 w-4" /> Preferências de Notificação
+                <Bell className="h-4 w-4" />
+                Preferências de Notificação
               </span>
             </Link>
           </Button>

--- a/src/app/(app)/resources/page.tsx
+++ b/src/app/(app)/resources/page.tsx
@@ -25,7 +25,8 @@ export default function ResourcesPage() {
         <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
           <Link href="/resources/upload">
             <span className="inline-flex items-center gap-2">
-              <UploadCloud className="mr-2 h-4 w-4" /> Carregar Novo Recurso
+              <UploadCloud className="h-4 w-4" />
+              Carregar Novo Recurso
             </span>
           </Link>
         </Button>

--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -212,8 +212,9 @@ export default function SchedulePage() {
         </div>
         <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
           <Link href="/schedule/new">
-            <span>
-              <PlusCircle className="mr-2 h-4 w-4" /> Novo Agendamento
+            <span className="inline-flex items-center gap-2">
+              <PlusCircle className="h-4 w-4" />
+              Novo Agendamento
             </span>
           </Link>
         </Button>
@@ -291,8 +292,9 @@ export default function SchedulePage() {
                 </DropdownMenu>
                  <Button variant="outline" size="sm" asChild className="w-full sm:w-auto">
                     <Link href={`/schedule/new?isBlockTime=true&date=${format(currentDate, 'yyyy-MM-dd')}`}>
-                        <span>
-                          <ShieldAlert className="mr-1.5 h-3.5 w-3.5" /> Bloquear Horário
+                        <span className="inline-flex items-center gap-2">
+                          <ShieldAlert className="h-3.5 w-3.5" />
+                          Bloquear Horário
                         </span>
                     </Link>
                  </Button>

--- a/src/app/(app)/schedule/today/page.tsx
+++ b/src/app/(app)/schedule/today/page.tsx
@@ -243,8 +243,9 @@ export default function TodaySchedulePage() {
         </div>
         <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
           <Link href="/schedule/new">
-            <span>
-              <PlusCircle className="mr-2 h-4 w-4" /> Novo Agendamento
+            <span className="inline-flex items-center gap-2">
+              <PlusCircle className="h-4 w-4" />
+              Novo Agendamento
             </span>
           </Link>
         </Button>

--- a/src/app/(app)/tasks/page.tsx
+++ b/src/app/(app)/tasks/page.tsx
@@ -40,7 +40,8 @@ export default function TasksPage() {
         <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
           <Link href="/tasks/new">
             <span className="inline-flex items-center gap-2">
-              <PlusCircle className="mr-2 h-4 w-4" /> Nova Tarefa
+              <PlusCircle className="h-4 w-4" />
+              Nova Tarefa
             </span>
           </Link>
         </Button>

--- a/src/components/layout/TabsBar.tsx
+++ b/src/components/layout/TabsBar.tsx
@@ -188,8 +188,9 @@ export default function TabsBar() {
               className="flex items-center gap-2 text-sm font-medium h-8 flex-shrink-0 ml-1"
               title="Adicionar Nova Aba"
             >
-              <span>
-                <PlusCircle className="h-4 w-4" /> Nova Aba
+              <span className="inline-flex items-center gap-2">
+                <PlusCircle className="h-4 w-4" />
+                Nova Aba
               </span>
             </Button>
           </DropdownMenuTrigger>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -64,17 +64,17 @@ export default function AppHeader() {
             <DropdownMenuSeparator />
             <DropdownMenuItem asChild>
               <Link href="/profile">
-                <span>
-                  <UserCircle className="mr-2 h-4 w-4" />
-                  <span>Perfil</span>
+                <span className="inline-flex items-center gap-2">
+                  <UserCircle className="h-4 w-4" />
+                  Perfil
                 </span>
               </Link>
             </DropdownMenuItem>
             <DropdownMenuItem asChild>
               <Link href="/settings">
-                <span>
-                  <Settings className="mr-2 h-4 w-4" />
-                  <span>Configurações</span>
+                <span className="inline-flex items-center gap-2">
+                  <Settings className="h-4 w-4" />
+                  Configurações
                 </span>
               </Link>
             </DropdownMenuItem>

--- a/src/components/notifications/notification-item.tsx
+++ b/src/components/notifications/notification-item.tsx
@@ -81,8 +81,9 @@ function NotificationItemComponent({ notification }: NotificationItemProps) {
                 aria-label="Ver detalhes"
               >
                 <Link href={notification.link}>
-                  <span>
-                    <ExternalLink className="mr-1 h-3.5 w-3.5" /> Ver
+                  <span className="inline-flex items-center gap-2">
+                    <ExternalLink className="h-3.5 w-3.5" />
+                    Ver
                   </span>
                 </Link>
               </Button>

--- a/src/components/patients/patient-list-item.tsx
+++ b/src/components/patients/patient-list-item.tsx
@@ -88,8 +88,8 @@ function PatientListItemComponent({ patient }: PatientListItemProps) {
           <div className="flex items-center gap-1 sm:gap-2">
             <Button variant="outline" size="sm" asChild className="h-8 px-2 sm:px-3" aria-label={`Editar perfil de ${patient.name}`}>
               <Link href={`/patients/${patient.id}/edit`}>
-                <span>
-                  <Edit3 className="h-3.5 w-3.5 sm:mr-1" />
+                <span className="inline-flex items-center gap-2">
+                  <Edit3 className="h-3.5 w-3.5" />
                   <span className="hidden sm:inline">Editar</span>
                   <span className="sr-only sm:hidden">Editar perfil de {patient.name}</span>
                 </span>
@@ -102,8 +102,9 @@ function PatientListItemComponent({ patient }: PatientListItemProps) {
                   className="flex items-center gap-2 text-sm font-medium text-destructive hover:text-destructive hover:bg-destructive/10 h-8"
                   aria-label={`Excluir paciente ${patient.name}`}
                 >
-                  <span>
-                    <Trash2 className="h-4 w-4" /> Excluir
+                  <span className="inline-flex items-center gap-2">
+                    <Trash2 className="h-4 w-4" />
+                    Excluir
                   </span>
                 </Button>
             </AlertDialogTrigger>
@@ -130,8 +131,9 @@ function PatientListItemComponent({ patient }: PatientListItemProps) {
               aria-label={`Ver detalhes de ${patient.name}`}
             >
               <Link href={`/patients/${patient.id}`} className="flex items-center gap-2">
-                <span>
-                  <ChevronRight className="h-5 w-5" /> Abrir
+                <span className="inline-flex items-center gap-2">
+                  <ChevronRight className="h-5 w-5" />
+                  Abrir
                 </span>
               </Link>
             </Button>

--- a/src/components/schedule/appointment-calendar.tsx
+++ b/src/components/schedule/appointment-calendar.tsx
@@ -273,39 +273,43 @@ function AppointmentCalendarComponent({ view, currentDate, filters, workingDaysO
           </div>
           <div className="flex flex-col gap-1.5 p-3 border-t bg-muted/30 rounded-b-lg">
               {appt.isGroupSession && appt.groupId && (
-                  <Button size="sm" variant="outline" asChild className="w-full">
-                      <Link href={`/groups/${appt.groupId}`}>
-                          <span>
-                            <UsersIcon className="mr-1.5 h-3.5 w-3.5"/> Ver Detalhes do Grupo
-                          </span>
-                      </Link>
-                  </Button>
+                    <Button size="sm" variant="outline" asChild className="w-full">
+                        <Link href={`/groups/${appt.groupId}`}>
+                            <span className="inline-flex items-center gap-2">
+                              <UsersIcon className="h-3.5 w-3.5"/>
+                              Ver Detalhes do Grupo
+                            </span>
+                        </Link>
+                    </Button>
               )}
               {!appt.isGroupSession && appt.patientId && (
-                  <Button size="sm" variant="outline" asChild className="w-full">
-                      <Link href={`/patients/${appt.patientId}?tab=notes&date=${format(dayDate, "yyyy-MM-dd")}`}>
-                          <span>
-                            <FileText className="mr-1.5 h-3.5 w-3.5"/> Iniciar Anotação
-                          </span>
-                      </Link>
-                  </Button>
+                    <Button size="sm" variant="outline" asChild className="w-full">
+                        <Link href={`/patients/${appt.patientId}?tab=notes&date=${format(dayDate, "yyyy-MM-dd")}`}>
+                            <span className="inline-flex items-center gap-2">
+                              <FileText className="h-3.5 w-3.5"/>
+                              Iniciar Anotação
+                            </span>
+                        </Link>
+                    </Button>
               )}
               <div className="flex gap-2 w-full">
-                  <Button size="sm" variant="outline" asChild className="flex-1">
-                    <Link href={appt.isGroupSession ? `/groups/edit/${appt.groupId}` : `/schedule/edit/${appt.id}`}>
-                      <span>
-                        <Edit className="mr-1.5 h-3.5 w-3.5"/> {appt.isGroupSession ? "Gerenciar Grupo" : "Editar"}
-                      </span>
-                    </Link>
-                  </Button>
+                    <Button size="sm" variant="outline" asChild className="flex-1">
+                      <Link href={appt.isGroupSession ? `/groups/edit/${appt.groupId}` : `/schedule/edit/${appt.id}`}>
+                        <span className="inline-flex items-center gap-2">
+                          <Edit className="h-3.5 w-3.5"/>
+                          {appt.isGroupSession ? "Gerenciar Grupo" : "Editar"}
+                        </span>
+                      </Link>
+                    </Button>
                   {!appt.isGroupSession && (
                     <AlertDialog>
                     <AlertDialogTrigger asChild>
-                        <Button size="sm" variant="destructive" className="flex-1 bg-destructive/90 hover:bg-destructive text-destructive-foreground">
-                          <span>
-                            <Trash2 className="mr-1.5 h-3.5 w-3.5"/> Excluir
-                          </span>
-                        </Button>
+                          <Button size="sm" variant="destructive" className="flex-1 bg-destructive/90 hover:bg-destructive text-destructive-foreground">
+                            <span className="inline-flex items-center gap-2">
+                              <Trash2 className="h-3.5 w-3.5"/>
+                              Excluir
+                            </span>
+                          </Button>
                     </AlertDialogTrigger>
                     <AlertDialogContent>
                         <AlertDialogHeader><AlertDialogTitle>Confirmar Exclusão</AlertDialogTitle>
@@ -322,11 +326,13 @@ function AppointmentCalendarComponent({ view, currentDate, filters, workingDaysO
               {!appt.isGroupSession && appt.type !== "Blocked Slot" && (
               <DropdownMenu>
                   <DropdownMenuTrigger asChild>
-                    <Button size="sm" variant="outline" className="w-full">
-                      <span>
-                        <Check className="mr-1.5 h-3.5 w-3.5" /> Marcar Status <ChevronDown className="ml-auto h-3.5 w-3.5 opacity-70"/>
-                      </span>
-                    </Button>
+                      <Button size="sm" variant="outline" className="w-full">
+                        <span className="inline-flex items-center gap-2">
+                          <Check className="h-3.5 w-3.5" />
+                          Marcar Status
+                          <ChevronDown className="ml-auto h-3.5 w-3.5 opacity-70"/>
+                        </span>
+                      </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent className="w-56">
                   <DropdownMenuLabel>Atualizar Status</DropdownMenuLabel><DropdownMenuSeparator />
@@ -395,12 +401,12 @@ function AppointmentCalendarComponent({ view, currentDate, filters, workingDaysO
                             .map(appt => renderAppointmentPopover(appt, dayDate))
                         }
                         <Button variant="ghost" size="icon" className="absolute bottom-0 right-0 h-6 w-6 opacity-0 hover:opacity-100 focus:opacity-100 transition-opacity" asChild>
-                           <Link href={`/schedule/new?date=${format(dayDate, "yyyy-MM-dd")}&time=${timeSlot}`}>
-                             <span>
-                               <PlusCircle className="h-4 w-4" />
-                               <span className="sr-only">Adicionar</span>
-                             </span>
-                           </Link>
+                             <Link href={`/schedule/new?date=${format(dayDate, "yyyy-MM-dd")}&time=${timeSlot}`}>
+                               <span className="inline-flex items-center gap-2">
+                                 <PlusCircle className="h-4 w-4" />
+                                 <span className="sr-only">Adicionar</span>
+                               </span>
+                             </Link>
                         </Button>
                     </div>
                 ))}
@@ -410,9 +416,9 @@ function AppointmentCalendarComponent({ view, currentDate, filters, workingDaysO
             <div className="mt-1 space-y-1 text-xs overflow-y-auto flex-grow p-1">
                 {dayAppointments.map(appt => renderAppointmentPopover(appt, dayDate))}
                  <Button variant="ghost" size="icon" className="absolute bottom-1 right-1 h-7 w-7 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity" asChild>
-                  <Link href={`/schedule/new?date=${format(dayDate, "yyyy-MM-dd")}`}>
-                    <span><PlusCircle className="h-5 w-5" /><span className="sr-only">Adicionar</span></span>
-                  </Link>
+                    <Link href={`/schedule/new?date=${format(dayDate, "yyyy-MM-dd")}`}>
+                      <span className="inline-flex items-center gap-2"><PlusCircle className="h-5 w-5" /><span className="sr-only">Adicionar</span></span>
+                    </Link>
                 </Button>
             </div>
         )}

--- a/src/components/tasks/task-item.tsx
+++ b/src/components/tasks/task-item.tsx
@@ -117,8 +117,9 @@ function TaskItemComponent({ task }: TaskItemProps) {
           {task.patientId && (
             <Button variant="link" size="sm" className="p-0 h-auto text-accent text-xs" asChild>
               <Link href={`/patients/${task.patientId}`}>
-                <span>
-                  <LinkIcon className="mr-1 h-3.5 w-3.5" /> Ver Paciente Relacionado
+                <span className="inline-flex items-center gap-2">
+                  <LinkIcon className="h-3.5 w-3.5" />
+                  Ver Paciente Relacionado
                 </span>
               </Link>
             </Button>
@@ -129,16 +130,18 @@ function TaskItemComponent({ task }: TaskItemProps) {
       <CardFooter className="p-3 border-t flex justify-end gap-1.5">
           <Button variant="outline" size="sm" asChild>
             <Link href={`/tasks/edit/${task.id}`}>
-              <span>
-                <Edit className="mr-1.5 h-3.5 w-3.5" /> Editar
+              <span className="inline-flex items-center gap-2">
+                <Edit className="h-3.5 w-3.5" />
+                Editar
               </span>
             </Link>
           </Button>
           <AlertDialog>
             <AlertDialogTrigger asChild>
               <Button variant="outline" size="sm" className="text-destructive hover:text-destructive hover:border-destructive/50">
-                <span>
-                  <Trash2 className="mr-1.5 h-3.5 w-3.5" /> Excluir
+                <span className="inline-flex items-center gap-2">
+                  <Trash2 className="h-3.5 w-3.5" />
+                  Excluir
                 </span>
               </Button>
             </AlertDialogTrigger>


### PR DESCRIPTION
## Summary
- ensure elements passed to `asChild` have a single wrapper
- update notifications, navigation items and resource pages
- adjust schedule pages and cards with inline-flex spans

## Testing
- `npm test` *(fails: Jest não encontrado)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68537e274e848324bea980bc0a9393fa