### PR TITLE
Fix Button asChild wrappers

### DIFF
--- a/src/app/(app)/assessments/page.tsx
+++ b/src/app/(app)/assessments/page.tsx
@@ -23,19 +23,15 @@ export default function AssessmentsPage() {
         </div>
         <div className="flex gap-2">
           <Button variant="outline" asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
-            <Link href="/assessments/templates/new">
-              <span className="inline-flex items-center gap-2">
-                <PlusCircle className="h-4 w-4" />
-                Criar Novo Modelo
-              </span>
+            <Link href="/assessments/templates/new" className="inline-flex items-center gap-2">
+              <PlusCircle className="h-4 w-4" />
+              Criar Novo Modelo
             </Link>
           </Button>
           <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
-            <Link href="/assessments/assign">
-              <span className="inline-flex items-center gap-2">
-                <ClipboardList className="h-4 w-4" />
-                Atribuir Avaliação
-              </span>
+            <Link href="/assessments/assign" className="inline-flex items-center gap-2">
+              <ClipboardList className="h-4 w-4" />
+              Atribuir Avaliação
             </Link>
           </Button>
         </div>

--- a/src/app/(app)/groups/[id]/page.tsx
+++ b/src/app/(app)/groups/[id]/page.tsx
@@ -143,11 +143,9 @@ export default function GroupDetailPage({ params }: { params: { id: string } }) 
         </Button>
         <div className="flex gap-2">
             <Button variant="outline" asChild>
-                <Link href={`/groups/edit/${currentGroup.id}`}>
-                    <span className="inline-flex items-center gap-2">
-                        <Edit className="h-4 w-4" />
-                        Editar Grupo
-                    </span>
+                <Link href={`/groups/edit/${currentGroup.id}`} className="inline-flex items-center gap-2">
+                    <Edit className="h-4 w-4" />
+                    Editar Grupo
                 </Link>
             </Button>
              <AlertDialog>
@@ -221,11 +219,9 @@ export default function GroupDetailPage({ params }: { params: { id: string } }) 
         </CardContent>
         <CardFooter>
             <Button variant="outline" asChild>
-                <Link href={`/groups/edit/${currentGroup.id}?tab=participants`}>
-                    <span className="inline-flex items-center gap-2">
-                        <Settings className="h-4 w-4" />
-                        Gerenciar Participantes
-                    </span>
+                <Link href={`/groups/edit/${currentGroup.id}?tab=participants`} className="inline-flex items-center gap-2">
+                    <Settings className="h-4 w-4" />
+                    Gerenciar Participantes
                 </Link>
             </Button>
         </CardFooter>
@@ -244,11 +240,9 @@ export default function GroupDetailPage({ params }: { params: { id: string } }) 
         </CardContent>
          <CardFooter>
             <Button variant="outline" asChild>
-                <Link href={`/groups/edit/${currentGroup.id}?tab=details`}>
-                    <span className="inline-flex items-center gap-2">
-                        <Edit className="h-4 w-4" />
-                        Editar Descrição
-                    </span>
+                <Link href={`/groups/edit/${currentGroup.id}?tab=details`} className="inline-flex items-center gap-2">
+                    <Edit className="h-4 w-4" />
+                    Editar Descrição
                 </Link>
             </Button>
         </CardFooter>
@@ -268,11 +262,9 @@ export default function GroupDetailPage({ params }: { params: { id: string } }) 
         </CardContent>
          <CardFooter>
             <Button variant="outline" asChild>
-                <Link href={`/groups/edit/${currentGroup.id}?tab=agenda`}>
-                    <span className="inline-flex items-center gap-2">
-                        <Edit className="h-4 w-4" />
-                        Editar Roteiro
-                    </span>
+                <Link href={`/groups/edit/${currentGroup.id}?tab=agenda`} className="inline-flex items-center gap-2">
+                    <Edit className="h-4 w-4" />
+                    Editar Roteiro
                 </Link>
             </Button>
         </CardFooter>
@@ -345,11 +337,9 @@ export default function GroupDetailPage({ params }: { params: { id: string } }) 
                     <div className="flex-shrink-0">
                     {resource.type === "link" && resource.url ? (
                          <Button variant="outline" size="sm" asChild>
-                            <a href={resource.url} target="_blank" rel="noopener noreferrer">
-                                <span className="inline-flex items-center gap-2">
-                                    <LinkIcon className="h-3.5 w-3.5" />
-                                    Acessar Link
-                                </span>
+                            <a href={resource.url} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-2">
+                                <LinkIcon className="h-3.5 w-3.5" />
+                                Acessar Link
                             </a>
                         </Button>
                     ) : (

--- a/src/app/(app)/groups/page.tsx
+++ b/src/app/(app)/groups/page.tsx
@@ -85,11 +85,9 @@ export default function TherapeuticGroupsPage() {
           <h1 className="text-3xl font-headline font-bold">Grupos Terapêuticos</h1>
         </div>
         <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
-          <Link href="/groups/new">
-            <span className="inline-flex items-center gap-2">
-              <PlusCircle className="h-4 w-4" />
-              Criar Novo Grupo
-            </span>
+          <Link href="/groups/new" className="inline-flex items-center gap-2">
+            <PlusCircle className="h-4 w-4" />
+            Criar Novo Grupo
           </Link>
         </Button>
       </div>
@@ -178,11 +176,9 @@ export default function TherapeuticGroupsPage() {
               <h3 className="mt-2 text-sm font-medium text-foreground">Nenhum grupo terapêutico encontrado</h3>
               <p className="mt-1 text-sm text-muted-foreground">Comece criando um novo grupo.</p>
                <Button asChild className="mt-4 bg-accent hover:bg-accent/90 text-accent-foreground">
-                  <Link href="/groups/new">
-                    <span className="inline-flex items-center gap-2">
-                      <PlusCircle className="h-4 w-4" />
-                      Criar Novo Grupo
-                    </span>
+                  <Link href="/groups/new" className="inline-flex items-center gap-2">
+                    <PlusCircle className="h-4 w-4" />
+                    Criar Novo Grupo
                   </Link>
                </Button>
             </div>

--- a/src/app/(app)/inventories-scales/page.tsx
+++ b/src/app/(app)/inventories-scales/page.tsx
@@ -24,17 +24,13 @@ export default function InventoriesScalesPage() {
         </div>
         <div className="flex gap-2">
           <Button variant="outline" asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
-            <Link href="/inventories-scales/templates/new">
-              <span className="inline-flex items-center gap-2">
-                <PlusCircle className="mr-2 h-4 w-4" /> Criar Novo Modelo
-              </span>
+            <Link href="/inventories-scales/templates/new" className="inline-flex items-center gap-2">
+              <PlusCircle className="mr-2 h-4 w-4" /> Criar Novo Modelo
             </Link>
           </Button>
           <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
-            <Link href="/inventories-scales/assign">
-              <span className="inline-flex items-center gap-2">
-                <ClipboardList className="mr-2 h-4 w-4" /> Atribuir Inventário/Escala
-              </span>
+            <Link href="/inventories-scales/assign" className="inline-flex items-center gap-2">
+              <ClipboardList className="mr-2 h-4 w-4" /> Atribuir Inventário/Escala
             </Link>
           </Button>
         </div>

--- a/src/app/(app)/notifications/page.tsx
+++ b/src/app/(app)/notifications/page.tsx
@@ -44,11 +44,9 @@ export default function NotificationsPage() {
                 <CheckCheck className="mr-2 h-4 w-4" /> Marcar Todas como Lidas
             </Button>
             <Button variant="outline" asChild>
-                <Link href="/settings?tab=notifications">
-                    <span className="inline-flex items-center gap-2">
-                        <Settings className="h-4 w-4" />
-                        Config. de Notificações
-                    </span>
+                <Link href="/settings?tab=notifications" className="inline-flex items-center gap-2">
+                    <Settings className="h-4 w-4" />
+                    Config. de Notificações
                 </Link>
             </Button>
         </div>

--- a/src/app/(app)/patients/[id]/page.tsx
+++ b/src/app/(app)/patients/[id]/page.tsx
@@ -15,10 +15,8 @@ export default function PatientDetailPagePlaceholder() {
         This page is temporarily simplified to help diagnose a Turbopack error.
       </p>
       <Button variant="outline" asChild>
-        <Link href="/patients">
-          <span>
-            <ArrowLeft className="mr-2 h-4 w-4" /> Voltar para Pacientes
-          </span>
+        <Link href="/patients" className="inline-flex items-center gap-2">
+          <ArrowLeft className="mr-2 h-4 w-4" /> Voltar para Pacientes
         </Link>
       </Button>
     </div>

--- a/src/app/(app)/patients/page.tsx
+++ b/src/app/(app)/patients/page.tsx
@@ -41,10 +41,8 @@ export default function PatientsPage() {
           <h1 className="text-3xl font-headline font-bold">Pacientes</h1>
         </div>
         <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
-          <Link href="/patients/new">
-            <span className="inline-flex items-center gap-2">
-              <UserPlus className="mr-2 h-4 w-4" /> Adicionar Novo Paciente
-            </span>
+          <Link href="/patients/new" className="inline-flex items-center gap-2">
+            <UserPlus className="mr-2 h-4 w-4" /> Adicionar Novo Paciente
           </Link>
         </Button>
       </div>
@@ -83,10 +81,8 @@ export default function PatientsPage() {
               description="Comece adicionando um novo paciente."
               action={
                 <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
-                  <Link href={APP_ROUTES.newPatient}>
-                    <span className="inline-flex items-center gap-2">
-                      <UserPlus className="mr-2 h-4 w-4" /> Adicionar Novo Paciente
-                    </span>
+                  <Link href={APP_ROUTES.newPatient} className="inline-flex items-center gap-2">
+                    <UserPlus className="mr-2 h-4 w-4" /> Adicionar Novo Paciente
                   </Link>
                 </Button>
               }

--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -160,27 +160,21 @@ export default function ProfilePage() {
         </CardContent>
         <CardFooter className="flex flex-col sm:flex-row justify-center gap-3 p-6 border-t">
           <Button variant="default" asChild className="w-full sm:w-auto bg-accent hover:bg-accent/90 text-accent-foreground">
-            <Link href="/settings?tab=account">
-              <span className="inline-flex items-center gap-2">
-                <Edit className="h-4 w-4" />
-                Editar Perfil
-              </span>
+            <Link href="/settings?tab=account" className="inline-flex items-center gap-2">
+              <Edit className="h-4 w-4" />
+              Editar Perfil
             </Link>
           </Button>
           <Button variant="outline" asChild className="w-full sm:w-auto">
-            <Link href="/settings?tab=account">
-              <span className="inline-flex items-center gap-2">
-                <Lock className="h-4 w-4" />
-                Alterar Senha
-              </span>
+            <Link href="/settings?tab=account" className="inline-flex items-center gap-2">
+              <Lock className="h-4 w-4" />
+              Alterar Senha
             </Link>
           </Button>
            <Button variant="outline" asChild className="w-full sm:w-auto">
-            <Link href="/settings?tab=notifications">
-              <span className="inline-flex items-center gap-2">
-                <Bell className="h-4 w-4" />
-                Preferências de Notificação
-              </span>
+            <Link href="/settings?tab=notifications" className="inline-flex items-center gap-2">
+              <Bell className="h-4 w-4" />
+              Preferências de Notificação
             </Link>
           </Button>
         </CardFooter>

--- a/src/app/(app)/resources/page.tsx
+++ b/src/app/(app)/resources/page.tsx
@@ -23,11 +23,9 @@ export default function ResourcesPage() {
           <h1 className="text-3xl font-headline font-bold">Recursos Compartilhados</h1>
         </div>
         <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
-          <Link href="/resources/upload">
-            <span className="inline-flex items-center gap-2">
-              <UploadCloud className="h-4 w-4" />
-              Carregar Novo Recurso
-            </span>
+          <Link href="/resources/upload" className="inline-flex items-center gap-2">
+            <UploadCloud className="h-4 w-4" />
+            Carregar Novo Recurso
           </Link>
         </Button>
       </div>

--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -211,11 +211,9 @@ export default function SchedulePage() {
           <h1 className="text-3xl font-headline font-bold">Agenda Comparativa</h1>
         </div>
         <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
-          <Link href="/schedule/new">
-            <span className="inline-flex items-center gap-2">
-              <PlusCircle className="h-4 w-4" />
-              Novo Agendamento
-            </span>
+          <Link href="/schedule/new" className="inline-flex items-center gap-2">
+            <PlusCircle className="h-4 w-4" />
+            Novo Agendamento
           </Link>
         </Button>
       </div>
@@ -291,11 +289,9 @@ export default function SchedulePage() {
                 </DropdownMenuContent>
                 </DropdownMenu>
                  <Button variant="outline" size="sm" asChild className="w-full sm:w-auto">
-                    <Link href={`/schedule/new?isBlockTime=true&date=${format(currentDate, 'yyyy-MM-dd')}`}>
-                        <span className="inline-flex items-center gap-2">
+                    <Link href={`/schedule/new?isBlockTime=true&date=${format(currentDate, 'yyyy-MM-dd')}`} className="inline-flex items-center gap-2">
                           <ShieldAlert className="h-3.5 w-3.5" />
                           Bloquear Horário
-                        </span>
                     </Link>
                  </Button>
             </div>

--- a/src/app/(app)/schedule/today/page.tsx
+++ b/src/app/(app)/schedule/today/page.tsx
@@ -242,11 +242,9 @@ export default function TodaySchedulePage() {
           <h1 className="text-3xl font-headline font-bold">Agenda de Hoje</h1>
         </div>
         <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
-          <Link href="/schedule/new">
-            <span className="inline-flex items-center gap-2">
-              <PlusCircle className="h-4 w-4" />
-              Novo Agendamento
-            </span>
+          <Link href="/schedule/new" className="inline-flex items-center gap-2">
+            <PlusCircle className="h-4 w-4" />
+            Novo Agendamento
           </Link>
         </Button>
       </div>

--- a/src/app/(app)/tasks/page.tsx
+++ b/src/app/(app)/tasks/page.tsx
@@ -38,11 +38,9 @@ export default function TasksPage() {
           <h1 className="text-3xl font-headline font-bold">Tarefas</h1>
         </div>
         <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
-          <Link href="/tasks/new">
-            <span className="inline-flex items-center gap-2">
-              <PlusCircle className="h-4 w-4" />
-              Nova Tarefa
-            </span>
+          <Link href="/tasks/new" className="inline-flex items-center gap-2">
+            <PlusCircle className="h-4 w-4" />
+            Nova Tarefa
           </Link>
         </Button>
       </div>

--- a/src/app/(app)/templates/page.tsx
+++ b/src/app/(app)/templates/page.tsx
@@ -26,9 +26,7 @@ export default function TemplatesPage() {
         </div>
         <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
           <Link href="/templates/new">
-            <span>
-              <PlusCircle className="mr-2 h-4 w-4" /> Criar Novo Modelo
-            </span>
+            <PlusCircle className="mr-2 h-4 w-4" /> Criar Novo Modelo
           </Link>
         </Button>
       </div>

--- a/src/app/(app)/tools/case-formulation-models/page.tsx
+++ b/src/app/(app)/tools/case-formulation-models/page.tsx
@@ -70,9 +70,7 @@ export default function CaseFormulationModelsPage() {
         </div>
         <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
           <Link href="/tools/case-formulation-models/new">
-            <span>
-              <PlusCircle className="mr-2 h-4 w-4" /> Criar Novo Modelo
-            </span>
+            <PlusCircle className="mr-2 h-4 w-4" /> Criar Novo Modelo
           </Link>
         </Button>
       </div>
@@ -152,9 +150,7 @@ export default function CaseFormulationModelsPage() {
               <p className="mt-1 text-sm text-muted-foreground">Comece criando um novo modelo.</p>
                 <Button asChild className="mt-4 bg-accent hover:bg-accent/90 text-accent-foreground">
                   <Link href="/tools/case-formulation-models/new">
-                    <span>
-                      <PlusCircle className="mr-2 h-4 w-4" /> Criar Novo Modelo
-                    </span>
+                    <PlusCircle className="mr-2 h-4 w-4" /> Criar Novo Modelo
                   </Link>
                 </Button>
             </div>

--- a/src/app/(app)/tools/page.tsx
+++ b/src/app/(app)/tools/page.tsx
@@ -56,9 +56,7 @@ export default function ToolsPage() {
             <CardFooter className="border-t pt-4">
               <Button asChild variant="outline" className="w-full">
                 <Link href={tool.href}>
-                  <span>
-                    Abrir Ferramenta <ChevronRight className="ml-2 h-4 w-4" />
-                  </span>
+                  Abrir Ferramenta <ChevronRight className="ml-2 h-4 w-4" />
                 </Link>
               </Button>
             </CardFooter>

--- a/src/app/(app)/waiting-list/page.tsx
+++ b/src/app/(app)/waiting-list/page.tsx
@@ -36,10 +36,8 @@ export default function WaitingListPage() {
           <h1 className="text-3xl font-headline font-bold">Lista de Espera</h1>
         </div>
         <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
-          <Link href="/waiting-list/add">
-            <span className="inline-flex items-center gap-2">
-              <UserPlus className="mr-2 h-4 w-4" /> Adicionar à Lista de Espera
-            </span>
+          <Link href="/waiting-list/add" className="inline-flex items-center gap-2">
+            <UserPlus className="mr-2 h-4 w-4" /> Adicionar à Lista de Espera
           </Link>
         </Button>
       </div>

--- a/src/app/403/page.tsx
+++ b/src/app/403/page.tsx
@@ -7,9 +7,7 @@ export default function ForbiddenPage() {
       <h1 className="text-4xl font-headline font-bold">403 - Acesso Negado</h1>
       <p className="text-muted-foreground">Você não tem permissão para acessar esta página.</p>
       <Button asChild>
-        <Link href="/login">
-          <span>Ir para Login</span>
-        </Link>
+        <Link href="/login">Ir para Login</Link>
       </Button>
     </div>
   );

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -22,9 +22,7 @@ export default function PrivacyPolicyPage() {
         </p>
       </div>
       <Button asChild className="bg-accent text-accent-foreground hover:bg-accent/90">
-        <Link href="/">
-          <span>Voltar para a Página Inicial</span>
-        </Link>
+        <Link href="/">Voltar para a Página Inicial</Link>
       </Button>
     </div>
   );

--- a/src/app/terms-of-service/page.tsx
+++ b/src/app/terms-of-service/page.tsx
@@ -22,9 +22,7 @@ export default function TermsOfServicePage() {
         </p>
       </div>
       <Button asChild className="bg-accent text-accent-foreground hover:bg-accent/90">
-        <Link href="/">
-          <span>Voltar para a Página Inicial</span>
-        </Link>
+        <Link href="/">Voltar para a Página Inicial</Link>
       </Button>
     </div>
   );

--- a/src/components/assessments/assessment-card.tsx
+++ b/src/components/assessments/assessment-card.tsx
@@ -88,10 +88,8 @@ function AssessmentCardComponent({ assessment, showPatientInfo = false }: Assess
         <div className="flex w-full justify-end gap-2">
           {assessment.status === "Completed" && (
             <Button variant="outline" size="sm" asChild>
-              <Link href={`/inventories-scales/${assessment.id}/results`}>
-                <span>
-                  <BarChart2 className="mr-2 h-4 w-4" /> Ver Resultados
-                </span>
+              <Link href={`/inventories-scales/${assessment.id}/results`} className="inline-flex items-center gap-2">
+                <BarChart2 className="mr-2 h-4 w-4" /> Ver Resultados
               </Link>
             </Button>
           )}

--- a/src/components/notifications/notification-item.tsx
+++ b/src/components/notifications/notification-item.tsx
@@ -80,11 +80,9 @@ function NotificationItemComponent({ notification }: NotificationItemProps) {
                 className="h-7 px-2 text-accent"
                 aria-label="Ver detalhes"
               >
-                <Link href={notification.link}>
-                  <span className="inline-flex items-center gap-2">
-                    <ExternalLink className="h-3.5 w-3.5" />
-                    Ver
-                  </span>
+                <Link href={notification.link} className="inline-flex items-center gap-2">
+                  <ExternalLink className="h-3.5 w-3.5" />
+                  Ver
                 </Link>
               </Button>
             )}

--- a/src/components/patients/patient-list-item.tsx
+++ b/src/components/patients/patient-list-item.tsx
@@ -77,12 +77,10 @@ function PatientListItemComponent({ patient }: PatientListItemProps) {
           </div>
           <div className="flex items-center gap-1 sm:gap-2">
             <Button variant="outline" size="sm" asChild className="h-8 px-2 sm:px-3" aria-label={`Editar perfil de ${patient.name}`}>
-              <Link href={`/patients/${patient.id}/edit`}>
-                <span className="inline-flex items-center gap-2">
-                  <Edit3 className="h-3.5 w-3.5" />
-                  <span className="hidden sm:inline">Editar</span>
-                  <span className="sr-only sm:hidden">Editar perfil de {patient.name}</span>
-                </span>
+              <Link href={`/patients/${patient.id}/edit`} className="inline-flex items-center gap-2">
+                <Edit3 className="h-3.5 w-3.5" />
+                <span className="hidden sm:inline">Editar</span>
+                <span className="sr-only sm:hidden">Editar perfil de {patient.name}</span>
               </Link>
             </Button>
             <AlertDialog>

--- a/src/components/schedule/appointment-calendar.tsx
+++ b/src/components/schedule/appointment-calendar.tsx
@@ -273,31 +273,25 @@ function AppointmentCalendarComponent({ view, currentDate, filters, workingDaysO
           <div className="flex flex-col gap-1.5 p-3 border-t bg-muted/30 rounded-b-lg">
               {appt.isGroupSession && appt.groupId && (
                     <Button size="sm" variant="outline" asChild className="w-full">
-                        <Link href={`/groups/${appt.groupId}`}>
-                            <span className="inline-flex items-center gap-2">
+                        <Link href={`/groups/${appt.groupId}`} className="inline-flex items-center gap-2">
                               <UsersIcon className="h-3.5 w-3.5"/>
                               Ver Detalhes do Grupo
-                            </span>
                         </Link>
                     </Button>
               )}
               {!appt.isGroupSession && appt.patientId && (
                     <Button size="sm" variant="outline" asChild className="w-full">
-                        <Link href={`/patients/${appt.patientId}?tab=notes&date=${format(dayDate, "yyyy-MM-dd")}`}>
-                            <span className="inline-flex items-center gap-2">
+                        <Link href={`/patients/${appt.patientId}?tab=notes&date=${format(dayDate, "yyyy-MM-dd")}`} className="inline-flex items-center gap-2">
                               <FileText className="h-3.5 w-3.5"/>
                               Iniciar Anotação
-                            </span>
                         </Link>
                     </Button>
               )}
               <div className="flex gap-2 w-full">
                     <Button size="sm" variant="outline" asChild className="flex-1">
-                      <Link href={appt.isGroupSession ? `/groups/edit/${appt.groupId}` : `/schedule/edit/${appt.id}`}>
-                        <span className="inline-flex items-center gap-2">
+                      <Link href={appt.isGroupSession ? `/groups/edit/${appt.groupId}` : `/schedule/edit/${appt.id}`} className="inline-flex items-center gap-2">
                           <Edit className="h-3.5 w-3.5"/>
                           {appt.isGroupSession ? "Gerenciar Grupo" : "Editar"}
-                        </span>
                       </Link>
                     </Button>
                   {!appt.isGroupSession && (

--- a/src/components/tasks/task-item.tsx
+++ b/src/components/tasks/task-item.tsx
@@ -116,11 +116,9 @@ function TaskItemComponent({ task }: TaskItemProps) {
           )}
           {task.patientId && (
             <Button variant="link" size="sm" className="p-0 h-auto text-accent text-xs" asChild>
-              <Link href={`/patients/${task.patientId}`}>
-                <span className="inline-flex items-center gap-2">
-                  <LinkIcon className="h-3.5 w-3.5" />
-                  Ver Paciente Relacionado
-                </span>
+              <Link href={`/patients/${task.patientId}`} className="inline-flex items-center gap-2">
+                <LinkIcon className="h-3.5 w-3.5" />
+                Ver Paciente Relacionado
               </Link>
             </Button>
           )}
@@ -129,11 +127,9 @@ function TaskItemComponent({ task }: TaskItemProps) {
 
       <CardFooter className="p-3 border-t flex justify-end gap-1.5">
           <Button variant="outline" size="sm" asChild>
-            <Link href={`/tasks/edit/${task.id}`}>
-              <span className="inline-flex items-center gap-2">
-                <Edit className="h-3.5 w-3.5" />
-                Editar
-              </span>
+            <Link href={`/tasks/edit/${task.id}`} className="inline-flex items-center gap-2">
+              <Edit className="h-3.5 w-3.5" />
+              Editar
             </Link>
           </Button>
           <AlertDialog>


### PR DESCRIPTION
## Summary
- remove unnecessary wrapper spans so Buttons with `asChild` render the intended child elements directly

## Testing
- `npm test` *(fails: Jest não encontrado)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853941f02f08324ab8980ede6b297fe