### PR TITLE
Remove duplicate colors config

### DIFF
--- a/src/components/clinical-formulation/FormulationMap.tsx
+++ b/src/components/clinical-formulation/FormulationMap.tsx
@@ -22,7 +22,8 @@ import ReactFlow, {
 } from 'reactflow';
 import 'reactflow/dist/style.css';
 
-import { useClinicalStore, allCardColors } from '@/stores/clinicalStore';
+import { useClinicalStore } from '@/stores/clinicalStore';
+import { clinicalCardColors } from '../../../tailwind.config';
 import ABCCardNode from './ABCCardNode';
 import SchemaNode from './SchemaNode';
 import NodeContextMenu from './NodeContextMenu';
@@ -174,7 +175,7 @@ const FormulationMap: React.FC = () => {
         formulationGuideAnswers: initialFormulationGuideQuestions.reduce((acc, q) => { acc[q.id] = false; return acc; }, {} as Record<string, boolean>),
         quickNotes: [],
         cardGroups: [],
-        activeColorFilters: [...allCardColors],
+        activeColorFilters: cardColorDisplayOptions.map(opt => opt.value),
         showSchemaNodes: true,
         emotionIntensityFilter: 0,
       };
@@ -287,7 +288,8 @@ const FormulationMap: React.FC = () => {
       nodesToDisplay = nodesToDisplay.filter(node => node.type !== 'schemaNode');
     }
 
-    const allColorsActive = activeTabData.activeColorFilters.length === allCardColors.length;
+    const allColorsActive =
+      activeTabData.activeColorFilters.length === cardColorDisplayOptions.length;
     if (!allColorsActive && activeTabData.activeColorFilters.length > 0) { 
       nodesToDisplay = nodesToDisplay.filter(node => {
         if (node.type === 'abcCard' && isABCCardData(node.data)) {

--- a/src/stores/clinicalStore.ts
+++ b/src/stores/clinicalStore.ts
@@ -11,21 +11,6 @@ import type {
 type PanelType = "hexaflex" | "chain" | "matrix" | null;
 
 // Define the colors for each card type
-export const allCardColors: Record<string, string> = {
-  abc: "#FFC0CB", // Pink
-  chain: "#ADD8E6", // LightBlue
-  matrix: "#90EE90", // LightGreen
-  generic: "#D3D3D3", // LightGrey
-  schema: "#FFB347", // LightOrange
-  note: "#B19CD9", // LightPurple
-  assessment: "#FFFF99", // LightYellow
-  goal: "#A7C7E7", // LightSteelBlue
-  intervention: "#C3B1E1", // Plum
-  resource: "#ACE1AF", // MintGreen
-  session: "#FFDDAF", // Peach
-  problem: "#FF6961", // LightCoral
-  solution: "#77DD77", // PastelGreen
-};
 
 interface ClinicalState {
   tabs: ClinicalTab[];

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,21 @@
 import type { Config } from "tailwindcss"
 
+export const clinicalCardColors = {
+  abc: "#FFC0CB",
+  chain: "#ADD8E6",
+  matrix: "#90EE90",
+  generic: "#D3D3D3",
+  schema: "#FFB347",
+  note: "#B19CD9",
+  assessment: "#FFFF99",
+  goal: "#A7C7E7",
+  intervention: "#C3B1E1",
+  resource: "#ACE1AF",
+  session: "#FFDDAF",
+  problem: "#FF6961",
+  solution: "#77DD77",
+} as const
+
 const config = {
   darkMode: ["class"],
   content: [


### PR DESCRIPTION
## Summary
- centralize card colors in `tailwind.config.ts`
- update `FormulationMap` to use new color source
- drop unused `allCardColors` constant

## Testing
- `npm ci`
- `npm run lint` *(fails: prettier/prettier, no-undef, etc.)*
- `npm run typecheck` *(fails: missing modules, type errors)*
- `./run-tests.sh` *(fails: `npx jest --runInBand` exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68579002eda88324800f76746914f465