### PR TITLE
Fix multi-child asChild usage

### DIFF
--- a/src/app/(app)/dashboard/layout.tsx
+++ b/src/app/(app)/dashboard/layout.tsx
@@ -111,7 +111,14 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
         <Tabs value={activeTabValue} className="w-full px-4 sm:px-6">
             <TabsList className="grid w-full grid-cols-1 gap-1.5 sm:grid-cols-2 md:grid-cols-4 md:max-w-2xl">
             {visibleTabs.map((tab) => (
-                <TabsTrigger key={tab.value} value={tab.value} asChild className="font-body"><Link href={tab.href} className="flex items-center gap-2"><tab.icon className="h-4 w-4" /><span className="truncate">{tab.label}</span></Link></TabsTrigger>
+                <TabsTrigger key={tab.value} value={tab.value} asChild className="font-body">
+                  <Link href={tab.href}>
+                    <span className="inline-flex items-center gap-2">
+                      <tab.icon className="h-4 w-4" />
+                      <span className="truncate">{tab.label}</span>
+                    </span>
+                  </Link>
+                </TabsTrigger>
             ))}
             </TabsList>
         </Tabs>

--- a/src/app/(app)/dashboard/my-panel/page.tsx
+++ b/src/app/(app)/dashboard/my-panel/page.tsx
@@ -238,7 +238,13 @@ export default function MyPanelPage() {
                         Enviada em: {format(parseISO(assessment.createdAt), "dd/MM/yyyy", { locale: ptBR })}
                       </p>
                     </div>
-                    <Button variant="outline" size="sm" asChild><Link href={`/patients/${assessment.patientId}`}>Ver Paciente <ExternalLink className="ml-2 h-3 w-3" /></Link></Button>
+                    <Button variant="outline" size="sm" asChild>
+                      <Link href={`/patients/${assessment.patientId}`}>
+                        <span className="inline-flex items-center gap-2">
+                          Ver Paciente <ExternalLink className="h-3 w-3" />
+                        </span>
+                      </Link>
+                    </Button>
                   </div>
                 ))}
               </div>

