### PR TITLE
Fix Firestore access rules and add security docs

### DIFF
--- a/__tests__/firestore-rules.test.ts
+++ b/__tests__/firestore-rules.test.ts
@@ -1,6 +1,9 @@
-import { initializeTestEnvironment, assertSucceeds } from '@firebase/rules-unit-testing';
+import {
+  initializeTestEnvironment,
+  assertSucceeds,
+  assertFails,
+} from '@firebase/rules-unit-testing';
 import { Firestore } from 'firebase/firestore';
-import fetch from 'node-fetch';
 import { readFileSync } from 'fs'; // <- ESSENCIAL!
 
 let testEnv: Awaited<ReturnType<typeof initializeTestEnvironment>>;
@@ -48,5 +51,28 @@ describe('Firestore security rules', () => {
         createdAt: '2024-01-01T00:00:00Z',
       })
     );
+  });
+
+  describe('Appointment Rules', () => {
+    test('non participant cannot read appointment', async () => {
+      const auth1 = { uid: 'psy1' };
+      const auth2 = { uid: 'other' };
+      const db1 = testEnv.authenticatedContext(auth1.uid).firestore();
+      const db2 = testEnv.authenticatedContext(auth2.uid).firestore();
+
+      const docRef = db1.collection('appointments').doc('appt1');
+      await assertSucceeds(docRef.set({ psychologistId: auth1.uid, patientId: 'pat1' }));
+
+      await assertFails(db2.collection('appointments').doc('appt1').get());
+      await assertFails(db2.collection('appointments').doc('appt1').update({ notes: 'x' }));
+    });
+
+    test('unauthenticated user cannot create appointment', async () => {
+      const db = testEnv.unauthenticatedContext().firestore();
+      await assertFails(
+        db.collection('appointments').doc('appt2').set({ psychologistId: 'p', patientId: 'pat1' })
+      );
+      await assertFails(db.collection('appointments').doc('appt1').get());
+    });
   });
 });

--- a/__tests__/patients.rules.test.ts
+++ b/__tests__/patients.rules.test.ts
@@ -1,7 +1,9 @@
-import { initializeTestEnvironment, assertSucceeds, assertFails } from '@firebase/rules-unit-testing';
+import {
+  initializeTestEnvironment,
+  assertSucceeds,
+  assertFails,
+} from '@firebase/rules-unit-testing';
 import { readFileSync } from 'fs';
-import { Firestore } from 'firebase/firestore';
-import fetch from 'node-fetch';
 
 let testEnv: Awaited<ReturnType<typeof initializeTestEnvironment>>;
 
@@ -24,34 +26,37 @@ afterAll(async () => {
   if (testEnv) await testEnv.cleanup();
 });
 
