### PR TITLE
Resolve analytics conflict

### DIFF
--- a/src/app/(app)/analytics/page.tsx
+++ b/src/app/(app)/analytics/page.tsx
@@ -29,7 +29,9 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
+import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
+import { checkUserRole } from '@/services/authRole';
 import { getTotalPatients, getSessionsThisMonth } from '@/services/metricsService';
 
 const SessionsTrendChart = dynamic(
@@ -146,6 +148,7 @@ const getOccupancyBadgeVariant = (
 };
 
 export default function AnalyticsHubPage() {
+  const router = useRouter();
   const userRole: 'Admin' | 'Psychologist' = 'Admin';
   const [overallStats, setOverallStats] = useState<OverallStats>({
     activePatients: 0,
@@ -154,6 +157,10 @@ export default function AnalyticsHubPage() {
   });
 
   useEffect(() => {
+    checkUserRole(['Admin', 'Psychologist']).then((ok) => {
+      if (!ok) router.replace('/');
+    });
+
     (async () => {
       const [patients, sessions] = await Promise.all([getTotalPatients(), getSessionsThisMonth()]);
       setOverallStats({
@@ -162,7 +169,7 @@ export default function AnalyticsHubPage() {
         avgOccupancyRate: 0,
       });
     })();
-  }, []);
+  }, [router]);
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary
- integrate checkUserRole hook into analytics page
- fetch initial metrics on load

## Testing
- `npm run test:all` *(fails: firestore emulator download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68583f6e38b0832482cf80250ba7c325