### PR TITLE
Add PropTypes validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "next": "15.3.3",
         "next-themes": "^0.3.0",
         "patch-package": "^8.0.0",
+        "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-d3-cloud": "^1.0.6",
         "react-day-picker": "^8.10.1",
@@ -12512,6 +12513,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "next": "15.3.3",
     "next-themes": "^0.3.0",
     "patch-package": "^8.0.0",
+    "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-d3-cloud": "^1.0.6",
     "react-day-picker": "^8.10.1",

--- a/src/app/(app)/dashboard/layout.tsx
+++ b/src/app/(app)/dashboard/layout.tsx
@@ -10,6 +10,7 @@ import { cn } from '@/lib/utils';
 import { LayoutDashboard, UserCircle, Activity, TrendingUp, ShieldAlert } from 'lucide-react'; 
 import type { UserRole } from '@/types';
 import { Button } from '@/components/ui/button'; // Import Button
+import PropTypes from 'prop-types';
 
 interface TabConfig {
   value: string;
@@ -122,3 +123,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
     </div>
   );
 }
+
+DashboardLayout.propTypes = {
+  children: PropTypes.element.isRequired,
+};

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -17,7 +17,8 @@ import {
   SidebarTrigger,
 } from "@/components/ui/sidebar";
 import { Button } from '@/components/ui/button';
-import { Moon, Sun } from 'lucide-react'; 
+import { Moon, Sun } from 'lucide-react';
+import PropTypes from 'prop-types';
 import { useTheme } from 'next-themes'; 
 import { FloatingChatButton } from '@/features/chat/components/FloatingChatButton';
 import { SimulatedNotificationManager } from '@/features/notifications/components/SimulatedNotificationManager';
@@ -115,3 +116,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
     </SidebarProvider>
   );
 }
+
+AppLayout.propTypes = {
+  children: PropTypes.element.isRequired,
+};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from 'next';
 import './globals.css';
 import { Toaster } from "@/components/ui/toaster";
-import { ThemeProvider } from "next-themes"; 
+import { ThemeProvider } from "next-themes";
+import PropTypes from 'prop-types';
 import { CustomThemeInitializer } from '@/components/layout/CustomThemeInitializer'; // Importado
 
 export const metadata: Metadata = {
@@ -39,3 +40,7 @@ export default function RootLayout({
     </html>
   );
 }
+
+RootLayout.propTypes = {
+  children: PropTypes.element.isRequired,
+};

--- a/src/components/auth/WithRole.tsx
+++ b/src/components/auth/WithRole.tsx
@@ -1,6 +1,7 @@
 
 "use client";
 import type { ReactNode } from 'react';
+import PropTypes from 'prop-types';
 import { useAuth } from '@/hooks/useAuth';
 import type { UserRole } from '@/types';
 
@@ -29,3 +30,7 @@ export function WithRole({ role, children, fallback = null }: WithRoleProps) {
 
   return <>{fallback}</>;
 }
+
+WithRole.propTypes = {
+  children: PropTypes.element.isRequired,
+};

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -5,6 +5,7 @@ import * as AccordionPrimitive from "@radix-ui/react-accordion"
 import { ChevronDown } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import PropTypes from 'prop-types';
 
 const Accordion = AccordionPrimitive.Root
 
@@ -39,6 +40,9 @@ const AccordionTrigger = React.forwardRef<
   </AccordionPrimitive.Header>
 ))
 AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName
+AccordionTrigger.propTypes = {
+  children: PropTypes.element.isRequired,
+};
 
 const AccordionContent = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Content>,
@@ -54,5 +58,8 @@ const AccordionContent = React.forwardRef<
 ))
 
 AccordionContent.displayName = AccordionPrimitive.Content.displayName
+AccordionContent.propTypes = {
+  children: PropTypes.element.isRequired,
+};
 
 export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react"
 import * as RechartsPrimitive from "recharts"
