### PR TITLE
Add Firestore notifications utilities

### DIFF
--- a/src/app/(app)/notifications/page.tsx
+++ b/src/app/(app)/notifications/page.tsx
@@ -12,7 +12,7 @@ import { registerFcmToken } from "@/services/notificationService";
 import { auth } from "@/lib/firebase"; // Caminho corrigido aqui
 
 export default function NotificationsPage() {
-  const { notifications } = useNotifications();
+  const { notifications, markAsRead, dismiss, markAllAsRead, clearRead } = useNotifications();
   const unreadCount = notifications.filter(n => !n.read).length;
 
   React.useEffect(() => {
@@ -40,7 +40,7 @@ export default function NotificationsPage() {
           )}
         </div>
         <div className="flex gap-2">
-            <Button variant="outline">
+            <Button variant="outline" onClick={markAllAsRead}>
                 <CheckCheck className="mr-2 h-4 w-4" /> Marcar Todas como Lidas
             </Button>
             <Button variant="outline" asChild>
@@ -61,7 +61,12 @@ export default function NotificationsPage() {
           {notifications.length > 0 ? (
             <div className="space-y-3 divide-y divide-zinc-200">
               {notifications.map(notification => (
-                <NotificationItem key={notification.id} notification={notification} />
+                <NotificationItem
+                  key={notification.id}
+                  notification={notification}
+                  onMarkRead={markAsRead}
+                  onDismiss={dismiss}
+                />
               ))}
             </div>
           ) : (
@@ -74,7 +79,11 @@ export default function NotificationsPage() {
         </CardContent>
         {notifications.length > 0 && (
             <CardFooter className="border-t pt-4 flex justify-end">
-                <Button variant="destructive" className="bg-destructive/90 hover:bg-destructive text-destructive-foreground">
+                <Button
+                    variant="destructive"
+                    className="bg-destructive/90 hover:bg-destructive text-destructive-foreground"
+                    onClick={clearRead}
+                >
                     <Trash2 className="mr-2 h-4 w-4" /> Limpar Notificações Lidas
                 </Button>
             </CardFooter>

--- a/src/components/notifications/notification-item.tsx
+++ b/src/components/notifications/notification-item.tsx
@@ -22,9 +22,11 @@ interface Notification {
 
 interface NotificationItemProps {
   notification: Notification;
+  onMarkRead: (id: string) => void;
+  onDismiss: (id: string) => void;
 }
 
-function NotificationItemComponent({ notification }: NotificationItemProps) {
+function NotificationItemComponent({ notification, onMarkRead, onDismiss }: NotificationItemProps) {
   const [timeAgo, setTimeAgo] = useState<string>('');
 
   useEffect(() => {
@@ -87,18 +89,25 @@ function NotificationItemComponent({ notification }: NotificationItemProps) {
               </Button>
             )}
             {!notification.read && (
-              <Button variant="outline" size="sm" className="h-7 px-2" aria-label="Marcar como lida">
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 px-2"
+                aria-label="Marcar como lida"
+                onClick={() => onMarkRead(notification.id)}
+              >
                 <span>
                   <Check className="mr-1 h-3.5 w-3.5" /> Marcar como lida
                 </span>
               </Button>
             )}
-             {notification.read && (
+            {notification.read && (
               <Button
                 variant="ghost"
                 size="sm"
                 className="h-7 px-2 text-muted-foreground hover:text-foreground"
                 aria-label="Dispensar notificação"
+                onClick={() => onDismiss(notification.id)}
               >
                 <span>
                   <X className="mr-1 h-3.5 w-3.5" /> Dispensar

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,6 +1,13 @@
 
 import { useEffect, useState } from 'react';
-import { listenToNotifications, Notification } from '@/services/notificationService';
+import {
+  listenToNotifications,
+  Notification,
+  markNotificationRead,
+  deleteNotification,
+  markAllNotificationsRead,
+  clearReadNotifications,
+} from '@/services/notificationService';
 import { auth } from '@/lib/firebase';
 
 export function useNotifications(userId?: string) {
@@ -17,5 +24,27 @@ export function useNotifications(userId?: string) {
     return () => unsub();
   }, [userId]);
 
-  return { notifications, loading };
+  const uid = userId || auth.currentUser?.uid;
+
+  const markAsRead = async (id: string) => {
+    if (!uid) return;
+    await markNotificationRead(uid, id);
+  };
+
+  const dismiss = async (id: string) => {
+    if (!uid) return;
+    await deleteNotification(uid, id);
+  };
+
+  const markAllAsRead = async () => {
+    if (!uid) return;
+    await markAllNotificationsRead(uid);
+  };
+
+  const clearRead = async () => {
+    if (!uid) return;
+    await clearReadNotifications(uid);
+  };
+
+  return { notifications, loading, markAsRead, dismiss, markAllAsRead, clearRead };
 }


### PR DESCRIPTION
## Summary
- create helpers to store and manage notifications in Firestore
- expose notification operations in `useNotifications`
- wire notification actions in the notifications page
- send push via Cloud Functions when new notification is created

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run typecheck` *(fails with TypeScript errors)*
- `npm run test:all` *(failed while downloading emulator)*

------
https://chatgpt.com/codex/tasks/task_e_68583b491b108324ac4fbf8d0709fe4a