### PR TITLE
Add helper scripts and NPM commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,14 @@
     "test:rules": "firebase emulators:exec --project=demo-project \"npx jest --selectProjects firestore\"",
     "jest": "jest",
     "backup": "node scripts/backup.js",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "start:local": "./scripts/start.sh",
+    "test:all": "./scripts/test.sh",
+    "lint:fix": "./scripts/lint-fix.sh",
+    "dev:clean": "./scripts/clean.sh",
+    "prepare:commit": "./scripts/prepare-commit.sh",
+    "emulator:snapshot": "./scripts/snapshot-emulator.sh",
+    "emulator:reset": "./scripts/reset-emulator.sh"
   },
   "lint-staged": {
     "src/**/*.{ts,tsx}": [

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+rm -rf node_modules .next .jest-cache
+npm cache clean --force
+npm install

--- a/scripts/deploy-dev.sh
+++ b/scripts/deploy-dev.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+firebase deploy --only functions,hosting,firestore --project thalamus-dev

--- a/scripts/generate-types.sh
+++ b/scripts/generate-types.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Este script será implementado em breve com suporte ao Firestore/Zod."

--- a/scripts/lint-fix.sh
+++ b/scripts/lint-fix.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+npx eslint . --fix
+npx prettier --write .

--- a/scripts/prepare-commit.sh
+++ b/scripts/prepare-commit.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+npm run lint
+npm run typecheck
+npm test

--- a/scripts/reset-emulator.sh
+++ b/scripts/reset-emulator.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+rm -rf emulator-data
+firebase emulators:start --only firestore,auth

--- a/scripts/snapshot-emulator.sh
+++ b/scripts/snapshot-emulator.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+mkdir -p emulator-data
+firebase emulators:export ./emulator-data

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+export VOLTA_HOME="$HOME/.volta"
+export PATH="$VOLTA_HOME/bin:$PATH"
+cd ~/studio
+npm ci
+firebase emulators:start --only firestore,auth --import=./emulator-data --export-on-exit &
+sleep 5
+npm run dev

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+npm ci
+npx firebase emulators:exec --only firestore "npm test"


### PR DESCRIPTION
## Summary
- add local dev and helper shell scripts under `scripts`
- expose helper scripts in `package.json` scripts

## Testing
- `npm test` *(fails: Firestore emulator not running)*
- `./scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68562d7cd09c8324acd6b7a42fc3690a