### PR TITLE
Remove unused ALLOWED_DEV_ORIGINS

### DIFF
--- a/env.example
+++ b/env.example
@@ -37,4 +37,3 @@ NEXT_PUBLIC_DISABLE_AUTH="false"
 # NEXT_PUBLIC_GOOGLE_CLIENT_SECRET=""
 # NEXT_PUBLIC_GOOGLE_REDIRECT_URI=""
 # NEXT_PUBLIC_FIREBASE_VAPID_KEY="" # Para Firebase Cloud Messaging (Web Push)
-\n# Domínios permitidos para desenvolvimento\nALLOWED_DEV_ORIGINS=""


### PR DESCRIPTION
## Summary
- remove `ALLOWED_DEV_ORIGINS` from env.example since it's unused

## Testing
- `npm run test:all` *(fails: Script "./scripts/run-tests.sh" exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68577ce2e2608324afd0363ea6cefb61