### PR TITLE
Fix emulator port mismatches

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Plataforma web para gestão de clínicas de psicologia, com agenda integrada, pr
     - Se esta é a primeira vez, configure os emuladores: `firebase init emulators` (selecione Firestore, Storage, Functions).
     - Inicie os emuladores: `firebase emulators:start --project=demo-project`
     - Certifique-se de que o `firebase.json` possua a entrada `"storage": { "rules": "storage.rules" }` para que o emulador de Storage possa iniciar.
-    - Verifique se os emuladores estão rodando nas portas corretas (Firestore: 8083, Storage: 9199, UI: 4003). O arquivo `firebase.json` está configurado para usar `host: "0.0.0.0"` para os emuladores.
+    - Verifique se os emuladores estão rodando nas portas corretas (Firestore: 8084, Storage: 9200, UI: 4004). O arquivo `firebase.json` está configurado para usar `host: "0.0.0.0"` para os emuladores.
 5.  **Inicie o Servidor de Desenvolvimento Next.js (em outro terminal):**
     ```bash
     npm run dev

--- a/__tests__/firestore-rules.test.ts
+++ b/__tests__/firestore-rules.test.ts
@@ -10,7 +10,7 @@ let testEnv: Awaited<ReturnType<typeof initializeTestEnvironment>>;
 
 describe('Firestore security rules', () => {
   beforeAll(async () => {
-    const hostPort = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8083';
+    const hostPort = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8084';
     const [host, portStr] = hostPort.split(':');
     const port = parseInt(portStr, 10);
 

--- a/__tests__/metrics.firestore.test.ts
+++ b/__tests__/metrics.firestore.test.ts
@@ -6,7 +6,7 @@ import { getTotalPatients, getSessionsThisMonth } from '@/services/metricsServic
 let testEnv: Awaited<ReturnType<typeof initializeTestEnvironment>>;
 
 beforeAll(async () => {
-  const hostPort = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8083';
+  const hostPort = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8084';
   const [host, portStr] = hostPort.split(':');
   const port = parseInt(portStr, 10);
 

--- a/__tests__/patients.rules.test.ts
+++ b/__tests__/patients.rules.test.ts
@@ -8,7 +8,7 @@ import { readFileSync } from 'fs';
 let testEnv: Awaited<ReturnType<typeof initializeTestEnvironment>>;
 
 beforeAll(async () => {
-  const hostPort = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8083';
+  const hostPort = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8084';
   const [host, portStr] = hostPort.split(':');
   const port = parseInt(portStr, 10);
 

--- a/__tests__/prontuario-flow.test.ts
+++ b/__tests__/prontuario-flow.test.ts
@@ -1,4 +1,4 @@
-import { initializeTestEnvironment, assertSucceeds } from '@firebase/rules-unit-testing'
+import { initializeTestEnvironment } from '@firebase/rules-unit-testing'
 import { readFileSync } from 'fs'
 import { Firestore } from 'firebase/firestore'
 import { saveSessionNote, getSessionNotes } from '../src/services/prontuarioService'
@@ -7,7 +7,7 @@ import { setEncryptionPassword } from '../src/lib/encryptionKey'
 let testEnv: Awaited<ReturnType<typeof initializeTestEnvironment>>
 
 beforeAll(async () => {
-  const hostPort = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8083'
+  const hostPort = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8084'
   const [host, portStr] = hostPort.split(':')
   const port = parseInt(portStr, 10)
 

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -55,11 +55,11 @@ if (process.env.NODE_ENV === 'development') {
     connectAuthEmulator(auth, `http://${host}:${authPort}`, { disableWarnings: true });
     console.info(`Auth Emulator connected to http://${host}:${authPort}`);
 
-    const firestorePort = 8083;
+    const firestorePort = 8084;
     connectFirestoreEmulator(db, host, firestorePort);
     console.info(`Firestore Emulator connected to ${host}:${firestorePort}`);
 
-    const storagePort = 9199;
+    const storagePort = 9200;
     connectStorageEmulator(storage, host, storagePort);
     console.info(`Storage Emulator connected to ${host}:${storagePort}`);
 


### PR DESCRIPTION
## Summary
- align Firestore/Storage emulator ports
- update tests to follow new ports
- tweak README instructions
- remove unused assert in prontuario-flow test

## Testing
- `./run-tests.sh` *(fails: Script "npx jest --runInBand" exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68592d6d87608324be7fd019cafa6237