### PR TITLE
feat(fixar-campos-preferidos-no-prontuario): adicionar funcionalidade de fixar campos

### DIFF
--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -1,0 +1,3 @@
+export const FEATURES = {
+  "fixar-campos-preferidos-no-prontuario": false,
+};

--- a/src/features/fixar-campos-preferidos-no-prontuario/components/PreferencesForm.tsx
+++ b/src/features/fixar-campos-preferidos-no-prontuario/components/PreferencesForm.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useForm, Controller } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { fieldsSchema, Field } from "../schemas";
+
+interface Props {
+  initialFields: Field[];
+  onSave: (fields: Field[]) => void;
+}
+
+export default function PreferencesForm({ initialFields, onSave }: Props) {
+  const { control, handleSubmit, watch, setValue } = useForm<{ fields: Field[] }>(
+    {
+      resolver: zodResolver(fieldsSchema),
+      defaultValues: { fields: initialFields },
+    },
+  );
+
+  const fields = watch("fields");
+
+  const move = (from: number, to: number) => {
+    const updated = [...fields];
+    const [moved] = updated.splice(from, 1);
+    updated.splice(to, 0, moved);
+    setValue("fields", updated);
+  };
+
+  const onSubmit = handleSubmit((data) => onSave(data.fields));
+
+  return (
+    <form onSubmit={onSubmit} role="form">
+      <ul>
+        {fields.map((field, idx) => (
+          <li key={field.id} className="mb-2 flex items-center gap-2">
+            <Controller
+              name={`fields.${idx}.pinned` as const}
+              control={control}
+              render={({ field }) => <input type="checkbox" {...field} />}
+            />
+            <span className="flex-1">{field.label}</span>
+            <button
+              type="button"
+              onClick={() => move(idx, idx - 1)}
+              disabled={idx === 0}
+            >
+              ↑
+            </button>
+            <button
+              type="button"
+              onClick={() => move(idx, idx + 1)}
+              disabled={idx === fields.length - 1}
+            >
+              ↓
+            </button>
+          </li>
+        ))}
+      </ul>
+      <button type="submit">Salvar</button>
+    </form>
+  );
+}

--- a/src/features/fixar-campos-preferidos-no-prontuario/hooks/usePreferredFields.ts
+++ b/src/features/fixar-campos-preferidos-no-prontuario/hooks/usePreferredFields.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Field, fieldsSchema } from "../schemas";
+
+const STORAGE_KEY = "preferredFields";
+
+export function usePreferredFields(defaultFields: Field[]) {
+  const [fields, setFields] = useState<Field[]>(defaultFields);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        const parsed = fieldsSchema.parse(JSON.parse(stored));
+        setFields(parsed);
+      } catch {
+        setFields(defaultFields);
+      }
+    }
+  }, [defaultFields]);
+
+  const save = (newFields: Field[]) => {
+    setFields(newFields);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(newFields));
+  };
+
+  return { fields, save };
+}

--- a/src/features/fixar-campos-preferidos-no-prontuario/pages/Page.tsx
+++ b/src/features/fixar-campos-preferidos-no-prontuario/pages/Page.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+import PreferencesForm from "../components/PreferencesForm";
+import { usePreferredFields } from "../hooks/usePreferredFields";
+import { DEFAULT_FIELDS } from "../schemas";
+
+export default function PreferredFieldsPage() {
+  const { fields, save } = usePreferredFields(DEFAULT_FIELDS);
+  const [editing, setEditing] = useState(false);
+
+  if (editing) {
+    return (
+      <PreferencesForm
+        initialFields={fields}
+        onSave={(f) => {
+          save(f);
+          setEditing(false);
+        }}
+      />
+    );
+  }
+
+  const pinned = fields.filter((f) => f.pinned);
+
+  return (
+    <div>
+      <h1>Campos Fixados</h1>
+      <ul>
+        {pinned.map((f) => (
+          <li key={f.id}>{f.label}</li>
+        ))}
+      </ul>
+      <button onClick={() => setEditing(true)}>Personalizar Visualização</button>
+    </div>
+  );
+}

