### PR TITLE
Add jest localStorage setup for tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ const createJestConfig = nextJest({
 const webConfig = createJestConfig({
   displayName: 'web',
   testEnvironment: 'jsdom',
-  setupFiles: ['<rootDir>/jest.polyfills.ts'],
+  setupFiles: ['<rootDir>/jest.polyfills.ts', '<rootDir>/tests/setupLocalStorage.ts'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
@@ -27,7 +27,7 @@ const firestoreConfig = {
   displayName: 'firestore',
   preset: 'ts-jest',
   testEnvironment: 'node',
-  setupFiles: ['<rootDir>/jest.polyfills.ts'],
+  setupFiles: ['<rootDir>/jest.polyfills.ts', '<rootDir>/tests/setupLocalStorage.ts'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   testMatch: [
     '<rootDir>/__tests__/**/*.rules.test.ts',

--- a/src/features/fixar-campos-preferidos-no-prontuario/tests/page.test.tsx
+++ b/src/features/fixar-campos-preferidos-no-prontuario/tests/page.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import Page from "../pages/Page";
 
 beforeEach(() => {
-  localStorage.clear();
+  window.localStorage.clear();
 });
 
 describe("PreferredFieldsPage", () => {

--- a/src/features/fixar-campos-preferidos-no-prontuario/tests/usePreferredFields.test.tsx
+++ b/src/features/fixar-campos-preferidos-no-prontuario/tests/usePreferredFields.test.tsx
@@ -9,7 +9,7 @@ describe("usePreferredFields", () => {
   ];
 
   beforeEach(() => {
-    localStorage.clear();
+    window.localStorage.clear();
   });
 
   it("loads defaults", () => {
@@ -22,8 +22,8 @@ describe("usePreferredFields", () => {
     act(() => {
       result.current.save([{ id: "x", label: "X", pinned: true }]);
     });
-    expect(JSON.parse(localStorage.getItem("preferredFields") || "null")).toEqual([
-      { id: "x", label: "X", pinned: true },
-    ]);
+    expect(
+      JSON.parse(window.localStorage.getItem("preferredFields") || "null"),
+    ).toEqual([{ id: "x", label: "X", pinned: true }]);
   });
 });

--- a/tests/setupLocalStorage.ts
+++ b/tests/setupLocalStorage.ts
@@ -1,0 +1,23 @@
+if (typeof global.localStorage === 'undefined') {
+  class LocalStorageMock {
+    private store: Record<string, string> = {};
+
+    clear() {
+      this.store = {};
+    }
+
+    getItem(key: string) {
+      return Object.prototype.hasOwnProperty.call(this.store, key) ? this.store[key] : null;
+    }
+
+    setItem(key: string, value: string) {
+      this.store[key] = value;
+    }
+
+    removeItem(key: string) {
+      delete this.store[key];
+    }
+  }
+
+  global.localStorage = new LocalStorageMock() as any;
+}


### PR DESCRIPTION
## Summary
- add a helper to provide `localStorage` for Jest
- register the helper in Jest config
- update preferred field tests to use `window.localStorage`

## Testing
- `npm test --silent` *(fails: connect ECONNREFUSED 127.0.0.1:8083)*

------
https://chatgpt.com/codex/tasks/task_e_68561a43456c83248de5f0a9cad550ae