### PR TITLE
Protect private routes with Firebase auth

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,13 +1,56 @@
 
-import { NextResponse, type NextRequest } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server'
+import { auth as adminAuth } from 'firebase-admin'
 
-export function middleware(request: NextRequest) {
-  // Autenticação desabilitada: permite acesso a todas as rotas.
-  console.debug('Auth is globally disabled in middleware, allowing access to:', request.nextUrl.pathname);
-  return NextResponse.next();
+const PUBLIC_PATHS = ['/login']
+
+function isPublic(pathname: string) {
+  return (
+    PUBLIC_PATHS.includes(pathname) ||
+    pathname.startsWith('/public/') ||
+    pathname.startsWith('/api/public/')
+  )
 }
 
-// Este config corresponde a todas as rotas, exceto as listadas.
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl
+
+  if (isPublic(pathname)) {
+    return NextResponse.next()
+  }
+
+  const authHeader = request.headers.get('authorization')
+  const bearerToken = authHeader?.startsWith('Bearer ')
+    ? authHeader.slice(7)
+    : null
+
+  let authenticated = false
+
+  if (bearerToken) {
+    try {
+      await adminAuth().verifyIdToken(bearerToken)
+      authenticated = true
+    } catch (err) {
+      console.error('Token Firebase inválido', err)
+    }
+  } else {
+    const nextAuthToken =
+      request.cookies.get('next-auth.session-token')?.value ??
+      request.cookies.get('__Secure-next-auth.session-token')?.value
+    if (nextAuthToken) {
+      authenticated = true
+    }
+  }
+
+  if (!authenticated) {
+    const url = request.nextUrl.clone()
+    url.pathname = '/login'
+    return NextResponse.redirect(url)
+  }
+
+  return NextResponse.next()
+}
+
 export const config = {
-  matcher: '/((?!api|_next/static|_next/image|favicon.ico|public).*)',
-};
+  matcher: ['/((?!api|_next|favicon.ico|public).*)'],
+}


### PR DESCRIPTION
## Summary
- enforce authentication in middleware

## Testing
- `npm run test:all` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_685724f037d08324b040dad676f0edde