### PR TITLE
Fix dashboard layout children

### DIFF
--- a/src/app/(app)/dashboard/layout.tsx
+++ b/src/app/(app)/dashboard/layout.tsx
@@ -113,11 +113,9 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
             <TabsList className="grid w-full grid-cols-1 gap-1.5 sm:grid-cols-2 md:grid-cols-4 md:max-w-2xl">
             {visibleTabs.map((tab) => (
                 <TabsTrigger key={tab.value} value={tab.value} asChild className="font-body">
-                  <Link href={tab.href}>
-                    <span className="inline-flex items-center gap-2">
-                      <tab.icon className="h-4 w-4" />
-                      <span className="truncate">{tab.label}</span>
-                    </span>
+                  <Link href={tab.href} className="inline-flex items-center gap-2">
+                    <tab.icon className="h-4 w-4" />
+                    <span className="truncate">{tab.label}</span>
                   </Link>
                 </TabsTrigger>
             ))}

--- a/src/app/(app)/dashboard/my-panel/page.tsx
+++ b/src/app/(app)/dashboard/my-panel/page.tsx
@@ -238,13 +238,11 @@ export default function MyPanelPage() {
                         Enviada em: {format(parseISO(assessment.createdAt), "dd/MM/yyyy", { locale: ptBR })}
                       </p>
                     </div>
-                    <Button variant="outline" size="sm" asChild>
-                      <Link href={`/patients/${assessment.patientId}`}>
-                        <span className="inline-flex items-center gap-2">
+                      <Button variant="outline" size="sm" asChild>
+                        <Link href={`/patients/${assessment.patientId}`} className="inline-flex items-center gap-2">
                           Ver Paciente <ExternalLink className="h-3 w-3" />
-                        </span>
-                      </Link>
-                    </Button>
+                        </Link>
+                      </Button>
                   </div>
                 ))}
               </div>

--- a/src/components/layout/SidebarNav.tsx
+++ b/src/components/layout/SidebarNav.tsx
@@ -87,9 +87,7 @@ export function SidebarNav() {
         };
         
         const menuItemContent = (
-            <SidebarMenuButton asChild isActive={isActive} tooltip={item.label} className={cn("w-full justify-start")}>
-              <Link href={item.href} onClick={item.anchor ? scrollHandler : undefined} target={item.external ? "_blank" : undefined} rel={item.external ? "noopener noreferrer" : undefined}><tab.icon className="mr-2 h-5 w-5 flex-shrink-0" /><span className="truncate font-body">{item.label}</span></Link>
-            </SidebarMenuButton>
+            <SidebarMenuButton asChild isActive={isActive} tooltip={item.label} className={cn("w-full justify-start")}> <Link href={item.href} onClick={item.anchor ? scrollHandler : undefined} target={item.external ? "_blank" : undefined} rel={item.external ? "noopener noreferrer" : undefined}><tab.icon className="mr-2 h-5 w-5 flex-shrink-0" /><span className="truncate font-body">{item.label}</span></Link></SidebarMenuButton>
         );
 
         if (item.roles) {

--- a/src/components/layout/UserNav.tsx
+++ b/src/components/layout/UserNav.tsx
@@ -36,8 +36,7 @@ export function UserNav() {
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="ghost" className="relative h-9 w-9 rounded-full">
+      <DropdownMenuTrigger asChild><Button variant="ghost" className="relative h-9 w-9 rounded-full">
           <Avatar className="h-9 w-9">
             <AvatarImage
               src={user.avatarUrl || ""}
@@ -48,8 +47,7 @@ export function UserNav() {
               {user.name ? getInitials(user.name) : <UserCircle />}
             </AvatarFallback>
           </Avatar>
-        </Button>
-      </DropdownMenuTrigger>
+        </Button></DropdownMenuTrigger>
 
       <DropdownMenuContent className="w-56" align="end" forceMount>
         <DropdownMenuLabel className="font-normal">
@@ -69,32 +67,20 @@ export function UserNav() {
         <DropdownMenuSeparator />
 
         <DropdownMenuGroup>
-          <DropdownMenuItem asChild>
-            <Link href="/settings">
-              <span className="inline-flex items-center gap-2">
-                <UserIconLucide className="h-4 w-4" />
-                <span>Perfil</span>
-              </span>
-            </Link>
-          </DropdownMenuItem>
+          <DropdownMenuItem asChild><Link href="/settings" className="inline-flex items-center gap-2">
+              <UserIconLucide className="h-4 w-4" />
+              <span>Perfil</span>
+            </Link></DropdownMenuItem>
 
-          <DropdownMenuItem asChild>
-            <Link href="/settings">
-              <span className="inline-flex items-center gap-2">
-                <Settings className="h-4 w-4" />
-                <span>Configurações</span>
-              </span>
-            </Link>
-          </DropdownMenuItem>
+          <DropdownMenuItem asChild><Link href="/settings" className="inline-flex items-center gap-2">
+              <Settings className="h-4 w-4" />
+              <span>Configurações</span>
+            </Link></DropdownMenuItem>
 
-          <DropdownMenuItem asChild>
-            <Link href="/guide">
-              <span className="inline-flex items-center gap-2">
-                <BookOpenText className="h-4 w-4" />
-                <span>Guia de Uso</span>
-              </span>
-            </Link>
-          </DropdownMenuItem>
+          <DropdownMenuItem asChild><Link href="/guide" className="inline-flex items-center gap-2">
+              <BookOpenText className="h-4 w-4" />
+              <span>Guia de Uso</span>
+            </Link></DropdownMenuItem>
         </DropdownMenuGroup>
 
         <DropdownMenuSeparator />


### PR DESCRIPTION
## Summary
- fix placement of elements inside `TabsTrigger`
- ensure asChild Buttons wrap only one child element
- make UserNav and SidebarNav use single child when `asChild` is set

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: ts errors)*

------
https://chatgpt.com/codex/tasks/task_e_6853c592af5083248030b518d8892861