### PR TITLE
Add thalamus domain to allowedDevOrigins

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -20,6 +20,7 @@ const nextConfig = {
   allowedDevOrigins: [
     'https://9003-firebase-studio-1749490048431.cluster-duylic2g3fbzerqpzxxbw6helm.cloudworkstations.dev',
     'https://3000-firebase-studio-1749490048431.cluster-duylic2g3fbzerqpzxxbw6helm.cloudworkstations.dev',
+    'https://3000-firebase-thalamus-1749490048431.cluster-duylic2g3fbzerqpzxxbw6helm.cloudworkstations.dev',
   ],
 };
 


### PR DESCRIPTION
## Summary
- allow the thalamus Cloud Workstations domain during development

## Testing
- `bash run-tests.sh` *(fails: Script "npx jest --runInBand" exited with code 1)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6857a287468c8324bac8640c921c9092