-function getAuthedDb(auth: { sub: string; role: string }): Firestore {
-  return testEnv.authenticatedContext(auth.sub, auth).firestore();
-}
-
 describe('Patient Rules Tests', () => {
-
-  test('owner can read and write patient document', async () => {
+  test('psychologist can read and write own patient document', async () => {
     const auth = { uid: 'user1' };
     const db = testEnv.authenticatedContext(auth.uid).firestore();
     const patientDoc = db.collection('patients').doc('patient1');
 
-    await assertSucceeds(patientDoc.set({ ownerId: auth.uid, name: 'Test Patient' }));
+    await assertSucceeds(patientDoc.set({ psychologistId: auth.uid, name: 'Test Patient' }));
     await assertSucceeds(patientDoc.get());
   });
 
-  test('non-owner cannot read or write patient document', async () => {
-    // Create a patient document owned by user1
+  test('other psychologist cannot access patient document', async () => {
     const ownerAuth = { uid: 'user1' };
     const ownerDb = testEnv.authenticatedContext(ownerAuth.uid).firestore();
     const ownerDoc = ownerDb.collection('patients').doc('patient2');
-    await assertSucceeds(ownerDoc.set({ ownerId: ownerAuth.uid, name: 'Test Patient' }));
+    await assertSucceeds(ownerDoc.set({ psychologistId: ownerAuth.uid, name: 'Test Patient' }));
 
-    // Try to access it as another user
     const otherAuth = { uid: 'user2' };
     const otherDb = testEnv.authenticatedContext(otherAuth.uid).firestore();
     const otherDoc = otherDb.collection('patients').doc('patient2');
 
     await assertFails(otherDoc.get());
-    await assertFails(otherDoc.set({ ownerId: otherAuth.uid, name: 'Should Fail' }));
+    await assertFails(otherDoc.set({ psychologistId: otherAuth.uid, name: 'Should Fail' }));
+  });
+
+  test('unauthenticated user cannot access patient document', async () => {
+    const patientDoc = testEnv
+      .unauthenticatedContext()
+      .firestore()
+      .collection('patients')
+      .doc('patient3');
+    await assertFails(patientDoc.get());
+    await assertFails(patientDoc.set({ psychologistId: 'someone', name: 'Nope' }));
   });
 });

--- a/docs/audit-trail-analysis.md
+++ b/docs/audit-trail-analysis.md
@@ -1,0 +1,32 @@
+# Análise da Trilha de Auditoria
+
+## 1. Gatilhos de Auditoria
+
+Nenhuma das operações de CRUD nos serviços `prontuarioService.ts` e `appointmentService.ts`, nem o endpoint de login em `src/app/api/login/route.ts`, executa chamadas para registrar logs de auditoria. As funções manipulam dados (ex.: criação de notas de sessão e agendamentos) sem gerar registros na coleção de auditoria.
+
+**Recomendação:** implementar uma função utilitária para gravar um documento na coleção `auditLogs` a cada operação sensível, sendo chamada sempre que notas, agendamentos ou sessões de login forem criados, lidos, atualizados ou excluídos.
+
+## 2. Conteúdo do Log
+
+Não existe estrutura definida para os registros de auditoria no código atual. Assim, campos essenciais como `userId`, `actionType`, `timestamp` e `targetResourceId` não são salvos.
+
+**Recomendação:** definir um esquema para `auditLogs` contendo ao menos:
+
+- `userId`: identificador do usuário responsável pela ação;
+- `actionType`: descrição da ação (ex.: `createAppointment`, `login`);
+- `timestamp`: data e hora geradas no servidor;
+- `targetResourceId`: id do recurso afetado.
+
+## 3. Imutabilidade do Log
+
+Não há regras de segurança para a coleção de auditoria. Sem regras específicas, usuários autenticados podem potencialmente alterar ou remover registros.
+
+**Recomendação:** adicionar ao `firestore.rules` a entrada abaixo para impedir modificações e exclusões:
+
+```firestore
+match /auditLogs/{id} {
+  allow create: if request.auth != null;
+  allow update, delete: if false;
+  allow read: if isAdmin();
+}
+```

--- a/docs/encryption-analysis.md
+++ b/docs/encryption-analysis.md
@@ -1,0 +1,20 @@
+# Análise de Criptografia de Dados Sensíveis
+
+O módulo `src/lib/crypto-utils.ts` implementa criptografia AES-256-GCM. A chave é obtida via `getEncryptionKey()` em `src/lib/encryptionKey.ts`, que por sua vez depende de `setEncryptionPassword()` para definir uma senha em memória. A chave não está hard-coded no repositório e deve ser fornecida por variável de ambiente ou processo de inicialização.
+
+## Campos Criptografados
+
+- **Notas de Sessão** (`sessionNotes`): o conteúdo textual da nota é criptografado antes de ser salvo. A função `saveSessionNote` gera objetos com campos `ciphertext`, `iv` e `tag`.
+
+## Campos Não Criptografados
+
+- Dados de pacientes (ex.: `name`, `email`, `avatarUrl`).
+- Informações de agendamentos (`appointmentDate`, `patientId`, `psychologistId`, etc.).
+
+Atualmente não há evidências de criptografia para PII como CPF, endereço ou telefone (caso venham a ser adicionados).
+
+## Recomendações
+
+1. Avaliar a necessidade de criptografar campos adicionais de pacientes, especialmente se incluírem PII/PHI como CPF, endereço completo ou telefone.
+2. Garantir que a senha utilizada em `setEncryptionPassword()` seja obtida via variável de ambiente segura (`ENCRYPTION_KEY`) ou fluxo de login do profissional, nunca armazenando em texto plano.
+3. Documentar o procedimento de definição da chave no início da aplicação para evitar operações sem criptografia.

--- a/firestore.rules
+++ b/firestore.rules
@@ -29,11 +29,11 @@ service cloud.firestore {
 
     // Valida a estrutura dos dados de um paciente.
     function validPatient() {
-      return request.resource.data.keys().hasOnly(['ownerId', 'name', 'birthdate']) &&
-             request.resource.data.ownerId is string &&
+      return request.resource.data.keys().hasOnly(['psychologistId', 'name', 'birthdate']) &&
+             request.resource.data.psychologistId is string &&
              request.resource.data.name is string &&
              (!('birthdate' in request.resource.data) || request.resource.data.birthdate is timestamp);
-    }
+   }
     
     // Valida os status permitidos para uma avaliação.
     function validAssessmentStatus(status) {
@@ -63,9 +63,23 @@ service cloud.firestore {
 
     // Coleção de Agendamentos (Appointments)
     match /appointments/{id} {
-      allow read: if isStaff();
-      allow create, update: if isStaff();
-      allow delete: if isAdmin();
+      // Apenas o psicólogo ou o paciente envolvido podem ler o agendamento
+      allow read: if request.auth != null && (
+        request.auth.uid == resource.data.psychologistId ||
+        request.auth.uid == resource.data.patientId
+      );
+
+      // Criação e edição também restritas ao psicólogo ou paciente relacionado
+      allow create, update: if request.auth != null && (
+        request.auth.uid == request.resource.data.psychologistId ||
+        request.auth.uid == request.resource.data.patientId
+      );
+
+      // Exclusão segue a mesma lógica de autorização
+      allow delete: if request.auth != null && (
+        request.auth.uid == resource.data.psychologistId ||
+        request.auth.uid == resource.data.patientId
+      );
     }
 
     // Coleção de Avaliações (Assessments)
@@ -136,20 +150,15 @@ service cloud.firestore {
 
     // Coleção de Pacientes (Patients)
     match /patients/{id} {
-      allow create: if isStaff() && // Apenas equipe pode criar pacientes
-                      request.resource.data.ownerId == request.auth.uid &&
+      allow create: if isStaff() &&
+                      request.resource.data.psychologistId == request.auth.uid &&
                       validPatient();
 
-      allow read: if (isStaff() && resource.data.ownerId == request.auth.uid) || isAdmin();
-      
-      allow list: if isStaff(); // Permite que a equipe liste, a query no app deve filtrar por ownerId.
+      // Leitura, edição e exclusão apenas pelo psicólogo responsável
+      allow read, update, delete: if request.auth != null &&
+        request.auth.uid == resource.data.psychologistId;
 
-      allow update: if (isStaff() &&
-                       resource.data.ownerId == request.auth.uid &&
-                       request.resource.data.ownerId == resource.data.ownerId &&
-                       validPatient()) || isAdmin();
-
-      allow delete: if (isStaff() && resource.data.ownerId == request.auth.uid) || isAdmin();
+      allow list: if isStaff();
     }
 
     // Coleção de Notas de Sessão (Criptografadas)


### PR DESCRIPTION
## Summary
- restrict appointment rules to patient or psychologist only
- restrict patient document access to assigned psychologist
- document audit trail gaps and encryption coverage
- add security tests for appointments and patients

## Testing
- `npm ci`
- `firebase emulators:exec --project=thalamus-dev --only firestore "npx jest --runInBand"` *(fails: Could not start emulator hub, port taken)*

------
https://chatgpt.com/codex/tasks/task_e_6858525471e88324875f5a07074a8151