### PR TITLE
Fix asChild child wrappers

### DIFF
--- a/src/app/(app)/groups/[id]/page.tsx
+++ b/src/app/(app)/groups/[id]/page.tsx
@@ -110,7 +110,10 @@ export default function GroupDetailPage({ params }: { params: { id: string } }) 
         <p className="text-muted-foreground mb-6">O grupo que você está procurando não existe ou foi movido.</p>
         <Button asChild variant="outline">
           <Link href="/groups">
-            <ArrowLeft className="mr-2 h-4 w-4" /> Voltar para Lista de Grupos
+            <span className="inline-flex items-center gap-2">
+              <ArrowLeft className="h-4 w-4" />
+              Voltar para Lista de Grupos
+            </span>
           </Link>
         </Button>
       </div>

--- a/src/app/(app)/patients/[id]/page.tsx
+++ b/src/app/(app)/patients/[id]/page.tsx
@@ -16,8 +16,9 @@ export default function PatientDetailPagePlaceholder() {
       </p>
       <Button variant="outline" asChild>
         <Link href="/patients">
-          <span>
-            <ArrowLeft className="mr-2 h-4 w-4" /> Voltar para Pacientes
+          <span className="inline-flex items-center gap-2">
+            <ArrowLeft className="h-4 w-4" />
+            Voltar para Pacientes
           </span>
         </Link>
       </Button>

--- a/src/components/assessments/assessment-card.tsx
+++ b/src/components/assessments/assessment-card.tsx
@@ -89,8 +89,9 @@ function AssessmentCardComponent({ assessment, showPatientInfo = false }: Assess
           {assessment.status === "Completed" && (
             <Button variant="outline" size="sm" asChild>
               <Link href={`/inventories-scales/${assessment.id}/results`}>
-                <span>
-                  <BarChart2 className="mr-2 h-4 w-4" /> Ver Resultados
+                <span className="inline-flex items-center gap-2">
+                  <BarChart2 className="h-4 w-4" />
+                  Ver Resultados
                 </span>
               </Link>
             </Button>

--- a/src/components/clinical-formulation/QuickNoteForm.tsx
+++ b/src/components/clinical-formulation/QuickNoteForm.tsx
@@ -64,8 +64,16 @@ const QuickNoteForm: React.FC = () => {
         <DialogFooter className="gap-2">
           <DialogClose asChild>
             {/* closeQuickNoteForm já é chamado por handleOpenChange */}
-            <Button type="button" variant="outline" className="flex items-center gap-2 text-sm font-medium" aria-label="Cancelar anotação">
-              <X className="h-4 w-4" /> Cancelar
+            <Button
+              type="button"
+              variant="outline"
+              className="flex items-center gap-2 text-sm font-medium"
+              aria-label="Cancelar anotação"
+            >
+              <span className="inline-flex items-center gap-2">
+                <X className="h-4 w-4" />
+                Cancelar
+              </span>
             </Button>
           </DialogClose>
           <Button


### PR DESCRIPTION
## Summary
- wrap icon/text pairs in `<span>` for asChild usage

## Testing
- `npm run lint` *(fails: 'FormDescription' is defined but never used, etc.)*
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:8083)*

------
https://chatgpt.com/codex/tasks/task_e_685394189fb4832482e93708b864e77f