+import PropTypes from 'prop-types';
 
 import { cn } from "@/lib/utils"
 
@@ -66,6 +67,9 @@ const ChartContainer = React.forwardRef<
   )
 })
 ChartContainer.displayName = "Chart"
+ChartContainer.propTypes = {
+  children: PropTypes.element.isRequired,
+};
 
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
   const colorConfig = Object.entries(config).filter(

--- a/src/components/ui/dashboard/ChartContainer.tsx
+++ b/src/components/ui/dashboard/ChartContainer.tsx
@@ -3,6 +3,7 @@
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import type { ReactNode } from "react";
+import PropTypes from 'prop-types';
 
 interface ChartContainerProps {
   title: string;
@@ -26,3 +27,7 @@ export function ChartContainer({ title, description, children, className, footer
     </Card>
   );
 }
+
+ChartContainer.propTypes = {
+  children: PropTypes.element.isRequired,
+};

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
+import PropTypes from 'prop-types';
 import { X } from "lucide-react"
 
 import { cn } from "@/lib/utils"
@@ -52,6 +53,9 @@ const DialogContent = React.forwardRef<
   </DialogPortal>
 ))
 DialogContent.displayName = DialogPrimitive.Content.displayName
+DialogContent.propTypes = {
+  children: PropTypes.element.isRequired,
+};
 
 const DialogHeader = ({
   className,

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -5,6 +5,7 @@ import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import { Check, ChevronRight, Circle } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import PropTypes from 'prop-types';
 
 const DropdownMenu = DropdownMenuPrimitive.Root
 
@@ -39,6 +40,9 @@ const DropdownMenuSubTrigger = React.forwardRef<
 ))
 DropdownMenuSubTrigger.displayName =
   DropdownMenuPrimitive.SubTrigger.displayName
+DropdownMenuSubTrigger.propTypes = {
+  children: PropTypes.element.isRequired,
+};
 
 const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
@@ -115,6 +119,9 @@ const DropdownMenuCheckboxItem = React.forwardRef<
 ))
 DropdownMenuCheckboxItem.displayName =
   DropdownMenuPrimitive.CheckboxItem.displayName
+DropdownMenuCheckboxItem.propTypes = {
+  children: PropTypes.element.isRequired,
+};
 
 const DropdownMenuRadioItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
@@ -137,6 +144,9 @@ const DropdownMenuRadioItem = React.forwardRef<
   </DropdownMenuPrimitive.RadioItem>
 ))
 DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName
+DropdownMenuRadioItem.propTypes = {
+  children: PropTypes.element.isRequired,
+};
 
 const DropdownMenuLabel = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Label>,

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -14,6 +14,7 @@ import {
 
 import { cn } from "@/lib/utils"
 import { Label } from "@/components/ui/label"
+import PropTypes from 'prop-types';
 
 const Form = FormProvider
 
@@ -165,6 +166,9 @@ const FormMessage = React.forwardRef<
   )
 })
 FormMessage.displayName = "FormMessage"
+FormMessage.propTypes = {
+  children: PropTypes.element.isRequired,
+};
 
 export {
   useFormField,

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -5,6 +5,7 @@ import * as MenubarPrimitive from "@radix-ui/react-menubar"
 import { Check, ChevronRight, Circle } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import PropTypes from 'prop-types';
 
 function MenubarMenu({
   ...props
@@ -86,6 +87,9 @@ const MenubarSubTrigger = React.forwardRef<
   </MenubarPrimitive.SubTrigger>
 ))
 MenubarSubTrigger.displayName = MenubarPrimitive.SubTrigger.displayName
+MenubarSubTrigger.propTypes = {
+  children: PropTypes.element.isRequired,
+};
 
 const MenubarSubContent = React.forwardRef<
   React.ElementRef<typeof MenubarPrimitive.SubContent>,
@@ -167,6 +171,9 @@ const MenubarCheckboxItem = React.forwardRef<
   </MenubarPrimitive.CheckboxItem>
 ))
 MenubarCheckboxItem.displayName = MenubarPrimitive.CheckboxItem.displayName
