### PR TITLE
Refactor use-auth to use Firebase

### DIFF
--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -52,7 +52,7 @@ export default function AppHeader() {
           <DropdownMenuTrigger asChild>
             <Button variant="ghost" size="icon" className="rounded-full" aria-label="Menu do usuário">
               <Avatar className="h-8 w-8">
-                <AvatarImage src={user.avatarUrl || "https://placehold.co/100x100.png"} alt={user.displayName || "Usuário"} data-ai-hint="user avatar" />
+                <AvatarImage src={user.photoURL || "https://placehold.co/100x100.png"} alt={user.displayName || "Usuário"} data-ai-hint="user avatar" />
                 <AvatarFallback>
                   <UserCircle className="h-6 w-6" />
                 </AvatarFallback>


### PR DESCRIPTION
## Summary
- integrate Firebase Auth in `use-auth` hook
- update header avatar to use Firebase `photoURL`

## Testing
- `npm run test:all` *(fails: npm ci requires lockfile update)*

------
https://chatgpt.com/codex/tasks/task_e_68572af1c86483248ffd7a42bb8bd63a