### PR TITLE
Implement token verification API

### DIFF
--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -1,19 +1,34 @@
-import { NextRequest } from 'next/server'
-import { middleware } from '../src/middleware'
-import { auth } from 'firebase-admin'
+import { NextRequest } from 'next/server';
+import { middleware } from '../src/middleware';
 
-jest.mock('firebase-admin', () => ({ auth: jest.fn(() => ({ verifyIdToken: jest.fn() })) }))
+beforeEach(() => {
+  globalThis.fetch = jest.fn();
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
 
 describe('middleware', () => {
   it('permite rota pública', async () => {
-    const req = new NextRequest('http://localhost/login')
-    const res = await middleware(req)
-    expect(res.status).toBe(200)
-  })
+    const req = new NextRequest('http://localhost/login');
+    const res = await middleware(req);
+    expect(res.status).toBe(200);
+  });
 
   it('redireciona sem token', async () => {
-    const req = new NextRequest('http://localhost/protected')
-    const res = await middleware(req)
-    expect(res.headers.get('location')).toContain('/login')
-  })
-})
+    const req = new NextRequest('http://localhost/protected');
+    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: false });
+    const res = await middleware(req);
+    expect(res.headers.get('location')).toContain('/login');
+  });
+
+  it('permite acesso com token válido', async () => {
+    const req = new NextRequest('http://localhost/protected', {
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true });
+    const res = await middleware(req);
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/api/verifyToken/route.ts
+++ b/src/app/api/verifyToken/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { auth as adminAuth } from 'firebase-admin';
+
+export async function POST(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  const token = authHeader?.split('Bearer ')[1];
+
+  if (!token) {
+    return NextResponse.json({ error: 'Token ausente' }, { status: 401 });
+  }
+
+  try {
+    await adminAuth().verifyIdToken(token);
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    globalThis.console.error('Falha ao verificar token', err);
+    return NextResponse.json({ error: 'Token inválido' }, { status: 401 });
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,34 +1,38 @@
+import { type NextRequest, NextResponse } from 'next/server';
 
-import { type NextRequest, NextResponse } from 'next/server'
-import { auth as adminAuth } from 'firebase-admin'
-
-const PUBLIC_PATHS = ['/login']
+const PUBLIC_PATHS = ['/login'];
 
 function isPublic(pathname: string) {
-  return PUBLIC_PATHS.includes(pathname)
+  return PUBLIC_PATHS.includes(pathname);
 }
 
 export async function middleware(request: NextRequest) {
-  const { pathname } = request.nextUrl
+  const { pathname } = request.nextUrl;
 
   if (isPublic(pathname)) {
-    return NextResponse.next()
+    return NextResponse.next();
   }
 
-  const authHeader = request.headers.get('authorization')
-  const token = authHeader?.split('Bearer ')[1]
+  const authHeader = request.headers.get('authorization');
+  const token = authHeader?.split('Bearer ')[1];
 
   if (token) {
     try {
-      await adminAuth().verifyIdToken(token)
-      return NextResponse.next()
+      const verifyUrl = new globalThis.URL('/api/verifyToken', request.url);
+      const res = await globalThis.fetch(verifyUrl.toString(), {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        return NextResponse.next();
+      }
     } catch (err) {
-      console.error('Token Firebase inválido', err)
+      globalThis.console.error('Erro ao verificar token', err);
     }
   }
-  return NextResponse.redirect(new URL('/login', request.url))
+  return NextResponse.redirect(new globalThis.URL('/login', request.url));
 }
 
 export const config = {
-  matcher: ['/((?!api/public|_next|favicon.ico|login).*)'],
-}
+  matcher: ['/((?!api/verifyToken|api/public|_next|favicon.ico|login).*)'],
+};


### PR DESCRIPTION
## Summary
- add verifyToken API route
- update middleware to call token verification API
- adjust middleware tests for new flow

## Testing
- `npm run lint` *(fails: 7335 errors)*
- `npm run typecheck` *(fails: 17 errors)*
- `npm run test:all` *(fails to run jest)*

------
https://chatgpt.com/codex/tasks/task_e_6857a284d25c83249fb79e1b4bc0e402