+MenubarCheckboxItem.propTypes = {
+  children: PropTypes.element.isRequired,
+};
 
 const MenubarRadioItem = React.forwardRef<
   React.ElementRef<typeof MenubarPrimitive.RadioItem>,
@@ -189,6 +196,9 @@ const MenubarRadioItem = React.forwardRef<
   </MenubarPrimitive.RadioItem>
 ))
 MenubarRadioItem.displayName = MenubarPrimitive.RadioItem.displayName
+MenubarRadioItem.propTypes = {
+  children: PropTypes.element.isRequired,
+};
 
 const MenubarLabel = React.forwardRef<
   React.ElementRef<typeof MenubarPrimitive.Label>,

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
 
 import { cn } from "@/lib/utils"
+import PropTypes from 'prop-types';
 
 const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
@@ -22,6 +23,9 @@ const ScrollArea = React.forwardRef<
   </ScrollAreaPrimitive.Root>
 ))
 ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
+ScrollArea.propTypes = {
+  children: PropTypes.element.isRequired,
+};
 
 const ScrollBar = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -5,6 +5,7 @@ import * as SelectPrimitive from "@radix-ui/react-select"
 import { Check, ChevronDown, ChevronUp } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import PropTypes from 'prop-types';
 
 const Select = SelectPrimitive.Root
 
@@ -31,6 +32,9 @@ const SelectTrigger = React.forwardRef<
   </SelectPrimitive.Trigger>
 ))
 SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+SelectTrigger.propTypes = {
+  children: PropTypes.element.isRequired,
+};
 
 const SelectScrollUpButton = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
@@ -98,6 +102,9 @@ const SelectContent = React.forwardRef<
   </SelectPrimitive.Portal>
 ))
 SelectContent.displayName = SelectPrimitive.Content.displayName
+SelectContent.propTypes = {
+  children: PropTypes.element.isRequired,
+};
 
 const SelectLabel = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Label>,
@@ -133,6 +140,9 @@ const SelectItem = React.forwardRef<
   </SelectPrimitive.Item>
 ))
 SelectItem.displayName = SelectPrimitive.Item.displayName
+SelectItem.propTypes = {
+  children: PropTypes.element.isRequired,
+};
 
 const SelectSeparator = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Separator>,

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -6,6 +6,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { X } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import PropTypes from 'prop-types';
 
 const Sheet = SheetPrimitive.Root
 
@@ -73,6 +74,9 @@ const SheetContent = React.forwardRef<
   </SheetPortal>
 ))
 SheetContent.displayName = SheetPrimitive.Content.displayName
+SheetContent.propTypes = {
+  children: PropTypes.element.isRequired,
+};
 
 const SheetHeader = ({
   className,

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -13,6 +13,7 @@ import { Input } from "@/components/ui/input"
 import { Separator } from "@/components/ui/separator"
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet" // Added SheetHeader, SheetTitle
 import { Skeleton } from "@/components/ui/skeleton"
+import PropTypes from 'prop-types';
 import {
   Tooltip,
   TooltipContent,
@@ -156,6 +157,9 @@ const SidebarProvider = React.forwardRef<
   }
 )
 SidebarProvider.displayName = "SidebarProvider"
+SidebarProvider.propTypes = {
+  children: PropTypes.element.isRequired,
+};
 
 const Sidebar = React.forwardRef<
   HTMLDivElement,


### PR DESCRIPTION
## Summary
- ensure `prop-types` dependency is installed
- validate that custom component children are single elements

## Testing
- `npm test` *(fails: FetchError contacting emulator)*

------
https://chatgpt.com/codex/tasks/task_e_6853bea160488324bec5d9c4080239e8