--- a/src/components/assessments/AssessmentCreator.tsx
+++ b/src/components/assessments/AssessmentCreator.tsx
@@ -166,7 +166,13 @@ export function AssessmentCreator({ onSave, existingAssessment, onCancel }: Asse
           <div className="flex items-center gap-2">
             <Input type="text" value={currentFormLink} readOnly className="bg-background"/>
             <Button type="button" variant="outline" size="sm" onClick={() => navigator.clipboard.writeText(window.location.origin + currentFormLink)}>Copiar Link</Button>
-            <Button asChild variant="secondary" size="sm"><Link href={currentFormLink} target="_blank">Abrir Link <ExternalLink className="ml-2 h-3 w-3" /></Link></Button>
+            <Button asChild variant="secondary" size="sm">
+              <Link href={currentFormLink} target="_blank">
+                <span className="inline-flex items-center gap-2">
+                  Abrir Link <ExternalLink className="h-3 w-3" />
+                </span>
+              </Link>
+            </Button>
           </div>
            <p className="text-xs text-muted-foreground">Salve a avaliação para gerar ou atualizar o link. O link será "enviado" ao paciente (simulado).</p>
         </div>

--- a/src/components/assessments/AssessmentResultsTable.tsx
+++ b/src/components/assessments/AssessmentResultsTable.tsx
@@ -141,11 +141,25 @@ export const AssessmentResultsTable = React.memo(function AssessmentResultsTable
                   </TableCell>
                   <TableCell className="text-right">
                     <DropdownMenu>
-                      <DropdownMenuTrigger asChild><Button variant="ghost" className="h-8 w-8 p-0"><span className="sr-only">Abrir menu</span><MoreHorizontal className="h-4 w-4" /></Button></DropdownMenuTrigger>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="ghost" className="h-8 w-8 p-0">
+                          <span className="inline-flex items-center gap-2">
+                            <span className="sr-only">Abrir menu</span>
+                            <MoreHorizontal className="h-4 w-4" />
+                          </span>
+                        </Button>
+                      </DropdownMenuTrigger>
                       <DropdownMenuContent align="end">
                         <DropdownMenuLabel>Ações</DropdownMenuLabel>
                          {assessment.formLink && assessment.formLink !== '#' && (
-                          <DropdownMenuItem asChild><Link href={assessment.formLink} target="_blank" rel="noopener noreferrer"><ExternalLink className="mr-2 h-4 w-4" /> Abrir Link do Formulário</Link></DropdownMenuItem>
+                          <DropdownMenuItem asChild>
+                            <Link href={assessment.formLink} target="_blank" rel="noopener noreferrer">
+                              <span className="inline-flex items-center gap-2">
+                                <ExternalLink className="h-4 w-4" />
+                                <span>Abrir Link do Formulário</span>
+                              </span>
+                            </Link>
+                          </DropdownMenuItem>
                         )}
                         <DropdownMenuItem onClick={() => onEdit(assessment)}>
                           <Edit className="mr-2 h-4 w-4" /> Editar Detalhes

--- a/src/components/documents/DocumentManager.tsx
+++ b/src/components/documents/DocumentManager.tsx
@@ -69,10 +69,24 @@ const DocumentTable = React.memo(({ docs, onDelete }: { docs: DocumentResource[]
               <TableCell className="hidden md:table-cell">{format(parseISO(doc.uploadedAt), "dd/MM/yyyy HH:mm", { locale: ptBR })}</TableCell>
               <TableCell className="text-right">
                 <DropdownMenu>
-                  <DropdownMenuTrigger asChild><Button variant="ghost" className="h-8 w-8 p-0"><span className="sr-only">Abrir menu</span><MoreHorizontal className="h-4 w-4" /></Button></DropdownMenuTrigger>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" className="h-8 w-8 p-0">
+                      <span className="inline-flex items-center gap-2">
+                        <span className="sr-only">Abrir menu</span>
+                        <MoreHorizontal className="h-4 w-4" />
+                      </span>
+                    </Button>
+                  </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
                     <DropdownMenuLabel>Ações</DropdownMenuLabel>
-                    <DropdownMenuItem asChild><a href={doc.url} download={doc.name} target="_blank" rel="noopener noreferrer"><Download className="mr-2 h-4 w-4" /> Download</a></DropdownMenuItem>
+                    <DropdownMenuItem asChild>
+                      <a href={doc.url} download={doc.name} target="_blank" rel="noopener noreferrer">
+                        <span className="inline-flex items-center gap-2">
+                          <Download className="h-4 w-4" />
+                          <span>Download</span>
+                        </span>
+                      </a>
+                    </DropdownMenuItem>
                     <DropdownMenuSeparator />
                     <DropdownMenuItem onClick={() => onDelete(doc.id)} className="text-destructive focus:text-destructive focus:bg-destructive/10">
                       <Trash2 className="mr-2 h-4 w-4" /> Excluir

--- a/src/components/features/assessments/AssessmentResultsTable.tsx
+++ b/src/components/features/assessments/AssessmentResultsTable.tsx
@@ -67,11 +67,25 @@ export function AssessmentResultsTable({ assessments, onEdit, onDelete }: Assess
                 </TableCell>
                 <TableCell className="text-right">
                   <DropdownMenu>
-                    <DropdownMenuTrigger asChild><Button variant="ghost" className="h-8 w-8 p-0"><span className="sr-only">Abrir menu</span><MoreHorizontal className="h-4 w-4" /></Button></DropdownMenuTrigger>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" className="h-8 w-8 p-0">
+                        <span className="inline-flex items-center gap-2">
+                          <span className="sr-only">Abrir menu</span>
+                          <MoreHorizontal className="h-4 w-4" />
+                        </span>
+                      </Button>
+                    </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
                       <DropdownMenuLabel>Ações</DropdownMenuLabel>
                        {assessment.formLink && (
-                        <DropdownMenuItem asChild><a href={assessment.formLink} target="_blank" rel="noopener noreferrer"><ExternalLink className="mr-2 h-4 w-4" /> Ver Link</a></DropdownMenuItem>
+                        <DropdownMenuItem asChild>
+                          <a href={assessment.formLink} target="_blank" rel="noopener noreferrer">
+                            <span className="inline-flex items-center gap-2">
+                              <ExternalLink className="h-4 w-4" />
+                              <span>Ver Link</span>
+                            </span>
+                          </a>
+                        </DropdownMenuItem>
                       )}
                       <DropdownMenuItem onClick={() => onEdit(assessment)}>
                         <Edit className="mr-2 h-4 w-4" /> Editar

--- a/src/components/features/documents/DocumentManager.tsx
+++ b/src/components/features/documents/DocumentManager.tsx
@@ -102,10 +102,24 @@ export function DocumentManager({ documents, onUpload, onDelete }: DocumentManag
                     <TableCell className="hidden md:table-cell">{format(parseISO(doc.uploadedAt), "dd/MM/yyyy HH:mm", { locale: ptBR })}</TableCell>
                     <TableCell className="text-right">
                       <DropdownMenu>
-                        <DropdownMenuTrigger asChild><Button variant="ghost" className="h-8 w-8 p-0"><span className="sr-only">Abrir menu</span><MoreHorizontal className="h-4 w-4" /></Button></DropdownMenuTrigger>
+                        <DropdownMenuTrigger asChild>
+                          <Button variant="ghost" className="h-8 w-8 p-0">
+                            <span className="inline-flex items-center gap-2">
+                              <span className="sr-only">Abrir menu</span>
+                              <MoreHorizontal className="h-4 w-4" />
+                            </span>
+                          </Button>
+                        </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
                           <DropdownMenuLabel>Ações</DropdownMenuLabel>
-                          <DropdownMenuItem asChild><a href={doc.url} download={doc.name} target="_blank" rel="noopener noreferrer"><Download className="mr-2 h-4 w-4" /> Download</a></DropdownMenuItem>
+                          <DropdownMenuItem asChild>
+                            <a href={doc.url} download={doc.name} target="_blank" rel="noopener noreferrer">
+                              <span className="inline-flex items-center gap-2">
+                                <Download className="h-4 w-4" />
+                                <span>Download</span>
+                              </span>
+                            </a>
+                          </DropdownMenuItem>
                           <DropdownMenuSeparator />
                           <DropdownMenuItem onClick={() => onDelete(doc.id)} className="text-destructive focus:text-destructive focus:bg-destructive/10">
                             <Trash2 className="mr-2 h-4 w-4" /> Excluir

--- a/src/components/features/patients/PatientListTable.tsx
+++ b/src/components/features/patients/PatientListTable.tsx
@@ -55,7 +55,14 @@ export function PatientListTable({ patients, onEditPatient, onDeletePatient }: P
               </TableCell>
               <TableCell className="text-right">
                 <DropdownMenu>
-                  <DropdownMenuTrigger asChild><Button variant="ghost" className="h-8 w-8 p-0"><span className="sr-only">Abrir menu</span><MoreHorizontal className="h-4 w-4" /></Button></DropdownMenuTrigger>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" className="h-8 w-8 p-0">
+                      <span className="inline-flex items-center gap-2">
+                        <span className="sr-only">Abrir menu</span>
+                        <MoreHorizontal className="h-4 w-4" />
+                      </span>
+                    </Button>
+                  </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
                     <DropdownMenuLabel>Ações</DropdownMenuLabel>
                     <DropdownMenuItem onClick={() => router.push(`/patients/${patient.id}`)}>

--- a/src/components/features/scheduling/SessionFormDialog.tsx
+++ b/src/components/features/scheduling/SessionFormDialog.tsx
@@ -137,13 +137,20 @@ export function SessionFormDialog({ isOpen, onOpenChange, session, onSave }: Ses
           <div>
             <Label htmlFor="sessionDate">Data da Sessão</Label>
             <Popover>
-              <PopoverTrigger asChild><Button
+              <PopoverTrigger asChild>
+                <Button
                   id="sessionDate"
                   variant={"outline"}
                   className="w-full justify-start text-left font-normal"
-                ><CalendarIcon className="mr-2 h-4 w-4" />
-                  {selectedDate ? format(selectedDate, "PPP", { locale: ptBR }) : <span>Escolha uma data</span>}
-                </Button></PopoverTrigger>
+                >
+                  <span className="inline-flex items-center gap-2">
+                    <CalendarIcon className="h-4 w-4" />
+                    {selectedDate ? format(selectedDate, "PPP", { locale: ptBR }) : (
+                      <span>Escolha uma data</span>
+                    )}
+                  </span>
+                </Button>
+              </PopoverTrigger>
               <PopoverContent className="w-auto p-0">
                 <Calendar
                   mode="single"

--- a/src/components/layout/UserNav.tsx
+++ b/src/components/layout/UserNav.tsx
@@ -46,13 +46,30 @@ export function UserNav() {
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuGroup>
-          <DropdownMenuItem asChild><Link href="/settings"><UserIconLucide className="mr-2 h-4 w-4" />
-              <span>Perfil</span></Link></DropdownMenuItem>
-          <DropdownMenuItem asChild><Link href="/settings"><Settings className="mr-2 h-4 w-4" />
+          <DropdownMenuItem asChild>
+            <Link href="/settings">
+              <span className="inline-flex items-center gap-2">
+                <UserIconLucide className="h-4 w-4" />
+                <span>Perfil</span>
+              </span>
+            </Link>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild>
+            <Link href="/settings">
+              <span className="inline-flex items-center gap-2">
+                <Settings className="h-4 w-4" />
                 <span>Configurações</span>
-            </Link></DropdownMenuItem>
-          <DropdownMenuItem asChild><Link href="/guide"><BookOpenText className="mr-2 h-4 w-4" />
-              <span>Guia de Uso</span></Link></DropdownMenuItem>
+              </span>
+            </Link>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild>
+            <Link href="/guide">
+              <span className="inline-flex items-center gap-2">
+                <BookOpenText className="h-4 w-4" />
+                <span>Guia de Uso</span>
+              </span>
+            </Link>
+          </DropdownMenuItem>
         </DropdownMenuGroup>
         <DropdownMenuSeparator />
         <DropdownMenuItem onClick={logout}>

--- a/src/components/patients/PatientListTable.tsx
+++ b/src/components/patients/PatientListTable.tsx
@@ -59,7 +59,14 @@ export const PatientListTable = React.memo(function PatientListTable({ patients,
               </TableCell>
               <TableCell className="text-right">
                 <DropdownMenu>
-                  <DropdownMenuTrigger asChild><Button variant="ghost" className="h-8 w-8 p-0"><span className="sr-only">Abrir menu</span><MoreHorizontal className="h-4 w-4" /></Button></DropdownMenuTrigger>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" className="h-8 w-8 p-0">
+                    <span className="inline-flex items-center gap-2">
+                      <span className="sr-only">Abrir menu</span>
+                      <MoreHorizontal className="h-4 w-4" />
+                    </span>
+                  </Button>
+                </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
                     <DropdownMenuLabel>Ações</DropdownMenuLabel>
                     <DropdownMenuItem onClick={() => router.push(`/patients/${patient.id}`)}>

--- a/src/components/scheduling/SessionFormDialog.tsx
+++ b/src/components/scheduling/SessionFormDialog.tsx
@@ -143,13 +143,20 @@ export function SessionFormDialog({ isOpen, onOpenChange, session, onSave }: Ses
           <div>
             <Label htmlFor="sessionDate">Data da Sessão</Label>
             <Popover>
-              <PopoverTrigger asChild><Button
+              <PopoverTrigger asChild>
+                <Button
                   id="sessionDate"
                   variant={"outline"}
                   className="w-full justify-start text-left font-normal"
-                ><CalendarIcon className="mr-2 h-4 w-4" />
-                  {selectedDate ? format(selectedDate, "PPP", { locale: ptBR }) : <span>Escolha uma data</span>}
-                </Button></PopoverTrigger>
+                >
+                  <span className="inline-flex items-center gap-2">
+                    <CalendarIcon className="h-4 w-4" />
+                    {selectedDate ? format(selectedDate, "PPP", { locale: ptBR }) : (
+                      <span>Escolha uma data</span>
+                    )}
+                  </span>
+                </Button>
+              </PopoverTrigger>
               <PopoverContent className="w-auto p-0">
                 <Calendar
                   mode="single"

--- a/src/components/ui/date-picker-with-range.tsx
+++ b/src/components/ui/date-picker-with-range.tsx
@@ -44,19 +44,21 @@ export function DatePickerWithRange({
               !date && "text-muted-foreground"
             )}
           >
-            <CalendarIcon className="mr-2 h-4 w-4" />
-            {date?.from ? (
-              date.to ? (
-                <>
-                  {format(date.from, "dd/MM/yy", { locale: ptBR })} -{" "}
-                  {format(date.to, "dd/MM/yy", { locale: ptBR })}
-                </>
+            <span className="inline-flex items-center gap-2">
+              <CalendarIcon className="h-4 w-4" />
+              {date?.from ? (
+                date.to ? (
+                  <>
+                    {format(date.from, "dd/MM/yy", { locale: ptBR })} -{" "}
+                    {format(date.to, "dd/MM/yy", { locale: ptBR })}
+                  </>
               ) : (
                 format(date.from, "dd/MM/yy", { locale: ptBR })
               )
-            ) : (
-              <span>{placeholder}</span>
-            )}
+              ) : (
+                <span>{placeholder}</span>
+              )}
+            </span>
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-auto p-0" align="start">

--- a/src/features/assessments/components/AssessmentCreator.tsx
+++ b/src/features/assessments/components/AssessmentCreator.tsx
@@ -163,7 +163,13 @@ export function AssessmentCreator({ onSave, existingAssessment, onCancel }: Asse
           <div className="flex items-center gap-2">
             <Input type="text" value={currentFormLink} readOnly className="bg-background"/>
             <Button type="button" variant="outline" size="sm" onClick={() => navigator.clipboard.writeText(window.location.origin + currentFormLink)}>Copiar Link</Button>
-            <Button asChild variant="secondary" size="sm"><Link href={currentFormLink} target="_blank">Abrir Link <ExternalLink className="ml-2 h-3 w-3" /></Link></Button>
+            <Button asChild variant="secondary" size="sm">
+              <Link href={currentFormLink} target="_blank">
+                <span className="inline-flex items-center gap-2">
+                  Abrir Link <ExternalLink className="h-3 w-3" />
+                </span>
+              </Link>
+            </Button>
           </div>
            <p className="text-xs text-muted-foreground">Salve a avaliação para gerar ou atualizar o link. O link será "enviado" ao paciente (simulado).</p>
         </div>

--- a/src/features/assessments/components/AssessmentResultsTable.tsx
+++ b/src/features/assessments/components/AssessmentResultsTable.tsx
@@ -141,11 +141,25 @@ export const AssessmentResultsTable = React.memo(function AssessmentResultsTable
                   </TableCell>
                   <TableCell className="text-right">
                     <DropdownMenu>
-                      <DropdownMenuTrigger asChild><Button variant="ghost" className="h-8 w-8 p-0"><span className="sr-only">Abrir menu</span><MoreHorizontal className="h-4 w-4" /></Button></DropdownMenuTrigger>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="ghost" className="h-8 w-8 p-0">
+                          <span className="inline-flex items-center gap-2">
+                            <span className="sr-only">Abrir menu</span>
+                            <MoreHorizontal className="h-4 w-4" />
+                          </span>
+                        </Button>
+                      </DropdownMenuTrigger>
                       <DropdownMenuContent align="end">
                         <DropdownMenuLabel>Ações</DropdownMenuLabel>
                          {assessment.formLink && assessment.formLink !== '#' && (
-                          <DropdownMenuItem asChild><Link href={assessment.formLink} target="_blank" rel="noopener noreferrer"><ExternalLink className="mr-2 h-4 w-4" /> Abrir Link do Formulário</Link></DropdownMenuItem>
+                          <DropdownMenuItem asChild>
+                            <Link href={assessment.formLink} target="_blank" rel="noopener noreferrer">
+                              <span className="inline-flex items-center gap-2">
+                                <ExternalLink className="h-4 w-4" />
+                                <span>Abrir Link do Formulário</span>
+                              </span>
+                            </Link>
+                          </DropdownMenuItem>
                         )}
                         <DropdownMenuItem onClick={() => onEdit(assessment)}>
                           <Edit className="mr-2 h-4 w-4" /> Editar Detalhes

--- a/src/features/documents/components/DocumentManager.tsx
+++ b/src/features/documents/components/DocumentManager.tsx
@@ -158,10 +158,24 @@ const DocumentTable = React.memo(({
                   className="hidden"
                 />
                 <DropdownMenu>
-                  <DropdownMenuTrigger asChild><Button variant="ghost" className="h-8 w-8 p-0"><span className="sr-only">Abrir menu</span><MoreHorizontal className="h-4 w-4" /></Button></DropdownMenuTrigger>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" className="h-8 w-8 p-0">
+                      <span className="inline-flex items-center gap-2">
+                        <span className="sr-only">Abrir menu</span>
+                        <MoreHorizontal className="h-4 w-4" />
+                      </span>
+                    </Button>
+                  </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
                     <DropdownMenuLabel>Ações do Documento</DropdownMenuLabel>
-                    <DropdownMenuItem asChild><a href={doc.url} download={doc.name} target="_blank" rel="noopener noreferrer"><Download className="mr-2 h-4 w-4" /> Download Original</a></DropdownMenuItem>
+                    <DropdownMenuItem asChild>
+                      <a href={doc.url} download={doc.name} target="_blank" rel="noopener noreferrer">
+                        <span className="inline-flex items-center gap-2">
+                          <Download className="h-4 w-4" />
+                          <span>Download Original</span>
+                        </span>
+                      </a>
+                    </DropdownMenuItem>
                     <DropdownMenuSeparator />
                     <DropdownMenuLabel>Assinatura GOV.BR (Simulado)</DropdownMenuLabel>
                     {doc.signatureStatus === 'none' && (

--- a/src/features/patients/components/PatientListTable.tsx
+++ b/src/features/patients/components/PatientListTable.tsx
@@ -59,7 +59,14 @@ export const PatientListTable = React.memo(function PatientListTable({ patients,
               </TableCell>
               <TableCell className="text-right">
                 <DropdownMenu>
-                  <DropdownMenuTrigger asChild><Button variant="ghost" className="h-8 w-8 p-0"><span className="sr-only">Abrir menu</span><MoreHorizontal className="h-4 w-4" /></Button></DropdownMenuTrigger>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" className="h-8 w-8 p-0">
+                    <span className="inline-flex items-center gap-2">
+                      <span className="sr-only">Abrir menu</span>
+                      <MoreHorizontal className="h-4 w-4" />
+                    </span>
+                  </Button>
+                </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
                     <DropdownMenuLabel>Ações</DropdownMenuLabel>
                     <DropdownMenuItem onClick={() => router.push(`/patients/${patient.id}`)}>

--- a/src/features/scheduling/components/SessionFormDialog.tsx
+++ b/src/features/scheduling/components/SessionFormDialog.tsx
@@ -143,13 +143,20 @@ export function SessionFormDialog({ isOpen, onOpenChange, session, onSave }: Ses
           <div>
             <Label htmlFor="sessionDate">Data da Sessão</Label>
             <Popover>
-              <PopoverTrigger asChild><Button
+              <PopoverTrigger asChild>
+                <Button
                   id="sessionDate"
                   variant={"outline"}
                   className="w-full justify-start text-left font-normal"
-                ><CalendarIcon className="mr-2 h-4 w-4" />
-                  {selectedDate ? format(selectedDate, "PPP", { locale: ptBR }) : <span>Escolha uma data</span>}
-                </Button></PopoverTrigger>
+                >
+                  <span className="inline-flex items-center gap-2">
+                    <CalendarIcon className="h-4 w-4" />
+                    {selectedDate ? format(selectedDate, "PPP", { locale: ptBR }) : (
+                      <span>Escolha uma data</span>
+                    )}
+                  </span>
+                </Button>
+              </PopoverTrigger>
               <PopoverContent className="w-auto p-0">
                 <Calendar
                   mode="single"

--- a/src/features/scheduling/components/WaitingListTable.tsx
+++ b/src/features/scheduling/components/WaitingListTable.tsx
@@ -107,7 +107,14 @@ export const WaitingListTable: React.FC<WaitingListTableProps> = ({ entries, onS
                 </TableCell>
                 <TableCell className="text-right">
                   <DropdownMenu>
-                    <DropdownMenuTrigger asChild><Button variant="ghost" className="h-8 w-8 p-0"><span className="sr-only">Abrir menu</span><MoreHorizontal className="h-4 w-4" /></Button></DropdownMenuTrigger>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" className="h-8 w-8 p-0">
+                        <span className="inline-flex items-center gap-2">
+                          <span className="sr-only">Abrir menu</span>
+                          <MoreHorizontal className="h-4 w-4" />
+                        </span>
+                      </Button>
+                    </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
                       <DropdownMenuLabel>Ações na Lista</DropdownMenuLabel>
                       {canSchedule && (

--- a/src/features/whatsapp-reminders/components/WhatsAppReminderDialog.tsx
+++ b/src/features/whatsapp-reminders/components/WhatsAppReminderDialog.tsx
@@ -251,7 +251,14 @@ export function WhatsAppReminderDialog({
             {whatsAppUrl ? "Atualizar Link WhatsApp" : "Gerar Link WhatsApp"}
           </Button>
           {whatsAppUrl && (
-            <Button asChild className="w-full sm:w-auto"><a href={whatsAppUrl} target="_blank" rel="noopener noreferrer"><ExternalLink className="mr-2 h-4 w-4" /> Abrir no WhatsApp</a></Button>
+            <Button asChild className="w-full sm:w-auto">
+              <a href={whatsAppUrl} target="_blank" rel="noopener noreferrer">
+                <span className="inline-flex items-center gap-2">
+                  <ExternalLink className="h-4 w-4" />
+                  <span>Abrir no WhatsApp</span>
+                </span>
+              </a>
+            </Button>
           )}
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
## Summary
- wrap multiple children passed to `asChild` elements in a container
- keep layout via `inline-flex` and `gap-2`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853be7504488324a7ab3c28691a05b2