### PR TITLE
Atualiza versão do Node.js no CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js 18
+      - name: Setup Node.js 20.11.0
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20.11.0
 
       - name: Cache node_modules
         uses: actions/cache@v3


### PR DESCRIPTION
## Summary
- atualiza a versão do Node.js para 20.11.0 no workflow `ci.yml`

## Testing
- `npm ci` *(falhou? check logs)*
- `npm run lint` *(falhou com erros de lint)*
- `npm run typecheck` *(falhou com erros de tipos)*
- `./run-tests.sh` *(falhou ao rodar jest)*

------
https://chatgpt.com/codex/tasks/task_e_685796f892e8832485a814464e0670a2