### PR TITLE
Ativa login real

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ _Ao adicionar `FIREBASE_PRIVATE_KEY` ao seu arquivo `.env.local` ou variável de
 - `NEXT_PUBLIC_GAS_PRONTUARIO_URL`: URL do script Google Apps Script para geração de prontuários.
 - `NEXT_PUBLIC_GOOGLE_CLIENT_ID`, `NEXT_PUBLIC_GOOGLE_CLIENT_SECRET`, `NEXT_PUBLIC_GOOGLE_REDIRECT_URI`: Para integração com o Google Calendar (opcional).
 - `NEXT_PUBLIC_FIREBASE_VAPID_KEY`: Chave VAPID para Firebase Cloud Messaging (Web Push). Encontrada no Console do Firebase -> Configurações do Projeto -> Cloud Messaging -> Web configuration -> Web Push certificates.
-- `NEXT_PUBLIC_DISABLE_AUTH`: Quando definido como `true`, desativa o sistema de login e autenticação. As verificações de autenticação nas rotas são contornadas e o acesso é liberado. **Atualmente, o código está configurado para operar como se esta variável estivesse sempre `true`, ignorando a necessidade de login.**
+- `NEXT_PUBLIC_DISABLE_AUTH`: Quando definido como `true`, desativa temporariamente o sistema de login. Por padrão esta variável é `false`, exigindo autenticação real.
 
 ## Importante sobre Segurança
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,16 +1,11 @@
-// src/app/login/page.tsx
-"use client";
-import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-import { APP_ROUTES } from '@/lib/routes';
+'use client';
 
-export default function LoginPageDisabled() {
-  const router = useRouter();
+import LoginForm from '@/components/forms/auth/login-form';
 
-  useEffect(() => {
-    // Redireciona para o dashboard, já que o login está desabilitado
-    router.replace(APP_ROUTES.dashboard);
-  }, [router]);
-
-  return null; // Renderiza nada enquanto redireciona
+export default function LoginPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <LoginForm />
+    </div>
+  );
 }

--- a/src/components/forms/auth/login-form.tsx
+++ b/src/components/forms/auth/login-form.tsx
@@ -1,28 +1,19 @@
 // src/components/forms/auth/login-form.tsx
 
-"use client";
+'use client';
 
-// 🔒 Login desabilitado temporariamente. Para reativar, remova os comentários abaixo e substitua o export atual pelo componente completo.
-
-export default function LoginFormDisabled() {
-  return null;
-}
-
-/*
-
-import * as React from "react";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm } from "react-hook-form";
-import * as z from "zod";
-import Link from "next/link";
+import * as React from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import * as z from 'zod';
 import {
   signInWithEmailAndPassword,
   getIdToken,
   setPersistence,
   browserLocalPersistence,
   browserSessionPersistence,
-} from "firebase/auth";
-import { Button } from "@/components/ui/button";
+} from 'firebase/auth';
+import { Button } from '@/components/ui/button';
 import {
   Form,
   FormControl,
@@ -30,23 +21,23 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import { Checkbox } from "@/components/ui/checkbox";
-import { Card, CardContent, CardFooter } from "@/components/ui/card";
-import { useRouter } from "next/navigation";
-import { auth } from "@/lib/firebase";
-import { useToast } from "@/hooks/use-toast";
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Card, CardContent } from '@/components/ui/card';
+import { useRouter } from 'next/navigation';
+import { auth } from '@/lib/firebase';
+import { useToast } from '@/hooks/use-toast';
 
 const loginSchema = z.object({
-  email: z.string().email({ message: "Por favor, insira um endereço de e-mail válido." }),
-  password: z.string().min(6, { message: "A senha deve ter pelo menos 6 caracteres." }),
+  email: z.string().email({ message: 'Por favor, insira um endereço de e-mail válido.' }),
+  password: z.string().min(6, { message: 'A senha deve ter pelo menos 6 caracteres.' }),
   rememberMe: z.boolean().optional(),
 });
 
 type LoginFormValues = z.infer<typeof loginSchema>;
 
-export function LoginForm() {
+export default function LoginForm() {
   const router = useRouter();
   const [isLoading, setIsLoading] = React.useState(false);
   const { toast } = useToast();
@@ -54,8 +45,8 @@ export function LoginForm() {
   const form = useForm<LoginFormValues>({
     resolver: zodResolver(loginSchema),
     defaultValues: {
-      email: "",
-      password: "",
+      email: '',
+      password: '',
       rememberMe: false,
     },
   });
@@ -67,41 +58,37 @@ export function LoginForm() {
         auth,
         data.rememberMe ? browserLocalPersistence : browserSessionPersistence
       );
-      const userCredential = await signInWithEmailAndPassword(
-        auth,
-        data.email,
-        data.password
-      );
+      const userCredential = await signInWithEmailAndPassword(auth, data.email, data.password);
       const idToken = await getIdToken(userCredential.user);
-      await fetch("/api/login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+      await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ idToken }),
       });
-      router.push("/dashboard");
+      router.push('/dashboard');
     } catch (error) {
-      console.error("DEBUG: Erro detalhado do Firebase Auth:", error);
-      let errorMessage = "Erro ao fazer login.";
+      console.error('DEBUG: Erro detalhado do Firebase Auth:', error);
+      let errorMessage = 'Erro ao fazer login.';
 
-      if (error instanceof Error && "code" in error) {
+      if (error instanceof Error && 'code' in error) {
         const errorCode = (error as { code: string }).code;
         switch (errorCode) {
-          case "auth/invalid-credential":
-            errorMessage = "E-mail ou senha incorretos.";
+          case 'auth/invalid-credential':
+            errorMessage = 'E-mail ou senha incorretos.';
             break;
-          case "auth/user-disabled":
-            errorMessage = "Usuário desabilitado.";
+          case 'auth/user-disabled':
+            errorMessage = 'Usuário desabilitado.';
             break;
-          case "auth/too-many-requests":
-            errorMessage = "Acesso bloqueado temporariamente.";
+          case 'auth/too-many-requests':
+            errorMessage = 'Acesso bloqueado temporariamente.';
             break;
         }
       }
 
       toast({
-        title: "Erro ao fazer login",
+        title: 'Erro ao fazer login',
         description: errorMessage,
-        variant: "destructive",
+        variant: 'destructive',
       });
     } finally {
       setIsLoading(false);
@@ -162,7 +149,7 @@ export function LoginForm() {
               className="w-full bg-accent hover:bg-accent/90 text-accent-foreground"
               disabled={isLoading}
             >
-              {isLoading ? "Entrando..." : "Entrar"}
+              {isLoading ? 'Entrando...' : 'Entrar'}
             </Button>
           </form>
         </Form>
@@ -170,5 +157,3 @@ export function LoginForm() {
     </Card>
   );
 }
-
-*/

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,11 +1,11 @@
+'use client';
 
