### PR TITLE
Add Firebase rules testing dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.2.0",
+        "@firebase/rules-unit-testing": "^4.0.1",
         "@next/eslint-plugin-next": "^15.3.4",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
@@ -2083,6 +2084,19 @@
       "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.4.0.tgz",
       "integrity": "sha512-7p3mRE/ldCNYt8fmWMQ/MSGRmXYlJ15Rvs9Rk17t8p0WwZDbeK7eRmoI1tvCPaDzn9Oqh+yD6Lw+sGLsLg4kKg==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/rules-unit-testing": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-4.0.1.tgz",
+      "integrity": "sha512-Vu8iMLP+dO9hCAqUCitWZQdORyM6CxucilRZtleeTZd5bejZmyOiaBPwYm3NOYG6025ac99CEeA+ETmJRxa9zg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "firebase": "^11.0.0"
+      }
     },
     "node_modules/@firebase/storage": {
       "version": "0.13.13",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "zustand": "^5.0.5"
   },
   "devDependencies": {
+    "@eslint/js": "^9.2.0",
+    "@firebase/rules-unit-testing": "^4.0.1",
     "@next/eslint-plugin-next": "^15.3.4",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
@@ -76,9 +78,11 @@
     "autoprefixer": "^10.4.21",
     "eslint": "^9.29.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
+    "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "firebase-tools": "^14.8.0",
+    "globals": "^13.24.0",
     "husky": "^9.1.7",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^30.0.2",
@@ -91,9 +95,6 @@
     "ts-jest": "^29.4.0",
     "tsx": "^4.20.3",
     "typescript": "^5.8.3",
-    "vitest": "^3.2.4",
-    "@eslint/js": "^9.2.0",
-    "eslint-plugin-prettier": "^5.1.3",
-    "globals": "^13.24.0"
+    "vitest": "^3.2.4"
   }
 }


### PR DESCRIPTION
## Summary
- add @firebase/rules-unit-testing as dev dependency

## Testing
- `npm run test:unit` *(fails: connect ECONNREFUSED 127.0.0.1:8083)*

------
https://chatgpt.com/codex/tasks/task_e_68577cc595d08324af7f9ca4d0d27733