### PR TITLE
Fix typecheck step in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: npm lint
 
       - name: Type check
-        run: npm run type-check
+        run: npm run typecheck
 
       - name: Test
         run: npm test


### PR DESCRIPTION
## Summary
- fix the typecheck script name in CI

## Testing
- `npm run lint` *(fails: 'no-unused-vars' etc.)*
- `npm run typecheck` *(fails to compile TS)*
- `npm test` *(fails: ECONNREFUSED localhost:8083)*

------
https://chatgpt.com/codex/tasks/task_e_6855f9de5d488324be1e222a0180ccc4