-"use client";
-
-import React from "react";
-import useAuth from "@/hooks/use-auth";
-import { SidebarTrigger } from "@/components/ui/sidebar";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
+import React from 'react';
+import useAuth from '@/hooks/use-auth';
+import { useRouter } from 'next/navigation';
+import { getAuth, signOut } from 'firebase/auth';
+import { SidebarTrigger } from '@/components/ui/sidebar';
+import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -13,22 +13,29 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Search, Bell, UserCircle, Settings, LogOut } from "lucide-react";
-import Link from "next/link";
-import ThemeToggle from "@/components/ui/theme-toggle";
+} from '@/components/ui/dropdown-menu';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Bell, UserCircle, Settings, LogOut } from 'lucide-react';
+import Link from 'next/link';
+import ThemeToggle from '@/components/ui/theme-toggle';
 // import { useTheme } from "next-themes"; // Assuming next-themes is installed for theme toggling
 
 export default function AppHeader() {
   // const { setTheme, theme } = useTheme(); // Uncomment if using next-themes
 
   const { user } = useAuth();
+  const router = useRouter();
 
-
+  const handleLogout = async () => {
+    await signOut(getAuth());
+    router.push('/login');
+  };
 
   return (
-    <header role="banner" className="sticky top-0 z-10 flex h-16 items-center gap-4 border-b bg-background/80 backdrop-blur-sm px-4 md:px-6">
+    <header
+      role="banner"
+      className="sticky top-0 z-10 flex h-16 items-center gap-4 border-b bg-background/80 backdrop-blur-sm px-4 md:px-6"
+    >
       <SidebarTrigger className="md:hidden" />
       <div className="flex-1">
         {/* Optional: Global Search can go here */}
@@ -50,9 +57,18 @@ export default function AppHeader() {
         </Button>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="icon" className="rounded-full" aria-label="Menu do usuário">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="rounded-full"
+              aria-label="Menu do usuário"
+            >
               <Avatar className="h-8 w-8">
-                <AvatarImage src={user.photoURL || "https://placehold.co/100x100.png"} alt={user.displayName || "Usuário"} data-ai-hint="user avatar" />
+                <AvatarImage
+                  src={user.photoURL || 'https://placehold.co/100x100.png'}
+                  alt={user.displayName || 'Usuário'}
+                  data-ai-hint="user avatar"
+                />
                 <AvatarFallback>
                   <UserCircle className="h-6 w-6" />
                 </AvatarFallback>
@@ -60,7 +76,9 @@ export default function AppHeader() {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-56">
-            <DropdownMenuLabel>Minha Conta{user.displayName ? ` - ${user.displayName}` : ''}</DropdownMenuLabel>
+            <DropdownMenuLabel>
+              Minha Conta{user.displayName ? ` - ${user.displayName}` : ''}
+            </DropdownMenuLabel>
             <DropdownMenuSeparator />
             <DropdownMenuItem asChild>
               <Link href="/profile">
@@ -79,10 +97,9 @@ export default function AppHeader() {
               </Link>
             </DropdownMenuItem>
             <DropdownMenuSeparator />
-            {/* Logout functionality commented out as auth is disabled */}
-            <DropdownMenuItem disabled>
+            <DropdownMenuItem onClick={handleLogout}>
               <LogOut className="mr-2 h-4 w-4" />
-              <span>Sair (Desabilitado)</span>
+              <span>Sair</span>
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>


### PR DESCRIPTION
## Summary
- habilita tela de login com formulário
- ativa botão de logout no cabeçalho
- remove redirecionamento automático da página de login
- ajusta README para refletir que `NEXT_PUBLIC_DISABLE_AUTH` é falso por padrão

## Testing
- `npm run test:all` *(falha: auth/invalid-api-key e PERMISSION_DENIED)*

------
https://chatgpt.com/codex/tasks/task_e_6857a952b2748324a76968b91754a5a1