### PR TITLE
Fix Codex workflow

### DIFF
--- a/.codex.yaml
+++ b/.codex.yaml
@@ -8,4 +8,5 @@ tasks:
   - run: npm ci
   - run: npm run lint
   - run: npm run typecheck
+  - run: npm run build
   - run: ./run-tests.sh


### PR DESCRIPTION
## Summary
- add `npm run build` step in `.codex.yaml`

## Testing
- `npm ci`
- `npm run lint` *(fails: prettier/no-undef issues)*
- `npm run typecheck` *(fails: cannot find module declarations)*
- `npm run build` *(fails: next config must use .js or .mjs)*
- `./run-tests.sh` *(fails: jest exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_685797041d4883249130ee7010ac1846