### PR TITLE
Restore patient pages with Firestore integration

### DIFF
--- a/src/__tests__/integration/PatientsPage.test.tsx
+++ b/src/__tests__/integration/PatientsPage.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import PatientsPage from '@/app/(app)/patients/page';
+import { fetchPatients } from '@/services/patientService';
+import { checkUserRole } from '@/services/authRole';
+
+jest.mock('@/services/patientService');
+jest.mock('@/services/authRole');
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: jest.fn() }),
+}));
+
+const mockedPatients = [
+  { id: '1', name: 'Alice', email: 'a@b.com' },
+  { id: '2', name: 'Bob', email: 'b@c.com' },
+];
+
+describe('PatientsPage', () => {
+  it('exibe pacientes obtidos do Firestore', async () => {
+    (fetchPatients as jest.Mock).mockResolvedValue(mockedPatients);
+    (checkUserRole as jest.Mock).mockResolvedValue(true);
+    render(<PatientsPage />);
+    expect(await screen.findByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+  });
+});

--- a/src/app/(app)/patients/[id]/page.tsx
+++ b/src/app/(app)/patients/[id]/page.tsx
@@ -1,25 +1,44 @@
 "use client";
 
-import React from "react";
-import { ArrowLeft } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import Link from "next/link";
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import type { Patient } from '@/types/patient';
+import { fetchPatient } from '@/services/patientService';
 
-export default function PatientDetailPagePlaceholder() {
-  // This is a drastically simplified version for debugging Turbopack errors.
-  // The original complex component has been temporarily replaced.
+export default function PatientDetailPage() {
+  const params = useParams();
+  const id = Array.isArray(params.id) ? params.id[0] : params.id;
+  const [patient, setPatient] = useState<Patient | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        if (id) {
+          const data = await fetchPatient(id);
+          setPatient(data);
+        }
+      } catch (err) {
+        console.error('Falha ao carregar paciente', err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [id]);
+
+  if (loading) return <p className="p-4">Carregando...</p>;
+  if (!patient) return <p className="p-4">Paciente nao encontrado</p>;
+
   return (
-    <div className="flex flex-col items-center justify-center min-h-[calc(100vh-200px)] text-center p-4">
-      <h1 className="text-2xl font-bold mb-4">
-        Patient Detail Page (Simplified)
-      </h1>
-      <p className="text-muted-foreground mb-6">
-        This page is temporarily simplified to help diagnose a Turbopack error.
-      </p>
-      <Button variant="outline" asChild>
-        <Link href="/patients" className="inline-flex items-center gap-2">
-          <ArrowLeft className="mr-2 h-4 w-4" />
-          Voltar para Pacientes
+    <div className="space-y-4 p-4">
+      <h1 className="text-2xl font-bold">{patient.name}</h1>
+      <p className="text-muted-foreground">{patient.email}</p>
+      <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
+        <Link href={`/clinical-map/${patient.id}/initialTab`}>
+          Abrir Prontuário
         </Link>
       </Button>
     </div>

--- a/src/app/(app)/patients/page.tsx
+++ b/src/app/(app)/patients/page.tsx
@@ -7,7 +7,8 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { UserPlus, Search, Filter, Users } from "lucide-react";
 import Link from "next/link";
 import PatientListItem from "@/components/patients/patient-list-item";
-import { mockPatients, type MockPatient } from "@/mocks/patients";
+import type { Patient } from "@/types/patient";
+import { fetchPatients } from "@/services/patientService";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { checkUserRole } from "@/services/authRole";
@@ -17,7 +18,7 @@ import { APP_ROUTES } from "@/lib/routes";
 
 export default function PatientsPage() {
   const router = useRouter();
-  const [patients, setPatients] = useState<MockPatient[]>([]);
+  const [patients, setPatients] = useState<Patient[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -25,12 +26,17 @@ export default function PatientsPage() {
       if (!ok) router.replace("/");
     });
 
-    const timer = setTimeout(() => {
-      setPatients(mockPatients);
-      setLoading(false);
-    }, 600);
-
-    return () => clearTimeout(timer);
+    async function load() {
+      try {
+        const list = await fetchPatients();
+        setPatients(list);
+      } catch (err) {
+        console.error('Falha ao carregar pacientes', err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
   }, [router]);
 
   return (

--- a/src/services/patientService.ts
+++ b/src/services/patientService.ts
@@ -1,0 +1,32 @@
+import { collection, getDocs, query, where, doc, getDoc } from 'firebase/firestore';
+import { db, auth } from '@/lib/firebase';
+import type { Patient } from '@/types/patient';
+import { FIRESTORE_COLLECTIONS } from '@/lib/firestore-collections';
+
+export async function fetchPatients(): Promise<Patient[]> {
+  try {
+    const uid = auth.currentUser?.uid;
+    if (!uid) return [];
+    const q = query(
+      collection(db, FIRESTORE_COLLECTIONS.PATIENTS),
+      where('ownerId', '==', uid)
+    );
+    const snap = await getDocs(q);
+    return snap.docs.map((d) => ({ id: d.id, ...(d.data() as Omit<Patient, 'id'>) }));
+  } catch (err) {
+    console.error('Erro ao buscar pacientes', err);
+    return [];
+  }
+}
+
+export async function fetchPatient(id: string): Promise<Patient | null> {
+  try {
+    const ref = doc(db, FIRESTORE_COLLECTIONS.PATIENTS, id);
+    const snap = await getDoc(ref);
+    if (!snap.exists()) return null;
+    return { id: snap.id, ...(snap.data() as Omit<Patient, 'id'>) };
+  } catch (err) {
+    console.error('Erro ao buscar paciente', err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add `patientService` for Firestore queries
- fetch patients list on PatientsPage
- fetch patient details and open clinical map
- add render test for PatientsPage

## Testing
- `npm run test:all` *(fails: Script exited unsuccessfully)*

------
https://chatgpt.com/codex/tasks/task_e_68583b584fd48324a6a272e2047f1ef0