### PR TITLE
Add CI script

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+npm run lint
+npm run typecheck
+npm run test:all
+


### PR DESCRIPTION
## Summary
- add a CI helper script to run lint, typecheck and tests

## Testing
- `npm ci`
- `./scripts/ci.sh` *(fails: eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68577cc07cec8324810374a44843b903