### PR TITLE
Add Jest test pipeline and husky integration

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run lint || true
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -18,6 +18,13 @@
     "backup": "node scripts/backup.js",
     "prepare": "husky install"
   },
+  "lint-staged": {
+    "src/**/*.{ts,tsx}": [
+      "eslint --fix",
+      "jest --bail --findRelatedTests",
+      "prettier --write"
+    ]
+  },
   "dependencies": {
     "@genkit-ai/googleai": "^1.8.0",
     "@genkit-ai/next": "^1.8.0",

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -1,0 +1,16 @@
+import '@testing-library/jest-dom';
+import './src/tests/__mocks__/test-utils';
+
+declare global {
+  interface Window {
+    ResizeObserver: any;
+  }
+}
+
+if (typeof window.ResizeObserver === 'undefined') {
+  window.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}

--- a/src/__tests__/integration/AppNavigation.test.tsx
+++ b/src/__tests__/integration/AppNavigation.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import DashboardPage from "@/features/dashboard/page";
+import SchedulingPage from "@/features/scheduling/page";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+describe("Navegação entre páginas", () => {
+  it("navega para a página de agendamento ao clicar em link simulado", async () => {
+    userEvent.setup();
+    render(<SchedulingPage />);
+    expect(screen.getByText(/Agendamento/i)).toBeInTheDocument();
+
+    render(<DashboardPage />);
+    expect(screen.getByText(/Dashboard/i)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/integration/AuthContext.test.tsx
+++ b/src/__tests__/integration/AuthContext.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import useAuth from "@/hooks/use-auth";
+
+jest.mock("@/hooks/use-auth", () => ({
+  __esModule: true,
+  default: () => ({
+    user: { uid: "mocked-user", email: "test@example.com" },
+    loading: false,
+  }),
+}));
+
+function AuthComponent() {
+  const { user } = useAuth();
+  return <div>{user?.email}</div>;
+}
+
+describe("AuthContext", () => {
+  it("renderiza email do usuário autenticado", () => {
+    render(<AuthComponent />);
+    expect(screen.getByText("test@example.com")).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/integration/AuthErrorHandling.test.tsx
+++ b/src/__tests__/integration/AuthErrorHandling.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import useAuth from "@/hooks/use-auth";
+
+jest.mock("@/hooks/use-auth", () => ({
+  __esModule: true,
+  default: () => {
+    throw new Error("Firebase Auth Failed");
+  },
+}));
+
+function ErrorBoundaryTest() {
+  try {
+    useAuth();
+    return <div>Autenticado</div>;
+  } catch (e) {
+    return <div>Erro: {(e as Error).message}</div>;
+  }
+}
+
+describe("Erro de Firebase Auth", () => {
+  it("exibe mensagem de erro se auth falhar", () => {
+    render(<ErrorBoundaryTest />);
+    expect(screen.getByText(/Erro: Firebase Auth Failed/i)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/integration/LoadingState.test.tsx
+++ b/src/__tests__/integration/LoadingState.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import useAuth from "@/hooks/use-auth";
+
+jest.mock("@/hooks/use-auth", () => ({
+  __esModule: true,
+  default: () => ({
+    user: null,
+    loading: true,
+  }),
+}));
+
+function LoadingComponent() {
+  const { loading } = useAuth();
+  return <div>{loading ? "Carregando..." : "Carregado"}</div>;
+}
+
+describe("Loading State", () => {
+  it("exibe mensagem de carregamento", () => {
+    render(<LoadingComponent />);
+    expect(screen.getByText("Carregando...")).toBeInTheDocument();
+  });
+});

--- a/src/features/dashboard/__tests__/DashboardPage.test.tsx
+++ b/src/features/dashboard/__tests__/DashboardPage.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from "@testing-library/react";
+import DashboardPage from "../page";
+
+describe("DashboardPage", () => {
+  it("deve exibir os cards principais", () => {
+    render(<DashboardPage />);
+    expect(screen.getByText(/Dashboard/i)).toBeInTheDocument();
+    expect(screen.getByText(/Sessões da Semana/i)).toBeInTheDocument();
+    expect(screen.getByText(/Pacientes Ativos/i)).toBeInTheDocument();
+  });
+});

--- a/src/features/dashboard/page.tsx
+++ b/src/features/dashboard/page.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export default function DashboardPage() {
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <div>Sessões da Semana</div>
+      <div>Pacientes Ativos</div>
+    </div>
+  );
+}

--- a/src/features/notes-ai/__tests__/NotesAIPage.test.tsx
+++ b/src/features/notes-ai/__tests__/NotesAIPage.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from "@testing-library/react";
+import NotesAIPage from "../page";
+
+describe("NotesAIPage", () => {
+  it("renderiza título de notas com IA", () => {
+    render(<NotesAIPage />);
+    expect(screen.getByText(/Notas com IA/i)).toBeInTheDocument();
+  });
+});

--- a/src/features/notes-ai/page.tsx
+++ b/src/features/notes-ai/page.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function NotesAIPage() {
+  return (
+    <div>
+      <h1>Notas com IA</h1>
+    </div>
+  );
+}

--- a/src/features/preview-prontuario/__tests__/PatientPreviewCard.test.tsx
+++ b/src/features/preview-prontuario/__tests__/PatientPreviewCard.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { PatientPreviewCard } from "../components/PatientPreviewCard";
+
+describe("PatientPreviewCard", () => {
+  it("renderiza dados do paciente corretamente", () => {
+    render(
+      <PatientPreviewCard
+        name="João Silva"
+        lastSession="10/06/2025"
+        focus="Ansiedade"
+        tasks={["Respiração diafragmática", "Registro de pensamentos"]}
+      />,
+    );
+    expect(screen.getByText("João Silva")).toBeInTheDocument();
+    expect(screen.getByText(/\u00daltima sessão/i)).toBeInTheDocument();
+    expect(screen.getByText(/Ansiedade/i)).toBeInTheDocument();
+    expect(screen.getByText(/Respiração diafragmática/i)).toBeInTheDocument();
+  });
+});

--- a/src/features/preview-prontuario/components/PatientPreviewCard.tsx
+++ b/src/features/preview-prontuario/components/PatientPreviewCard.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+interface PatientPreviewCardProps {
+  name: string;
+  lastSession: string;
+  focus: string;
+  tasks: string[];
+}
+
+export function PatientPreviewCard({
+  name,
+  lastSession,
+  focus,
+  tasks,
+}: PatientPreviewCardProps) {
+  return (
+    <div>
+      <h2>{name}</h2>
+      <p>Última sessão: {lastSession}</p>
+      <p>{focus}</p>
+      <ul>
+        {tasks.map((t) => (
+          <li key={t}>{t}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/features/scheduling/__tests__/SchedulingPage.test.tsx
+++ b/src/features/scheduling/__tests__/SchedulingPage.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from "@testing-library/react";
+import SchedulingPage from "../page";
+
+describe("SchedulingPage", () => {
+  it("renderiza título de agendamento", () => {
+    render(<SchedulingPage />);
+    expect(screen.getByText(/Agendamento/i)).toBeInTheDocument();
+  });
+});

--- a/src/features/scheduling/page.tsx
+++ b/src/features/scheduling/page.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function SchedulingPage() {
+  return (
+    <div>
+      <h1>Agendamento</h1>
+    </div>
+  );
+}

--- a/src/tests/__mocks__/test-utils.ts
+++ b/src/tests/__mocks__/test-utils.ts
@@ -1,0 +1,27 @@
+export const mockRouter = {
+  push: jest.fn(),
+  replace: jest.fn(),
+  pathname: "/",
+  query: {},
+  asPath: "/",
+};
+
+export const mockAuth = {
+  user: { uid: "mocked-user", email: "test@example.com" },
+  loading: false,
+};
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => mockRouter,
+  usePathname: () => mockRouter.pathname,
+  useSearchParams: () => ({ get: jest.fn() }),
+}));
+
+jest.mock("next/router", () => ({
+  useRouter: () => mockRouter,
+}));
+
+jest.mock("@/hooks/use-auth", () => ({
+  __esModule: true,
+  default: () => mockAuth,
+}));


### PR DESCRIPTION
## Summary
- configure global setupTests with jest-dom and mocks
- add reusable test utils for router and auth mocks
- create feature pages and unit tests for dashboard, scheduling, notes AI, and preview prontuário
- write integration tests for navigation and auth handling
- update husky pre-commit to run lint-staged and add lint-staged config

## Testing
- `npm test` *(fails: Firestore emulator connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68560b27dc7083248db564f1c59d664b