### PR TITLE
Fix PostCSS config and dev origin

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -21,6 +21,7 @@ const nextConfig = {
     'https://9003-firebase-studio-1749490048431.cluster-duylic2g3fbzerqpzxxbw6helm.cloudworkstations.dev',
     'https://3000-firebase-studio-1749490048431.cluster-duylic2g3fbzerqpzxxbw6helm.cloudworkstations.dev',
     'https://3000-firebase-thalamus-1749490048431.cluster-duylic2g3fbzerqpzxxbw6helm.cloudworkstations.dev',
+    'https://3000-firebase-thalamus-20-1750567551083.cluster-etsqrqvqyvd4erxx7qq32imrjk.cloudworkstations.dev',
   ],
 };
 

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,8 @@
 /* global module require */
 /* eslint-env node */
 module.exports = {
-  plugins: [require('@tailwindcss/postcss'), require('autoprefixer')],
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 };


### PR DESCRIPTION
## Summary
- update PostCSS plugins to use object syntax
- add a new Cloud Workstation domain to `allowedDevOrigins`

## Testing
- `npm run test:all` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68583c9de9308324b1f3f51654372601