### PR TITLE
Add fallback when children are missing

### DIFF
--- a/src/app/(app)/dashboard/layout.tsx
+++ b/src/app/(app)/dashboard/layout.tsx
@@ -117,7 +117,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
         </Tabs>
       )}
       <main className="flex-1 overflow-auto p-4 sm:px-6 sm:py-0 md:gap-8 mt-4">
-        {children}
+        {children || <div>Conteúdo não disponível</div>}
       </main>
     </div>
   );

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -103,8 +103,8 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
           </div>
           <UserNav />
         </header>
-        <main className="flex-1 p-4 md:p-6 lg:p-8 pt-12 md:pt-6 lg:pt-8"> 
-          {children}
+        <main className="flex-1 p-4 md:p-6 lg:p-8 pt-12 md:pt-6 lg:pt-8">
+          {children || <div>Conteúdo não disponível</div>}
         </main>
         <footer className="p-4 text-center text-xs text-muted-foreground border-t border-border">
           Desenvolvido por Bruno Henrique Cordeiro

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,8 +31,8 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <CustomThemeInitializer /> 
-          {children}
+          <CustomThemeInitializer />
+          {children || <div>Conteúdo não disponível</div>}
           <Toaster />
         </ThemeProvider>
       </body>

--- a/src/components/auth/WithRole.tsx
+++ b/src/components/auth/WithRole.tsx
@@ -6,7 +6,7 @@ import type { UserRole } from '@/types';
 
 interface WithRoleProps {
   role: UserRole | UserRole[];
-  children: ReactNode;
+  children?: ReactNode;
   fallback?: ReactNode; // Optional fallback UI if role doesn't match
 }
 
@@ -24,7 +24,7 @@ export function WithRole({ role, children, fallback = null }: WithRoleProps) {
 
   const rolesToCheck = Array.isArray(role) ? role : [role];
   if (rolesToCheck.includes(user.role)) {
-    return <>{children}</>;
+    return <>{children ?? fallback}</>;
   }
 
   return <>{fallback}</>;

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -38,7 +38,7 @@ const ChartContainer = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div"> & {
     config: ChartConfig
-    children: React.ComponentProps<
+    children?: React.ComponentProps<
       typeof RechartsPrimitive.ResponsiveContainer
     >["children"]
   }
@@ -59,7 +59,7 @@ const ChartContainer = React.forwardRef<
       >
         <ChartStyle id={chartId} config={config} />
         <RechartsPrimitive.ResponsiveContainer>
-          {children}
+          {children || <div>Sem dados disponíveis</div>}
         </RechartsPrimitive.ResponsiveContainer>
       </div>
     </ChartContext.Provider>

--- a/src/components/ui/dashboard/ChartContainer.tsx
+++ b/src/components/ui/dashboard/ChartContainer.tsx
@@ -7,7 +7,7 @@ import type { ReactNode } from "react";
 interface ChartContainerProps {
   title: string;
   description?: string;
-  children: ReactNode;
+  children?: ReactNode;
   className?: string;
   footer?: ReactNode;
 }
@@ -20,7 +20,7 @@ export function ChartContainer({ title, description, children, className, footer
         {description && <CardDescription>{description}</CardDescription>}
       </CardHeader>
       <CardContent>
-        {children}
+        {children || <div>Nenhum conteúdo disponível</div>}
       </CardContent>
       {footer && <div className="p-6 pt-0">{footer}</div>}
     </Card>


### PR DESCRIPTION
## Summary
- provide fallback rendering in RootLayout, AppLayout, DashboardLayout
- make `children` optional in `WithRole`, `ChartContainer`, and chart wrapper

## Testing
- `npm run lint`
- `npm test` *(fails: FetchError request to Firestore emulator)*

------
https://chatgpt.com/codex/tasks/task_e_6853bea81f848324a87dd0332f2ab97f