### PR TITLE
Update Node setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js 20.11.0
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20.11.0


### PR DESCRIPTION
## Summary
- set up Node 20.11.0 without embedding the version in the step name

## Testing
- `./run-tests.sh` *(fails: missing network access for npm)*

------
https://chatgpt.com/codex/tasks/task_e_68579aaacefc832486449c8a6da16244