### PR TITLE
Adiciona configuração padrão de editor

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+


### PR DESCRIPTION
## Summary
- define `.editorconfig` para uso de charset UTF-8, indentação com 2 espaços e final de linha LF

## Testing
- `npm run test:unit` *(falha: comando vitest não encontrado)*
- `npm run lint` *(falha: dependências ausentes)*

------
https://chatgpt.com/codex/tasks/task_e_68577cd26c108324ba15a82701218590