### PR TITLE
Fix start script path

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Pasta do projeto (Firebase Studio)
 SCRIPT_DIR="$(dirname "$0")"
-PROJECT_DIR="$SCRIPT_DIR/studio"
+PROJECT_DIR="$SCRIPT_DIR"
 
 # Ativa Volta para usar versoes fixadas
 export VOLTA_HOME="$HOME/.volta"


### PR DESCRIPTION
## Summary
- use current script directory instead of non-existent `studio` folder in `start.sh`

## Testing
- `npm run test:unit` *(fails: Failed to resolve imports)*
- `./start.sh` *(fails: firebase: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68577cd9fae083248289ea49047fe81f