--- a/src/features/fixar-campos-preferidos-no-prontuario/registry.tsx
+++ b/src/features/fixar-campos-preferidos-no-prontuario/registry.tsx
@@ -1,0 +1,2 @@
+export * from "./hooks/usePreferredFields";
+export { default as PreferredFieldsPage } from "./pages/Page";

--- a/src/features/fixar-campos-preferidos-no-prontuario/schemas.ts
+++ b/src/features/fixar-campos-preferidos-no-prontuario/schemas.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const fieldSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  pinned: z.boolean(),
+});
+
+export type Field = z.infer<typeof fieldSchema>;
+
+export const fieldsSchema = z.array(fieldSchema);
+
+export const DEFAULT_FIELDS: Field[] = [
+  { id: "lastPlan", label: "Plano da Última Sessão", pinned: true },
+  { id: "goals", label: "Objetivos de Tratamento", pinned: true },
+  { id: "alerts", label: "Alertas Clínicos", pinned: true },
+  { id: "history", label: "Histórico Médico", pinned: false },
+  { id: "meds", label: "Medicações", pinned: false },
+];

--- a/src/features/fixar-campos-preferidos-no-prontuario/tests/page.test.tsx
+++ b/src/features/fixar-campos-preferidos-no-prontuario/tests/page.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import Page from "../pages/Page";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("PreferredFieldsPage", () => {
+  it("renders pinned fields", () => {
+    render(<Page />);
+    expect(screen.getByText("Plano da Última Sessão")).toBeInTheDocument();
+  });
+
+  it("opens customization form", () => {
+    render(<Page />);
+    fireEvent.click(screen.getByText("Personalizar Visualização"));
+    expect(screen.getByRole("form")).toBeInTheDocument();
+  });
+});

--- a/src/features/fixar-campos-preferidos-no-prontuario/tests/usePreferredFields.test.tsx
+++ b/src/features/fixar-campos-preferidos-no-prontuario/tests/usePreferredFields.test.tsx
@@ -1,0 +1,29 @@
+import { renderHook, act } from "@testing-library/react";
+import { usePreferredFields } from "../hooks/usePreferredFields";
+import { Field } from "../schemas";
+
+describe("usePreferredFields", () => {
+  const defaults: Field[] = [
+    { id: "a", label: "A", pinned: true },
+    { id: "b", label: "B", pinned: false },
+  ];
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("loads defaults", () => {
+    const { result } = renderHook(() => usePreferredFields(defaults));
+    expect(result.current.fields).toEqual(defaults);
+  });
+
+  it("saves to localStorage", () => {
+    const { result } = renderHook(() => usePreferredFields(defaults));
+    act(() => {
+      result.current.save([{ id: "x", label: "X", pinned: true }]);
+    });
+    expect(JSON.parse(localStorage.getItem("preferredFields") || "null")).toEqual([
+      { id: "x", label: "X", pinned: true },
+    ]);
+  });
+});


### PR DESCRIPTION
## Escopo da feature
Implementa funcionalidade **Fixar Campos Preferidos no Prontuário** de forma isolada em `src/features/fixar-campos-preferidos-no-prontuario`. Inclui schema, hooks, componente de formulário, página demonstrativa e testes.

### Como testar manualmente
1. Instale dependências com `npm install`.
2. Execute `npm run lint` e `npm test` (podem falhar por dependências de ambiente).
3. Importe e utilize `PreferredFieldsPage` onde desejar.

### Habilitar a flag
Arquivo `src/config/features.ts` possui a flag `fixar-campos-preferidos-no-prontuario`. Ajuste para `true` para ativar quando integrar na aplicação.

------
https://chatgpt.com/codex/tasks/task_e_685398ef2b4883248711a59d7ff6bf56