### PR TITLE
Fix dashboard asChild wrappers

### DIFF
--- a/src/app/(app)/dashboard/layout.tsx
+++ b/src/app/(app)/dashboard/layout.tsx
@@ -96,9 +96,9 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
         <h1 className="text-2xl font-headline font-semibold mb-2">Acesso Restrito</h1>
         <p className="text-muted-foreground">Sua função ({user.role}) não tem permissão para acessar nenhuma seção deste painel.</p>
         <p className="text-muted-foreground mt-1">Por favor, contate um administrador se você acredita que isso é um erro.</p>
-         <Link href="/login" passHref>
-            <Button variant="outline" className="mt-6">Voltar para Login</Button>
-        </Link>
+         <Button asChild variant="outline" className="mt-6">
+            <Link href="/login">Voltar para Login</Link>
+         </Button>
       </div>
     );
   }

--- a/src/app/(app)/dashboard/my-panel/page.tsx
+++ b/src/app/(app)/dashboard/my-panel/page.tsx
@@ -121,7 +121,11 @@ export default function MyPanelPage() {
             </CardHeader>
             <CardContent className="text-center">
                 <p className="text-muted-foreground">Esta seção é destinada apenas a psicólogos e administradores.</p>
-                <Button asChild className="mt-4"><Link href="/dashboard">Voltar para Visão Geral</Link></Button>
+                <Button asChild className="mt-4">
+                  <Link href="/dashboard">
+                    <span>Voltar para Visão Geral</span>
+                  </Link>
+                </Button>
             </CardContent>
         </Card>
     );

--- a/src/components/layout/SidebarNav.tsx
+++ b/src/components/layout/SidebarNav.tsx
@@ -87,9 +87,24 @@ export function SidebarNav() {
         };
         
         const menuItemContent = (
-            <SidebarMenuButton asChild isActive={isActive} tooltip={item.label} className={cn("w-full justify-start")}>
-              <Link href={item.href} onClick={item.anchor ? scrollHandler : undefined} target={item.external ? "_blank" : undefined} rel={item.external ? "noopener noreferrer" : undefined}><tab.icon className="mr-2 h-5 w-5 flex-shrink-0" /><span className="truncate font-body">{item.label}</span></Link>
-            </SidebarMenuButton>
+          <SidebarMenuButton
+            asChild
+            isActive={isActive}
+            tooltip={item.label}
+            className={cn("w-full justify-start")}
+          >
+            <Link
+              href={item.href}
+              onClick={item.anchor ? scrollHandler : undefined}
+              target={item.external ? "_blank" : undefined}
+              rel={item.external ? "noopener noreferrer" : undefined}
+            >
+              <span className="inline-flex items-center gap-2">
+                <tab.icon className="h-5 w-5 flex-shrink-0" />
+                <span className="truncate font-body">{item.label}</span>
+              </span>
+            </Link>
+          </SidebarMenuButton>
         );
 
         if (item.roles) {
@@ -110,7 +125,14 @@ export function SidebarNav() {
             isActive={checkIsActive("/admin/metrics", pathname)}
             tooltip="Métricas Admin"
             className={cn("w-full justify-start")}
-          ><Link href="/admin/metrics"><AreaChart className="mr-2 h-5 w-5 flex-shrink-0" /><span className="truncate font-body">Métricas Admin</span></Link></SidebarMenuButton>
+          >
+            <Link href="/admin/metrics">
+              <span className="inline-flex items-center gap-2">
+                <AreaChart className="h-5 w-5 flex-shrink-0" />
+                <span className="truncate font-body">Métricas Admin</span>
+              </span>
+            </Link>
+          </SidebarMenuButton>
         </WithRole>
       </SidebarMenuItem>
     </SidebarMenu>


### PR DESCRIPTION
## Summary
- wrap sidebar nav link contents in a span to avoid multiple children
- fix login button markup in dashboard layout
- ensure button on My Panel page contains single child

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853c592af5083248030b518d8892861