### PR TITLE
Add encryption for patient contact data

### DIFF
--- a/__tests__/metrics.firestore.test.ts
+++ b/__tests__/metrics.firestore.test.ts
@@ -32,7 +32,7 @@ test('count patients and sessions', async () => {
   const auth = { uid: 'admin', role: 'Admin' };
   const db = getAuthedDb(auth);
 
-  await setDoc(doc(db, 'patients/p1'), { ownerId: 'admin', name: 'Test' });
+  await setDoc(doc(db, 'patients/p1'), { ownerId: 'admin', name: 'Test', email: 't@e.st' });
   await setDoc(doc(db, 'appointments/a1'), {
     startDate: Timestamp.fromDate(new Date()),
     status: 'Scheduled',

--- a/docs/encryption-analysis.md
+++ b/docs/encryption-analysis.md
@@ -5,16 +5,26 @@ O módulo `src/lib/crypto-utils.ts` implementa criptografia AES-256-GCM. A chave
 ## Campos Criptografados
 
 - **Notas de Sessão** (`sessionNotes`): o conteúdo textual da nota é criptografado antes de ser salvo. A função `saveSessionNote` gera objetos com campos `ciphertext`, `iv` e `tag`.
+- **Dados Sensíveis de Pacientes** (`patients`): campos `phoneEnc`, `addressEnc` e `identifierEnc` são objetos cifrados com `ciphertext`, `iv` e `tag`.
 
 ## Campos Não Criptografados
 
-- Dados de pacientes (ex.: `name`, `email`, `avatarUrl`).
+- Dados básicos de pacientes (`name`, `email`, `avatarUrl`).
 - Informações de agendamentos (`appointmentDate`, `patientId`, `psychologistId`, etc.).
-
-Atualmente não há evidências de criptografia para PII como CPF, endereço ou telefone (caso venham a ser adicionados).
 
 ## Recomendações
 
 1. Avaliar a necessidade de criptografar campos adicionais de pacientes, especialmente se incluírem PII/PHI como CPF, endereço completo ou telefone.
 2. Garantir que a senha utilizada em `setEncryptionPassword()` seja obtida via variável de ambiente segura (`ENCRYPTION_KEY`) ou fluxo de login do profissional, nunca armazenando em texto plano.
 3. Documentar o procedimento de definição da chave no início da aplicação para evitar operações sem criptografia.
+
+## Migração de Pacientes Existentes
+
+Para bases já em produção é necessário criptografar retrospectivamente os campos sensíveis de cada paciente. O passo a passo sugerido é:
+
+1. Carregue todos os documentos da coleção `patients` com uma conta administrativa.
+2. Para cada paciente, leia os valores em texto plano (`phone`, `address`, `identifier`).
+3. Utilize `encrypt()` com a chave derivada em `getEncryptionKey()` e grave os resultados nos novos campos `phoneEnc`, `addressEnc` e `identifierEnc`.
+4. Remova os campos antigos em texto plano após verificar a consistência dos dados criptografados.
+
+Este processo deve ser executado uma única vez e preferencialmente em script de migração utilizando os emuladores do Firebase para validação.

--- a/firestore.rules
+++ b/firestore.rules
@@ -28,11 +28,24 @@ service cloud.firestore {
     }
 
     // Valida a estrutura dos dados de um paciente.
+    function validEncryptedField(field) {
+      return field.keys().hasOnly(['ciphertext', 'iv', 'tag']) &&
+             field.ciphertext is string &&
+             field.iv is string &&
+             field.tag is string;
+    }
+
     function validPatient() {
-      return request.resource.data.keys().hasOnly(['psychologistId', 'name', 'birthdate']) &&
-             request.resource.data.psychologistId is string &&
+      return request.resource.data.keys().hasOnly([
+               'ownerId', 'name', 'birthdate', 'phoneEnc', 'addressEnc', 'identifierEnc', 'email', 'notes'
+             ]) &&
+             request.resource.data.ownerId is string &&
              request.resource.data.name is string &&
-             (!('birthdate' in request.resource.data) || request.resource.data.birthdate is timestamp);
+             request.resource.data.email is string &&
+             (!('birthdate' in request.resource.data) || request.resource.data.birthdate is timestamp) &&
+             (!('phoneEnc' in request.resource.data) || validEncryptedField(request.resource.data.phoneEnc)) &&
+             (!('addressEnc' in request.resource.data) || validEncryptedField(request.resource.data.addressEnc)) &&
+             (!('identifierEnc' in request.resource.data) || validEncryptedField(request.resource.data.identifierEnc));
    }
     
     // Valida os status permitidos para uma avaliação.
@@ -151,12 +164,12 @@ service cloud.firestore {
     // Coleção de Pacientes (Patients)
     match /patients/{id} {
       allow create: if isStaff() &&
-                      request.resource.data.psychologistId == request.auth.uid &&
+                      request.resource.data.ownerId == request.auth.uid &&
                       validPatient();
 
       // Leitura, edição e exclusão apenas pelo psicólogo responsável
       allow read, update, delete: if request.auth != null &&
-        request.auth.uid == resource.data.psychologistId;
+        request.auth.uid == resource.data.ownerId;
 
       allow list: if isStaff();
     }

--- a/src/components/forms/patient-form.tsx
+++ b/src/components/forms/patient-form.tsx
@@ -1,12 +1,11 @@
+'use client';
 
-"use client";
-
-import * as React from "react";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm } from "react-hook-form";
-import * as z from "zod";
-import { useRouter } from "next/navigation";
-import { Button } from "@/components/ui/button";
+import * as React from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import * as z from 'zod';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
 import {
   Form,
   FormControl,
@@ -14,29 +13,27 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
-  FormDescription,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
-import { Calendar } from "@/components/ui/calendar";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { CalendarIcon, Save } from "lucide-react";
-import { cn } from "@/shared/utils";
-import { format } from "date-fns";
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Calendar } from '@/components/ui/calendar';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { CalendarIcon, Save } from 'lucide-react';
+import { cn } from '@/shared/utils';
+import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
-import { useToast } from "@/hooks/use-toast";
+import { useToast } from '@/hooks/use-toast';
+import { createPatient, updatePatient } from '@/services/patientService';
 
 const patientFormSchema = z.object({
-  name: z
-    .string()
-    .min(3, { message: "O nome completo deve ter pelo menos 3 caracteres." }),
-  age: z
-    .coerce.number()
-    .min(0, { message: "Idade inválida." })
-    .max(120, { message: "Idade inválida." })
+  name: z.string().min(3, { message: 'O nome completo deve ter pelo menos 3 caracteres.' }),
+  age: z.coerce
+    .number()
+    .min(0, { message: 'Idade inválida.' })
+    .max(120, { message: 'Idade inválida.' })
     .optional(),
-  email: z.string().email({ message: "Por favor, insira um endereço de e-mail válido." }),
+  email: z.string().email({ message: 'Por favor, insira um endereço de e-mail válido.' }),
   phone: z.string().optional(),
   dob: z.date().optional(),
   address: z.string().optional(),
@@ -57,25 +54,53 @@ export default function PatientForm({ patientData }: PatientFormProps) {
   const form = useForm<PatientFormValues>({
     resolver: zodResolver(patientFormSchema),
     defaultValues: {
-      name: patientData?.name || "",
+      name: patientData?.name || '',
       age: patientData?.age || undefined,
-      email: patientData?.email || "",
-      phone: patientData?.phone || "",
+      email: patientData?.email || '',
+      phone: patientData?.phone || '',
       dob: patientData?.dob ? new Date(patientData.dob) : undefined,
-      address: patientData?.address || "",
-      notes: patientData?.notes || "",
+      address: patientData?.address || '',
+      notes: patientData?.notes || '',
     },
   });
 
   async function onSubmit(data: PatientFormValues) {
     setIsLoading(true);
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    setIsLoading(false);
-    toast({
-      title: patientData?.id ? "Paciente Atualizado (Simulado)" : "Paciente Adicionado (Simulado)",
-      description: `${data.name} foi ${patientData?.id ? 'atualizado(a)' : 'adicionado(a)'} com sucesso.`,
-    });
-    router.push(patientData?.id ? `/patients/${patientData.id}` : "/patients");
+    try {
+      if (patientData?.id) {
+        await updatePatient(patientData.id, {
+          name: data.name,
+          email: data.email,
+          phone: data.phone,
+          address: data.address,
+          dob: data.dob ?? null,
+          notes: data.notes,
+        });
+        toast({
+          title: 'Paciente Atualizado',
+          description: `${data.name} atualizado com sucesso.`,
+        });
+      } else {
+        await createPatient({
+          name: data.name,
+          email: data.email,
+          phone: data.phone,
+          address: data.address,
+          dob: data.dob ?? null,
+          notes: data.notes,
+        });
+        toast({
+          title: 'Paciente Adicionado',
+          description: `${data.name} foi adicionado com sucesso.`,
+        });
+      }
+      router.push('/patients');
+    } catch (err) {
+      console.error(err);
+      toast({ title: 'Erro ao salvar paciente', variant: 'destructive' });
+    } finally {
+      setIsLoading(false);
+    }
   }
 
   return (
@@ -83,7 +108,9 @@ export default function PatientForm({ patientData }: PatientFormProps) {
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)}>
           <CardHeader>
-            <CardTitle className="font-headline">{patientData?.id ? "Editar Detalhes do Paciente" : "Informações do Novo Paciente"}</CardTitle>
+            <CardTitle className="font-headline">
+              {patientData?.id ? 'Editar Detalhes do Paciente' : 'Informações do Novo Paciente'}
+            </CardTitle>
           </CardHeader>
           <CardContent className="space-y-6">
             <div className="grid md:grid-cols-2 gap-6">
@@ -151,14 +178,14 @@ export default function PatientForm({ patientData }: PatientFormProps) {
                       <PopoverTrigger asChild>
                         <FormControl>
                           <Button
-                            variant={"outline"}
+                            variant={'outline'}
                             className={cn(
-                              "w-full pl-3 text-left font-normal",
-                              !field.value && "text-muted-foreground"
+                              'w-full pl-3 text-left font-normal',
+                              !field.value && 'text-muted-foreground'
                             )}
                           >
                             {field.value ? (
-                              format(field.value, "P", { locale: ptBR })
+                              format(field.value, 'P', { locale: ptBR })
                             ) : (
                               <span>Escolha uma data</span>
                             )}
@@ -171,9 +198,7 @@ export default function PatientForm({ patientData }: PatientFormProps) {
                           mode="single"
                           selected={field.value}
                           onSelect={field.onChange}
-                          disabled={(date) =>
-                            date > new Date() || date < new Date("1900-01-01")
-                          }
+                          disabled={(date) => date > new Date() || date < new Date('1900-01-01')}
                           initialFocus
                           locale={ptBR}
                         />
@@ -191,7 +216,11 @@ export default function PatientForm({ patientData }: PatientFormProps) {
                 <FormItem>
                   <FormLabel>Endereço</FormLabel>
                   <FormControl>
-                    <Textarea placeholder="Rua Exemplo, 123, Bairro, Cidade - UF" {...field} rows={3} />
+                    <Textarea
+                      placeholder="Rua Exemplo, 123, Bairro, Cidade - UF"
+                      {...field}
+                      rows={3}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -212,9 +241,19 @@ export default function PatientForm({ patientData }: PatientFormProps) {
             />
           </CardContent>
           <CardFooter className="flex justify-end">
-            <Button type="submit" className="bg-accent hover:bg-accent/90 text-accent-foreground" disabled={isLoading}>
+            <Button
+              type="submit"
+              className="bg-accent hover:bg-accent/90 text-accent-foreground"
+              disabled={isLoading}
+            >
               <Save className="mr-2 h-4 w-4" />
-              {isLoading ? (patientData?.id ? "Salvando Alterações..." : "Adicionando Paciente...") : (patientData?.id ? "Salvar Alterações" : "Adicionar Paciente")}
+              {isLoading
+                ? patientData?.id
+                  ? 'Salvando Alterações...'
+                  : 'Adicionando Paciente...'
+                : patientData?.id
+                  ? 'Salvar Alterações'
+                  : 'Adicionar Paciente'}
             </Button>
           </CardFooter>
         </form>
@@ -222,5 +261,3 @@ export default function PatientForm({ patientData }: PatientFormProps) {
     </Card>
   );
 }
-
-    

--- a/src/types/patient.ts
+++ b/src/types/patient.ts
@@ -4,6 +4,11 @@ export interface Patient {
   id: string;
   name: string;
   email: string;
+  phone?: string;
+  address?: string;
+  identifier?: string;
+  dob?: Timestamp | null;
+  notes?: string;
   lastSession?: string | null;
   nextAppointment?: string | null;
   avatarUrl?: string;


### PR DESCRIPTION
## Summary
- encrypt sensitive patient info (`phone`, `address`, `identifier`) when saving
- decrypt these fields in service fetch functions
- add `createPatient` and `updatePatient` helpers
- wire up patient form to use the new helpers
- adjust Firestore rules to accept encrypted patient fields
- update unit tests and docs with migration notes

## Testing
- `./run-tests.sh` *(fails: Metadata lookup warning and emulator download hang)*

------
https://chatgpt.com/codex/tasks/task_e_68592d6baf4c8324abfd47e0b6b92c31