### PR TITLE
Add local AI cache

### DIFF
--- a/__tests__/aiServiceCache.test.ts
+++ b/__tests__/aiServiceCache.test.ts
@@ -1,0 +1,47 @@
+import { generateSessionInsights, DEFAULT_CACHE_TTL_MS } from '../src/services/aiService';
+import '../tests/setupLocalStorage';
+import { TextEncoder } from 'util';
+
+(global as any).TextEncoder = TextEncoder;
+
+describe('aiService cache', () => {
+  const input = { sessionNotes: 'ok' };
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    jest.useFakeTimers();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.resetAllMocks();
+  });
+
+  it('reutiliza resposta em cache', async () => {
+    const first = await generateSessionInsights(input);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const second = await generateSessionInsights(input);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(second).toEqual(first);
+  });
+
+  it('expira após TTL', async () => {
+    await generateSessionInsights(input);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(DEFAULT_CACHE_TTL_MS + 1000);
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: false }),
+    });
+
+    const res = await generateSessionInsights(input);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(res).toEqual({ success: false });
+  });
+});

--- a/docs/ai-caching.md
+++ b/docs/ai-caching.md
@@ -1,0 +1,8 @@
+# Cache de Respostas da IA
+
+Os serviços de IA usam um cache local no navegador para evitar chamadas
+repetidas. A chave do cache é gerada com SHA-256 sobre o corpo da
+requisição e cada entrada expira em dez minutos.
+
+Ao solicitar o mesmo conteúdo dentro desse período, o dado salvo em
+`localStorage` é retornado imediatamente, sem nova requisição de rede.

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -1,58 +1,93 @@
-"use client";
+'use client';
 
 import type {
   GenerateSessionInsightsInput,
   GenerateSessionInsightsOutput,
-} from "@/ai/flows/generate-session-insights";
+} from '@/ai/flows/generate-session-insights';
 import type {
   GenerateReportDraftInput,
   GenerateReportDraftOutput,
-} from "@/ai/flows/generate-report-draft-flow";
+} from '@/ai/flows/generate-report-draft-flow';
 import type {
   GenerateSessionNoteTemplateInput,
   GenerateSessionNoteTemplateOutput,
-} from "@/ai/flows/generate-session-note-template";
+} from '@/ai/flows/generate-session-note-template';
 
-async function requestAI<T>(url: string, body: unknown): Promise<T> {
+export const DEFAULT_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutos
+
+interface CacheEntry<T> {
+  ts: number;
+  data: T;
+}
+
+async function hashInput(input: unknown): Promise<string> {
+  const str = JSON.stringify(input);
+  const buf = new TextEncoder().encode(str);
+  const hash = await crypto.subtle.digest('SHA-256', buf);
+  return Array.from(new Uint8Array(hash))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function requestAI<T>(url: string, body: unknown, ttlMs = DEFAULT_CACHE_TTL_MS): Promise<T> {
+  const key = `ai_${url}_${await hashInput(body)}`;
+
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem(key);
+    if (stored) {
+      try {
+        const entry = JSON.parse(stored) as CacheEntry<T>;
+        if (Date.now() - entry.ts < ttlMs) {
+          return entry.data;
+        }
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }
+
   try {
     const res = await fetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     });
     if (!res.ok) {
       const message = await res.text();
-      throw new Error(message || "Erro na requisição AI");
+      throw new Error(message || 'Erro na requisição AI');
     }
-    return res.json() as Promise<T>;
+    const data = (await res.json()) as T;
+    if (typeof window !== 'undefined') {
+      const entry: CacheEntry<T> = { ts: Date.now(), data };
+      try {
+        localStorage.setItem(key, JSON.stringify(entry));
+      } catch {
+        // ignore quota errors
+      }
+    }
+    return data;
   } catch (e) {
-    console.error("Erro na comunicação com o serviço de IA:", e);
+    console.error('Erro na comunicação com o serviço de IA:', e);
     throw new Error(
-      "Não foi possível conectar ao serviço de IA. Verifique sua conexão e tente novamente.",
+      'Não foi possível conectar ao serviço de IA. Verifique sua conexão e tente novamente.'
     );
   }
 }
 
 export async function generateSessionInsights(
-  input: GenerateSessionInsightsInput,
+  input: GenerateSessionInsightsInput
 ): Promise<GenerateSessionInsightsOutput> {
-  return requestAI<GenerateSessionInsightsOutput>(
-    "/api/ai/session-insights",
-    input,
-  );
+  return requestAI<GenerateSessionInsightsOutput>('/api/ai/session-insights', input);
 }
 
 export async function generateReportDraft(
-  input: GenerateReportDraftInput,
+  input: GenerateReportDraftInput
 ): Promise<GenerateReportDraftOutput> {
-  return requestAI<GenerateReportDraftOutput>("/api/ai/report-draft", input);
+  return requestAI<GenerateReportDraftOutput>('/api/ai/report-draft', input);
 }
 
 export async function generateSessionNoteTemplate(
-  input: GenerateSessionNoteTemplateInput,
+  input: GenerateSessionNoteTemplateInput
 ): Promise<GenerateSessionNoteTemplateOutput> {
-  return requestAI<GenerateSessionNoteTemplateOutput>(
-    "/api/ai/session-note-template",
-    input,
-  );
+  return requestAI<GenerateSessionNoteTemplateOutput>('/api/ai/session-note-template', input);
 }


### PR DESCRIPTION
## Summary
- implement simple TTL-based caching inside `aiService`
- document how AI responses are cached
- test cache hits using a new test suite

## Testing
- `npm test` *(fails: fetch is not defined and other modules not found)*

------
https://chatgpt.com/codex/tasks/task_e_68592d711b98832490a75c7152923d02