### PR TITLE
Add client-side encryption for session notes

### DIFF
--- a/__tests__/crypto-utils.test.ts
+++ b/__tests__/crypto-utils.test.ts
@@ -1,6 +1,7 @@
 import { encrypt, decrypt } from '../src/lib/crypto-utils'
+import { deriveKeyFromPassword } from '../src/lib/encryptionKey'
 
-const key = Buffer.alloc(32, 0)
+const key = deriveKeyFromPassword('senha-teste')
 
 describe('crypto-utils', () => {
   it('encrypts and decrypts a string', () => {

--- a/__tests__/prontuario-flow.test.ts
+++ b/__tests__/prontuario-flow.test.ts
@@ -1,0 +1,42 @@
+import { initializeTestEnvironment, assertSucceeds } from '@firebase/rules-unit-testing'
+import { readFileSync } from 'fs'
+import { Firestore } from 'firebase/firestore'
+import { saveSessionNote, getSessionNotes } from '../src/services/prontuarioService'
+import { setEncryptionPassword } from '../src/lib/encryptionKey'
+
+let testEnv: Awaited<ReturnType<typeof initializeTestEnvironment>>
+
+beforeAll(async () => {
+  const hostPort = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8083'
+  const [host, portStr] = hostPort.split(':')
+  const port = parseInt(portStr, 10)
+
+  testEnv = await initializeTestEnvironment({
+    projectId: 'demo-project',
+    firestore: {
+      host,
+      port,
+      rules: readFileSync('firestore.rules', 'utf8'),
+    },
+  })
+})
+
+afterAll(async () => {
+  if (testEnv) await testEnv.cleanup()
+})
+
+function getAuthedDb(auth: { sub: string; role: string }): Firestore {
+  return testEnv.authenticatedContext(auth.sub, auth).firestore()
+}
+
+test('save and retrieve encrypted session note', async () => {
+  const auth = { sub: 'therapist1', role: 'Psychologist' }
+  const db = getAuthedDb(auth)
+  setEncryptionPassword('senha-teste')
+
+  const noteId = await saveSessionNote(db, 'patient1', 'conteudo sigiloso')
+  expect(noteId).toBeDefined()
+
+  const notes = await getSessionNotes(db, 'patient1')
+  expect(notes[0].summary).toBe('conteudo sigiloso')
+})

--- a/docs/backend_requirements.md
+++ b/docs/backend_requirements.md
@@ -27,6 +27,11 @@ Este documento lista funcionalidades e regras de negócio que precisam ser imple
     *   **Escopo da Criptografia:**
         *   Identificar claramente quais campos de dados são considerados sensíveis e requerem criptografia. Campos não sensíveis (ex: nome do paciente para listagem, datas de agendamento) podem permanecer não criptografados para permitir buscas e indexação.
         *   Notas de sessão, diagnósticos, resumos de tratamento, e respostas detalhadas de avaliações são candidatos primários para criptografia.
+        *   **Campos obrigatoriamente cifrados:**
+            - `sessionSummary` e demais anotações clínicas.
+            - `diagnosis` e `treatmentPlan` registrados no prontuário.
+            - `assessmentResponses` armazenadas para avaliações psicológicas.
+            - Qualquer "histórico médico" com informações sensíveis do paciente.
     *   **Impacto na Funcionalidade:**
         *   **Busca:** Dados criptografados no Firestore não podem ser pesquisados diretamente pelo conteúdo (ex: buscar todas as notas que mencionam "ansiedade"). Estratégias de metadados não criptografados ou técnicas de "searchable encryption" (altamente complexas) podem ser necessárias para funcionalidades de busca limitadas.
         *   **Compartilhamento de Dados:** Se os dados precisarem ser compartilhados entre profissionais, o gerenciamento e compartilhamento seguro das chaves de descriptografia se torna um desafio adicional.

--- a/firestore.rules
+++ b/firestore.rules
@@ -170,6 +170,22 @@ service cloud.firestore {
       allow create, delete: if isAdmin();
     }
 
+    function validSessionNote() {
+      return request.resource.data.keys().hasOnly(['patientId','data','createdAt']) &&
+             request.resource.data.patientId is string &&
+             request.resource.data.createdAt is timestamp &&
+             request.resource.data.data.keys().hasOnly(['ciphertext','iv','tag']) &&
+             request.resource.data.data.ciphertext is string &&
+             request.resource.data.data.iv is string &&
+             request.resource.data.data.tag is string;
+    }
+
+    match /sessionNotes/{noteId} {
+      allow read: if isStaff();
+      allow create: if isStaff() && validSessionNote();
+      allow update, delete: if false;
+    }
+
     // Catch-all
     match /{document=**} {
       allow read, write: if false;

--- a/src/lib/encryptionKey.ts
+++ b/src/lib/encryptionKey.ts
@@ -1,0 +1,16 @@
+import crypto from 'crypto'
+
+let key: Buffer | null = null
+
+export function deriveKeyFromPassword(password: string, salt = 'psiguard'): Buffer {
+  return crypto.pbkdf2Sync(password, salt, 100000, 32, 'sha256')
+}
+
+export function setEncryptionPassword(password: string): void {
+  key = deriveKeyFromPassword(password)
+}
+
+export function getEncryptionKey(): Buffer {
+  if (!key) throw new Error('Chave de criptografia não definida')
+  return key
+}

--- a/src/lib/firestore-collections.ts
+++ b/src/lib/firestore-collections.ts
@@ -8,6 +8,7 @@ export const FIRESTORE_COLLECTIONS = {
   NOTIFICATIONS: 'notifications',
   FCM_TOKENS: 'fcmTokens',
   MESSAGES: 'messages',
+  SESSION_NOTES: 'sessionNotes',
 } as const;
 
 export type FirestoreCollectionKeys = keyof typeof FIRESTORE_COLLECTIONS;


### PR DESCRIPTION
## Summary
- document which fields must be encrypted
- manage encryption password in `src/lib/encryptionKey`
- add SESSION_NOTES collection constant
- encrypt/decrypt session notes in `prontuarioService`
- allow session note access in Firestore rules
- test crypto utils using derived key
- add session note encryption flow test

## Testing
- `./run-tests.sh` *(fails: ENVs block emulator download)*

------
https://chatgpt.com/codex/tasks/task_e_68583b3a69588324a048e4081acf61a7