### PR TITLE
Fix PostCSS plugin config

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,8 +1,8 @@
-/* global module require */
+/* global module */
 /* eslint-env node */
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
## Summary
- update PostCSS config to use `@tailwindcss/postcss`

## Testing
- `npm ci`
- `npm run lint` *(fails: 5679 problems)*
- `npm run typecheck` *(fails with TS errors)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68584743421883248e7453c6a053dfbd