### PR TITLE
Add Codex CI setup script

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+# Ensure Node.js 20 is active for firebase-tools compatibility
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+nvm install 20 >/dev/null
+nvm use 20 >/dev/null
+
+# Install dependencies
+npm ci
+
+# Run tests with Firestore emulator
+npx firebase emulators:exec --project=demo-project --only firestore "npx jest --runInBand"


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` to install deps and run tests under Firestore emulator
- load nvm before switching Node version

## Testing
- `npx firebase emulators:exec --project=demo-project --only firestore "npx jest --runInBand"`
- `.codex/setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_6855f82b2a548324ad4c8798396692ff