### PR TITLE
Add ESLint rule to prevent invalid asChild usage

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,6 +48,7 @@
       "specialLink": ["hrefLeft", "hrefRight"],
       "aspects": ["invalidHref", "preferButton"]
     }],
-    "local-rules/no-aschild-on-a": "error"
+    "local-rules/no-aschild-on-a": "error",
+    "local-rules/aschild-single-child": "error"
   }
 }

--- a/README.md
+++ b/README.md
@@ -133,5 +133,5 @@ Erros genéricos como **"An unexpected Turbopack error occurred"** costumam esta
 3. Copie `env.example` para `.env.local` e preencha as variáveis necessárias.
 4. Apague a pasta `.next` (cache do Next.js) e tente novamente: `rm -rf .next && npm run dev`.
 5. Observe o log completo gerado pelo `next dev` para identificar possíveis mensagens adicionais de erro.
-6. Se encontrar a mensagem **"React.Children.only expected to receive a single React element child"**, verifique se componentes como `Button`, `FormControl` ou `SidebarMenuButton` (quando usados com `asChild`) recebem **apenas um** elemento React filho. Envolva múltiplos elementos em uma tag `<div>` ou `<span>` caso necessário.
+6. Se encontrar a mensagem **"React.Children.only expected to receive a single React element child"**, verifique se componentes como `Button`, `FormControl` ou `SidebarMenuButton` (quando usados com `asChild`) recebem **apenas um** elemento React filho. Envolva múltiplos elementos em uma tag `<div>` ou `<span>` caso necessário. O projeto inclui uma regra do **ESLint** (`local-rules/aschild-single-child`) que sinaliza esse problema durante o desenvolvimento.
 

--- a/eslint-rules/aschild-single-child.js
+++ b/eslint-rules/aschild-single-child.js
@@ -1,0 +1,63 @@
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: "Ensure components using 'asChild' have a single React element child",
+      recommended: true,
+    },
+    schema: [],
+  },
+  create(context) {
+    function hasAsChildAttr(node) {
+      return (
+        node.openingElement.attributes || []
+      ).some(
+        (attr) =>
+          attr.type === 'JSXAttribute' &&
+          attr.name &&
+          attr.name.name === 'asChild'
+      );
+    }
+
+    return {
+      JSXElement(node) {
+        if (!hasAsChildAttr(node)) return;
+
+        const children = node.children.filter((child) => {
+          return !(child.type === 'JSXText' && child.value.trim() === '');
+        });
+
+        if (children.length !== 1) {
+          context.report({
+            node,
+            message:
+              "Element with 'asChild' must have exactly one child element",
+          });
+          return;
+        }
+
+        const [child] = children;
+
+        if (child.type !== 'JSXElement') {
+          context.report({
+            node: child,
+            message:
+              "Element with 'asChild' must contain a single JSX element child",
+          });
+          return;
+        }
+
+        if (
+          child.openingElement.name.type === 'JSXIdentifier' &&
+          child.openingElement.name.name === 'Fragment'
+        ) {
+          context.report({
+            node: child,
+            message:
+              "Fragment children are not allowed when using 'asChild'",
+          });
+        }
+      },
+    };
+  },
+};

--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -6,4 +6,5 @@
 // are rule names and values are rule definitions.
 module.exports = {
   'no-aschild-on-a': require('./no-aschild-on-a'),
+  'aschild-single-child': require('./aschild-single-child'),
 };


### PR DESCRIPTION
## Summary
- enforce single-child requirement for the `asChild` prop via new ESLint rule
- document the rule in the troubleshooting section

## Testing
- `npm run lint` *(fails: various lint errors)*
- `npm test` *(fails: Firestore emulator connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_685526763dd88324a1719adb26132703