### PR TITLE
Resolve Firestore rules merge conflict

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -170,6 +170,14 @@ service cloud.firestore {
       allow create, delete: if isAdmin();
     }
 
+    match /backupSettings/{id} {
+      allow read, write: if isAdmin();
+    }
+
+    match /backups/{id} {
+      allow read, create: if isAdmin();
+    }
+
     // Waiting list
     match /waitingList/{id} {
       allow read, update: if isStaff();


### PR DESCRIPTION
## Summary
- merge backup document permissions with waiting list and session notes

## Testing
- `npm run test:all` *(fails: MetadataLookupWarning)*

------
https://chatgpt.com/codex/tasks/task_e_6858425a8e448324aaf8c33a32e14b29