### PR TITLE
Add phase 4 reliability checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,13 +121,14 @@ _Ao adicionar `FIREBASE_PRIVATE_KEY` ao seu arquivo `.env.local` ou variável de
   ```
 
 Consulte [docs/blueprint.md](docs/blueprint.md) para uma visão geral das funcionalidades planejadas.
+Diretrizes adicionais sobre confiabilidade e processos de desenvolvimento estão em [docs/phase4-reliability.md](docs/phase4-reliability.md).
 
 ## Solucao de Problemas
 
 Erros genéricos como **"An unexpected Turbopack error occurred"** costumam estar relacionados a configurações de ambiente ou dependências ausentes. Caso se depare com essa mensagem ao rodar `npm run dev`, verifique os pontos abaixo:
 
 1. Execute `npm install` para garantir que todas as dependências estejam instaladas.
-2. Confirme se está utilizando uma versão do **Node.js** compatível (18 ou superior).
+2. Utilize a versão **Node.js 20.11.0** (padronizada no projeto).
 3. Copie `env.example` para `.env.local` e preencha as variáveis necessárias.
 4. Apague a pasta `.next` (cache do Next.js) e tente novamente: `rm -rf .next && npm run dev`.
 5. Observe o log completo gerado pelo `next dev` para identificar possíveis mensagens adicionais de erro.

--- a/__tests__/ai-logging.test.ts
+++ b/__tests__/ai-logging.test.ts
@@ -1,0 +1,13 @@
+import { trackFlow } from '../src/ai/logging';
+
+describe('trackFlow', () => {
+  it('registra tempo e tamanhos', async () => {
+    const fn = jest.fn(async (n: number) => n + 1);
+    const spy = jest.spyOn(console, 'info').mockImplementation(() => {});
+    const res = await trackFlow('test', fn, 1);
+    expect(res).toBe(2);
+    expect(fn).toHaveBeenCalledWith(1);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/__tests__/generate-session-insights.test.ts
+++ b/__tests__/generate-session-insights.test.ts
@@ -1,13 +1,16 @@
-import { generateSessionInsights } from '../src/ai/flows/generate-session-insights'
-import { ai } from '../src/ai/genkit'
+import { generateSessionInsights } from '../src/ai/flows/generate-session-insights';
+import { ai } from '../src/ai/genkit';
 
-jest.mock('../src/ai/genkit', () => ({
-  ai: { definePrompt: () => () => ({ output: { keywords: [], themes: [], symptomEvolution: '', suggestiveInsights: '' } }), defineFlow: (_cfg: any, fn: any) => fn }
-}))
+jest.mock('../src/ai/genkit', () => {
+  const { createMockAI } = require('../src/tests/__mocks__/ai');
+  return {
+    ai: createMockAI({ keywords: [], themes: [], symptomEvolution: '', suggestiveInsights: '' }),
+  };
+});
 
 describe('generateSessionInsights', () => {
   it('retorna sucesso', async () => {
-    const res = await generateSessionInsights({ sessionNotes: 'ok' })
-    expect(res.success).toBe(true)
-  })
-})
+    const res = await generateSessionInsights({ sessionNotes: 'ok' });
+    expect(res.success).toBe(true);
+  });
+});

--- a/__tests__/prompt-safety.test.ts
+++ b/__tests__/prompt-safety.test.ts
@@ -1,0 +1,17 @@
+import { generateSessionInsightsPrompt } from '../src/ai/prompts/session-insights';
+import { generateReportDraftPrompt } from '../src/ai/prompts/report-draft';
+import { generateSessionNoteTemplatePrompt } from '../src/ai/prompts/session-note-template';
+import { clinicalSupervisionMasterPrompt } from '../src/ai/prompts/clinical-supervision';
+
+const prompts = [
+  generateSessionInsightsPrompt,
+  generateReportDraftPrompt,
+  generateSessionNoteTemplatePrompt,
+  clinicalSupervisionMasterPrompt,
+];
+
+describe('IA prompts', () => {
+  it.each(prompts)('inclui aviso de uso seguro', (prompt) => {
+    expect(prompt.toLowerCase()).toMatch(/n\u00e3o/);
+  });
+});

--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -28,3 +28,7 @@
 - Use professional, clean icons related to healthcare and psychology.
 - Use a consistent grid system for responsive design across different screen sizes.
 - Implement visual states (hover, focus, active, disabled) and feedback (loading, success/error, confirmation) for all interactions.
+
+## Fase 4: Confiabilidade e Desenvolvimento
+
+Diretrizes sobre segurança de prompts de IA, controle de custos e padronização do ambiente estão detalhadas em [phase4-reliability.md](./phase4-reliability.md).

--- a/docs/phase4-reliability.md
+++ b/docs/phase4-reliability.md
@@ -1,0 +1,32 @@
+# Confiabilidade da IA e Processos de Desenvolvimento
+
+Esta fase foca em mitigar riscos de IA e consolidar o ambiente de desenvolvimento.
+A seguir estão os principais pontos a serem avaliados e implementados.
+
+## 1. Análise de Segurança e Robustez dos Prompts de IA
+
+- Revisar todos os fluxos de IA implementados com Genkit para garantir que não possam ser manipulados por entradas maliciosas.
+- Incluir testes de prompts que validem respostas seguras e bloqueiem conteúdo inadequado.
+- Registrar nos logs quaisquer falhas ou mensagens rejeitadas para posterior auditoria.
+
+## 2. Análise de Custo e Performance dos Fluxos de IA
+
+- Monitorar o tempo de execução e o número de chamadas aos modelos durante o uso.
+- Definir limites de custo por operação e alertas em caso de extrapolação.
+- Otimizar prompts e lógica para reduzir repetições desnecessárias.
+
+## 3. Conflitos e Redundâncias em Ferramentas de Teste
+
+- Avaliar as bibliotecas de teste atuais para eliminar sobreposições.
+- Padronizar o uso do Jest com Testing Library para React e regras do Firestore.
+- Documentar comandos e scripts de testes unificados para todo o time.
+
+## 4. Estratégia de Mocking
+
+- Utilizar mocks para serviços externos e chamadas de IA, permitindo cenários controlados durante os testes.
+- Centralizar os mocks em utilitários compartilhados para facilitar a manutenção.
+
+## 5. Padronização de Ambiente (Node.js)
+
+- Definir versão mínima de Node.js no arquivo `package.json` e configurar ferramentas como Volta ou nvm.
+- Garantir que todos os ambientes locais e de CI usem a mesma versão para evitar inconsistências.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "node": "20.11.0",
     "npm": "10.2.4"
   },
+  "engines": {
+    "node": ">=20.11.0"
+  },
   "scripts": {
     "dev": "next dev",
     "dev:force": "lsof -ti:9003 | xargs kill -9 || true && sleep 2 && next dev --turbopack -p 9003",

--- a/src/ai/flows/generate-report-draft-flow.ts
+++ b/src/ai/flows/generate-report-draft-flow.ts
@@ -7,14 +7,17 @@
  * - GenerateReportDraftOutput - The return type for the generateReportDraft function.
  */
 
-import {ai} from '@/ai/genkit';
-import {z} from 'genkit';
-import {getPrompt} from '@/ai/prompts';
+import { ai } from '@/ai/genkit';
+import { trackFlow } from '@/ai/logging';
+import { z } from 'genkit';
+import { getPrompt } from '@/ai/prompts';
 
 export const GenerateReportDraftInputSchema = z.object({
   sessionNotes: z.string().describe('The session notes to base the report on.'),
   patientName: z.string().describe('The name of the patient.'),
-  reportType: z.enum(["progress_report", "referral_letter", "session_summary"]).describe('The type of report to generate.'),
+  reportType: z
+    .enum(['progress_report', 'referral_letter', 'session_summary'])
+    .describe('The type of report to generate.'),
   therapistName: z.string().optional().describe('The name of the therapist (e.g., Dr. Silva).'),
 });
 export type GenerateReportDraftInput = z.infer<typeof GenerateReportDraftInputSchema>;
@@ -26,9 +29,11 @@ export type GenerateReportDraftOutput = z.infer<typeof GenerateReportDraftOutput
 
 import type { Result } from '@/ai/types';
 
-export async function generateReportDraft(input: GenerateReportDraftInput): Promise<Result<GenerateReportDraftOutput>> {
+export async function generateReportDraft(
+  input: GenerateReportDraftInput
+): Promise<Result<GenerateReportDraftOutput>> {
   try {
-    const data = await generateReportDraftFlow(input);
+    const data = await trackFlow('generateReportDraftFlow', generateReportDraftFlow, input);
     return { success: true, data };
   } catch (err) {
     return { success: false, error: 'Erro ao gerar resposta' };
@@ -37,9 +42,9 @@ export async function generateReportDraft(input: GenerateReportDraftInput): Prom
 
 const prompt = ai.definePrompt({
   name: 'generateReportDraftPrompt',
-  input: {schema: GenerateReportDraftInputSchema},
-  output: {schema: GenerateReportDraftOutputSchema},
-  prompt: getPrompt("generateReportDraft"),
+  input: { schema: GenerateReportDraftInputSchema },
+  output: { schema: GenerateReportDraftOutputSchema },
+  prompt: getPrompt('generateReportDraft'),
 });
 
 const generateReportDraftFlow = ai.defineFlow(
@@ -49,7 +54,7 @@ const generateReportDraftFlow = ai.defineFlow(
     outputSchema: GenerateReportDraftOutputSchema,
   },
   async (input: GenerateReportDraftInput) => {
-    const {output} = await prompt(input);
+    const { output } = await prompt(input);
     return output!;
   }
 );

--- a/src/ai/flows/generate-session-insights.ts
+++ b/src/ai/flows/generate-session-insights.ts
@@ -1,4 +1,4 @@
-"use server";
+'use server';
 
 /**
  * @fileOverview Generates session insights from session notes using AI.
@@ -8,89 +8,74 @@
  * - GenerateSessionInsightsOutput - The return type for the generateSessionInsights function.
  */
 
-import { ai } from "@/ai/genkit";
-import { getPrompt } from "@/ai/prompts";
-import { z } from "genkit";
+import { ai } from '@/ai/genkit';
+import { trackFlow } from '@/ai/logging';
+import { getPrompt } from '@/ai/prompts';
+import { z } from 'genkit';
 
 export const GenerateSessionInsightsInputSchema = z.object({
-  sessionNotes: z.string().describe("The session notes to analyze."),
+  sessionNotes: z.string().describe('The session notes to analyze.'),
   patientHistorySummary: z
     .string()
     .optional()
-    .describe(
-      "A brief summary of the patient relevant history and previous inventory results.",
-    ),
+    .describe('A brief summary of the patient relevant history and previous inventory results.'),
 });
-export type GenerateSessionInsightsInput = z.infer<
-  typeof GenerateSessionInsightsInputSchema
->;
+export type GenerateSessionInsightsInput = z.infer<typeof GenerateSessionInsightsInputSchema>;
 
 export const GenerateSessionInsightsOutputSchema = z.object({
-  keywords: z
-    .array(z.string())
-    .describe("Keywords identified in the session notes."),
-  themes: z
-    .array(z.string())
-    .describe("Themes identified in the session notes."),
-  symptomEvolution: z
-    .string()
-    .describe("Description of symptom evolution based on the notes."),
+  keywords: z.array(z.string()).describe('Keywords identified in the session notes.'),
+  themes: z.array(z.string()).describe('Themes identified in the session notes.'),
+  symptomEvolution: z.string().describe('Description of symptom evolution based on the notes.'),
   suggestiveInsights: z
     .string()
-    .describe(
-      "Suggestive insights to improve understanding of patient progress.",
-    ),
+    .describe('Suggestive insights to improve understanding of patient progress.'),
   therapeuticMilestones: z
     .array(z.string())
     .optional()
-    .describe(
-      "Identified significant therapeutic milestones or breakthroughs in the session.",
-    ),
+    .describe('Identified significant therapeutic milestones or breakthroughs in the session.'),
   inventoryComparisonInsights: z
     .string()
     .optional()
     .describe(
-      "Analysis comparing current session notes with past inventory responses and history to show evolution.",
+      'Analysis comparing current session notes with past inventory responses and history to show evolution.'
     ),
   potentialRiskAlerts: z
     .array(z.string())
     .optional()
     .describe(
-      "Subtle alerts based on language patterns or metric decline indicating potential risks (e.g., increased anxiety, depressive thoughts).",
+      'Subtle alerts based on language patterns or metric decline indicating potential risks (e.g., increased anxiety, depressive thoughts).'
     ),
 });
-export type GenerateSessionInsightsOutput = z.infer<
-  typeof GenerateSessionInsightsOutputSchema
->;
+export type GenerateSessionInsightsOutput = z.infer<typeof GenerateSessionInsightsOutputSchema>;
 
-import type { Result } from "@/ai/types";
+import type { Result } from '@/ai/types';
 
 export async function generateSessionInsights(
-  input: GenerateSessionInsightsInput,
+  input: GenerateSessionInsightsInput
 ): Promise<Result<GenerateSessionInsightsOutput>> {
   try {
-    const data = await generateSessionInsightsFlow(input);
+    const data = await trackFlow('generateSessionInsightsFlow', generateSessionInsightsFlow, input);
     return { success: true, data };
   } catch (err) {
-    return { success: false, error: "Erro ao gerar resposta" };
+    return { success: false, error: 'Erro ao gerar resposta' };
   }
 }
 
 const prompt = ai.definePrompt({
-  name: "generateSessionInsightsPrompt",
+  name: 'generateSessionInsightsPrompt',
   input: { schema: GenerateSessionInsightsInputSchema },
   output: { schema: GenerateSessionInsightsOutputSchema },
-  prompt: getPrompt("generateSessionInsights"),
+  prompt: getPrompt('generateSessionInsights'),
 });
 
 const generateSessionInsightsFlow = ai.defineFlow(
   {
-    name: "generateSessionInsightsFlow",
+    name: 'generateSessionInsightsFlow',
     inputSchema: GenerateSessionInsightsInputSchema,
     outputSchema: GenerateSessionInsightsOutputSchema,
   },
   async (input) => {
     const { output } = await prompt(input);
     return output!;
-  },
+  }
 );

--- a/src/ai/flows/generate-session-note-template.ts
+++ b/src/ai/flows/generate-session-note-template.ts
@@ -1,4 +1,4 @@
-"use server";
+'use server';
 /**
  * @fileOverview An AI agent for generating session note templates.
  *
@@ -7,24 +7,25 @@
  * - GenerateSessionNoteTemplateOutput - The return type for the generateSessionNoteTemplate function.
  */
 
-import { ai } from "@/ai/genkit";
-import { getPrompt } from "@/ai/prompts";
-import { z } from "genkit";
+import { ai } from '@/ai/genkit';
+import { trackFlow } from '@/ai/logging';
+import { getPrompt } from '@/ai/prompts';
+import { z } from 'genkit';
 
 export const GenerateSessionNoteTemplateInputSchema = z.object({
-  patientName: z.string().describe("The name of the patient."),
-  sessionSummary: z.string().describe("A summary of the therapy session."),
+  patientName: z.string().describe('The name of the patient.'),
+  sessionSummary: z.string().describe('A summary of the therapy session.'),
   therapistInstructions: z
     .string()
     .optional()
-    .describe("Optional instructions for the AI to tailor the template."),
+    .describe('Optional instructions for the AI to tailor the template.'),
 });
 export type GenerateSessionNoteTemplateInput = z.infer<
   typeof GenerateSessionNoteTemplateInputSchema
 >;
 
 export const GenerateSessionNoteTemplateOutputSchema = z.object({
-  template: z.string().describe("The generated session note template."),
+  template: z.string().describe('The generated session note template.'),
 });
 export type GenerateSessionNoteTemplateOutput = z.infer<
   typeof GenerateSessionNoteTemplateOutputSchema
@@ -33,10 +34,14 @@ export type GenerateSessionNoteTemplateOutput = z.infer<
 import type { Result } from '@/ai/types';
 
 export async function generateSessionNoteTemplate(
-  input: GenerateSessionNoteTemplateInput,
+  input: GenerateSessionNoteTemplateInput
 ): Promise<Result<GenerateSessionNoteTemplateOutput>> {
   try {
-    const data = await generateSessionNoteTemplateFlow(input);
+    const data = await trackFlow(
+      'generateSessionNoteTemplateFlow',
+      generateSessionNoteTemplateFlow,
+      input
+    );
     return { success: true, data };
   } catch (_err) {
     return { success: false, error: 'Erro ao gerar resposta' };
@@ -44,20 +49,20 @@ export async function generateSessionNoteTemplate(
 }
 
 const prompt = ai.definePrompt({
-  name: "generateSessionNoteTemplatePrompt",
+  name: 'generateSessionNoteTemplatePrompt',
   input: { schema: GenerateSessionNoteTemplateInputSchema },
   output: { schema: GenerateSessionNoteTemplateOutputSchema },
-  prompt: getPrompt("generateSessionNoteTemplate"),
+  prompt: getPrompt('generateSessionNoteTemplate'),
 });
 
 const generateSessionNoteTemplateFlow = ai.defineFlow(
   {
-    name: "generateSessionNoteTemplateFlow",
+    name: 'generateSessionNoteTemplateFlow',
     inputSchema: GenerateSessionNoteTemplateInputSchema,
     outputSchema: GenerateSessionNoteTemplateOutputSchema,
   },
   async (input) => {
     const { output } = await prompt(input);
     return output!;
-  },
+  }
 );

--- a/src/ai/logging.ts
+++ b/src/ai/logging.ts
@@ -1,0 +1,17 @@
+export async function trackFlow<TInput, TOutput>(
+  name: string,
+  fn: (input: TInput) => Promise<TOutput>,
+  input: TInput
+): Promise<TOutput> {
+  const start = Date.now();
+  const result = await fn(input);
+  const duration = Date.now() - start;
+  logUsage(name, input, result, duration);
+  return result;
+}
+
+function logUsage(name: string, input: unknown, output: unknown, ms: number) {
+  const inSize = JSON.stringify(input).length;
+  const outSize = JSON.stringify(output).length;
+  console.info(`[AI] ${name} ${ms}ms in/out ${inSize}/${outSize}`);
+}

--- a/src/ai/prompts/report-draft.ts
+++ b/src/ai/prompts/report-draft.ts
@@ -1,4 +1,5 @@
-export const generateReportDraftPrompt = `Você é um assistente de IA especializado em ajudar psicólogos a redigir documentos clínicos.
+export const generateReportDraftPrompt = `AVISO: Conteúdo gerado apenas para apoio profissional e sem substituir julgamento clínico.
+Você é um assistente de IA especializado em ajudar psicólogos a redigir documentos clínicos.
 Com base nas notas da sessão fornecidas, no nome do paciente e no tipo de relatório solicitado, gere um rascunho conciso e profissional.
 {{#if therapistName}}O relatório pode ser assinado por {{therapistName}}.{{/if}}
 

--- a/src/ai/prompts/session-insights.ts
+++ b/src/ai/prompts/session-insights.ts
@@ -1,4 +1,5 @@
-export const generateSessionInsightsPrompt = `You are an AI assistant for psychologists. Analyze the following session notes to identify key themes, symptom evolution, provide suggestive insights, and flag important observations.
+export const generateSessionInsightsPrompt = `AVISO: Esta ferramenta não substitui avaliação profissional ou supervisão clínica.
+You are an AI assistant for psychologists. Analyze the following session notes to identify key themes, symptom evolution, provide suggestive insights, and flag important observations.
 
 Session Notes:
 {{{sessionNotes}}}

--- a/src/ai/prompts/session-note-template.ts
+++ b/src/ai/prompts/session-note-template.ts
@@ -1,4 +1,5 @@
-export const generateSessionNoteTemplatePrompt = `You are an AI assistant that generates session note templates for psychologists.
+export const generateSessionNoteTemplatePrompt = `AVISO: O modelo gerado não substitui supervisão ou avaliação clínica.
+You are an AI assistant that generates session note templates for psychologists.
 
   Given the patient's name and a summary of the session, create a comprehensive session note template.
   Consider the therapist's instructions, if any, to tailor the template.

--- a/src/tests/__mocks__/ai.ts
+++ b/src/tests/__mocks__/ai.ts
@@ -1,0 +1,8 @@
+export function createMockAI(output: any) {
+  return {
+    definePrompt: () => () => ({ output }),
+    defineFlow: (_cfg: unknown, fn: any) => fn,
+  };
+}
+
+export const mockAI = createMockAI({});


### PR DESCRIPTION
## Summary
- enforce Node 20.11.0 usage
- add AI flow logging utility and tests
- insert safety disclaimers in AI prompts
- centralize AI mocks and update tests

## Testing
- `npm run lint` *(fails: prettier errors)*
- `npm run typecheck` *(no output)*
- `npm run test:all` *(stops during Firebase emulator download)*

------
https://chatgpt.com/codex/tasks/task_e_6858a645c49483248dc1065923e773ec