### PR TITLE
Centralize shared TypeScript types

### DIFF
--- a/src/app/(app)/groups/[id]/page.tsx
+++ b/src/app/(app)/groups/[id]/page.tsx
@@ -36,41 +36,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/hooks/use-toast";
 import { Separator } from "@/components/ui/separator";
-
-
-interface Participant {
-  id: string;
-  name: string;
-  avatarUrl?: string;
-  dataAiHint?: string;
-}
-
-export interface GroupResource {
-  id: string;
-  name: string;
-  type: "pdf" | "docx" | "image" | "link" | "other";
-  url?: string;
-  uploadDate: string; // ISO date string
-  description?: string;
-  dataAiHint?: string;
-}
-
-interface Group {
-  id: string;
-  name: string;
-  psychologist: string;
-  psychologistId: string;
-  membersCount: number; 
-  schedule: string; 
-  dayOfWeek: string; 
-  startTime: string; 
-  endTime: string; 
-  nextSession?: string;
-  description?: string;
-  participants: Participant[];
-  meetingAgenda?: string;
-  resources?: GroupResource[];
-}
+import type { Participant, GroupResource, Group } from "@/types/group";
 
 const getInitials = (name: string) => {
   const names = name.split(' ');

--- a/src/app/(app)/groups/page.tsx
+++ b/src/app/(app)/groups/page.tsx
@@ -12,7 +12,7 @@ import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
-import type { GroupResource } from '@/app/(app)/groups/[id]/page'; 
+import type { GroupResource } from '@/types/group';
 
 export const mockTherapeuticGroups = [
   {

--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -11,8 +11,7 @@ import Link from "next/link";
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { useToast } from '@/hooks/use-toast';
-
-type UserGender = "masculino" | "feminino" | "outro";
+import type { UserGender } from '@/types/user';
 
 const getDefaultAvatarByGender = (gender?: UserGender, name?: string) => {
   const initials = name ? (name.split(' ')[0][0] + (name.split(' ').length > 1 ? name.split(' ')[name.split(' ').length - 1][0] : '')).toUpperCase() : "??";

--- a/src/components/dashboard/dashboard-weekly-schedule.tsx
+++ b/src/components/dashboard/dashboard-weekly-schedule.tsx
@@ -20,21 +20,7 @@ import {
   eachDayOfInterval,
 } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
-
-type Appointment = {
-  id: string;
-  startTime: string;
-  endTime: string;
-  patient: string;
-  type: string;
-  psychologistId: string;
-  status: string;
-  notes?: string;
-};
-
-type AppointmentsByDate = {
-  [date: string]: Appointment[];
-};
+import type { Appointment, AppointmentsByDate } from '@/types/appointment';
 
 export default function DashboardWeeklySchedule() {
   const [currentDate, setCurrentDate] = useState<Date | null>(null);

--- a/src/components/patients/patient-list-item.tsx
+++ b/src/components/patients/patient-list-item.tsx
@@ -21,17 +21,7 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { useToast } from "@/hooks/use-toast";
-
-
-interface Patient {
-  id: string;
-  name: string;
-  email: string;
-  lastSession?: string | null;
-  nextAppointment?: string | null;
-  avatarUrl?: string;
-  dataAiHint?: string;
-}
+import type { Patient } from "@/types/patient";
 
 interface PatientListItemProps {
   patient: Patient;

--- a/src/components/schedule/appointment-calendar.tsx
+++ b/src/components/schedule/appointment-calendar.tsx
@@ -33,7 +33,6 @@ import { useToast } from "@/hooks/use-toast";
 import type { Appointment, AppointmentsByDate, AppointmentStatus } from "@/types/appointment";
 import InfoDisplay from '@/components/ui/info-display';
 import { mockTherapeuticGroups } from '@/app/(app)/groups/page';
-import type { Group as TherapeuticGroup } from '@/app/(app)/groups/[id]/page';
 
 
 const mockPsychologists = [

--- a/src/mocks/patients.ts
+++ b/src/mocks/patients.ts
@@ -1,5 +1,5 @@
 
-type UserGender = "masculino" | "feminino" | "outro";
+import type { UserGender } from '@/types/user';
 
 const getDefaultPatientAvatar = (gender?: UserGender, name?: string) => {
   const initials = name ? (name.split(' ')[0][0] + (name.split(' ').length > 1 ? name.split(' ')[name.split(' ').length - 1][0] : '')).toUpperCase() : "P";

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -1,17 +1,6 @@
 
 import { create } from 'zustand';
-
-interface User {
-  id: string;
-  name: string;
-  avatar?: string;
-}
-
-interface CurrentUser {
-  uid: string | null;
-  displayName: string | null;
-  avatarUrl?: string | null;
-}
+import type { User, CurrentUser } from '@/types/user';
 
 interface ChatState {
   isChatOpen: boolean;

--- a/src/types/group.ts
+++ b/src/types/group.ts
@@ -1,9 +1,33 @@
-export type Group = {
+export interface Participant {
   id: string;
   name: string;
-  dayOfWeek: string; // ex: "monday", "tuesday", etc.
-  startTime: string; // ex: "14:00"
-  endTime: string;   // ex: "15:00"
+  avatarUrl?: string;
+  dataAiHint?: string;
+}
+
+export interface GroupResource {
+  id: string;
+  name: string;
+  type: "pdf" | "docx" | "image" | "link" | "other";
+  url?: string;
+  uploadDate: string;
+  description?: string;
+  dataAiHint?: string;
+}
+
+export interface Group {
+  id: string;
+  name: string;
+  psychologist: string;
   psychologistId: string;
+  membersCount: number;
+  schedule: string;
+  dayOfWeek: string;
+  startTime: string;
+  endTime: string;
+  nextSession?: string;
+  description?: string;
+  participants: Participant[];
   meetingAgenda?: string;
-};
+  resources?: GroupResource[];
+}

--- a/src/types/patient.ts
+++ b/src/types/patient.ts
@@ -1,0 +1,9 @@
+export interface Patient {
+  id: string;
+  name: string;
+  email: string;
+  lastSession?: string | null;
+  nextAppointment?: string | null;
+  avatarUrl?: string;
+  dataAiHint?: string;
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,13 @@
+export type UserGender = "masculino" | "feminino" | "outro";
+
+export interface User {
+  id: string;
+  name: string;
+  avatar?: string;
+}
+
+export interface CurrentUser {
+  uid: string | null;
+  displayName: string | null;
+  avatarUrl?: string | null;
+}


### PR DESCRIPTION
## Summary
- centralize `Patient`, `User`, and group related types
- import new shared types in components and pages

## Testing
- `npm test --silent` *(fails: Jest não encontrado. Execute 'npm install' para instalar as dependências.)*

------
https://chatgpt.com/codex/tasks/task_e_685393f3ec0c8324a6e5eb44e9757f80