### PR TITLE
Fix docs for removed Cloud Functions

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -2,9 +2,8 @@
 
 This directory contains Firebase Cloud Functions for PsiGuard.
 
-* `scheduleReminders` runs hourly and checks appointments and tasks that occur within the next 24 hours. Any matching records trigger push notifications to users via Firebase Cloud Messaging.
-* `onCreateUser` triggers when a new Firebase Authentication user is created and assigns a custom claim `role`. Emails under the `@psiguard.app` domain become `Admin`; all others default to `Psychologist`.
-* `setUserRole` listens for user creation, reads the `role` field stored in `users/{uid}` (set during signup) and applies it via `admin.auth().setCustomUserClaims`.
+- `scheduleReminders` runs hourly and checks appointments and tasks that occur within the next 24 hours. Any matching records trigger push notifications to users via Firebase Cloud Messaging.
+- The previous triggers `onCreateUser` and `setUserRole` were removed because authentication is currently disabled in the project.
 
 ## Deploy
 


### PR DESCRIPTION
## Summary
- update functions README to match the current codebase

## Testing
- `npm ci`
- `npx jest --runInBand` *(fails: Configuring Next.js via 'next.config.ts' is not supported)*


------
https://chatgpt.com/codex/tasks/task_e_68579ac118108324a15d876234a4e55b