### PR TITLE
Add audit logging for patient and assessment actions

### DIFF
--- a/__tests__/audit-logs.test.ts
+++ b/__tests__/audit-logs.test.ts
@@ -3,6 +3,11 @@ import { readFileSync } from 'fs';
 import { Firestore, getDocs, collection } from 'firebase/firestore';
 import { saveSessionNote } from '../src/services/prontuarioService';
 import { createAppointment } from '../src/services/appointmentService';
+
+let createPatient: any;
+let updatePatient: any;
+let createAssessment: any;
+let submitAssessmentResponses: any;
 import { setEncryptionPassword } from '../src/lib/encryptionKey';
 
 let testEnv: Awaited<ReturnType<typeof initializeTestEnvironment>>;
@@ -20,22 +25,41 @@ beforeAll(async () => {
       rules: readFileSync('firestore.rules', 'utf8'),
     },
   });
+
+  const auth = { uid: 'therapist1', role: 'Psychologist' };
+  const db = testEnv.authenticatedContext(auth.uid, auth).firestore();
+
+  jest.doMock('../src/lib/firebase', () => ({
+    db,
+    auth: { currentUser: { uid: auth.uid } },
+  }));
+
+  ({ createPatient, updatePatient } = await import('../src/services/patientService'));
+  ({ createAssessment, submitAssessmentResponses } = await import(
+    '../src/services/assessmentService'
+  ));
 });
 
 afterAll(async () => {
   if (testEnv) await testEnv.cleanup();
+  jest.resetModules();
 });
 
 function getDb(auth: { uid: string; role: string }): Firestore {
   return testEnv.authenticatedContext(auth.uid, auth).firestore();
 }
 
-test('audit log created for session note and appointment', async () => {
+test('audit log created for multiple actions', async () => {
   const auth = { uid: 'therapist1', role: 'Psychologist' };
   const db = getDb(auth);
   setEncryptionPassword('senha');
 
-  const noteId = await saveSessionNote(db, 'patient1', 'text', auth.uid);
+  const patientId = await createPatient({ name: 'Ana', email: 'a@b.com' }, db);
+  expect(patientId).toBeDefined();
+
+  await updatePatient(patientId, { name: 'Ana', email: 'a@b.com' }, db);
+
+  const noteId = await saveSessionNote(db, patientId, 'text', auth.uid);
   expect(noteId).toBeDefined();
 
   const apptId = await createAppointment(
@@ -44,13 +68,27 @@ test('audit log created for session note and appointment', async () => {
       startTime: '10:00',
       endTime: '11:00',
       psychologistId: auth.uid,
-      patientId: 'patient1',
+      patientId,
       type: 'Consulta',
     },
-    db,
+    db
   );
   expect(apptId).toBeDefined();
 
+  const assessmentId = await createAssessment(
+    {
+      patientId,
+      templateId: 't1',
+      templateName: 't1',
+      assignedBy: auth.uid,
+      status: 'assigned',
+    },
+    db
+  );
+  expect(assessmentId).toBeDefined();
+
+  await submitAssessmentResponses(assessmentId, { q1: 'a' }, db);
+
   const logsSnap = await getDocs(collection(db, 'auditLogs'));
-  expect(logsSnap.size).toBe(2);
+  expect(logsSnap.size).toBe(6);
 });

--- a/src/services/assessmentService.ts
+++ b/src/services/assessmentService.ts
@@ -1,27 +1,68 @@
-"use client";
-import { collection, addDoc, updateDoc, doc, getDocs, query, where } from 'firebase/firestore';
-import { db } from '@/lib/firebase'; // Alterado de @/services/firebase
+'use client';
+import {
+  collection,
+  addDoc,
+  updateDoc,
+  doc,
+  getDocs,
+  query,
+  where,
+  type Firestore,
+} from 'firebase/firestore';
+import { db, auth } from '@/lib/firebase'; // Alterado de @/services/firebase
+import { writeAuditLog } from './auditLogService';
 import { FIRESTORE_COLLECTIONS } from '@/lib/firestore-collections';
 import type { Assessment } from '@/types/assessment';
 
-export async function createAssessment(data: Omit<Assessment, 'id' | 'createdAt' | 'completedAt'>): Promise<string> {
-  const docRef = await addDoc(collection(db, FIRESTORE_COLLECTIONS.ASSESSMENTS), {
+export async function createAssessment(
+  data: Omit<Assessment, 'id' | 'createdAt' | 'completedAt'>,
+  firestore: Firestore = db
+): Promise<string> {
+  const docRef = await addDoc(collection(firestore, FIRESTORE_COLLECTIONS.ASSESSMENTS), {
     ...data,
     createdAt: new Date().toISOString(),
   });
+  await writeAuditLog(
+    {
+      userId: data.assignedBy,
+      actionType: 'createAssessment',
+      timestamp: new Date().toISOString(),
+      targetResourceId: docRef.id,
+    },
+    firestore
+  );
   return docRef.id;
 }
 
-export async function submitAssessmentResponses(assessmentId: string, responses: Record<string, unknown>): Promise<void> {
-  await updateDoc(doc(db, FIRESTORE_COLLECTIONS.ASSESSMENTS, assessmentId), {
+export async function submitAssessmentResponses(
+  assessmentId: string,
+  responses: Record<string, unknown>,
+  firestore: Firestore = db
+): Promise<void> {
+  await updateDoc(doc(firestore, FIRESTORE_COLLECTIONS.ASSESSMENTS, assessmentId), {
     responses,
     status: 'completed',
     completedAt: new Date().toISOString(),
   });
+  const uid = auth.currentUser?.uid;
+  if (uid) {
+    await writeAuditLog(
+      {
+        userId: uid,
+        actionType: 'submitAssessmentResponses',
+        timestamp: new Date().toISOString(),
+        targetResourceId: assessmentId,
+      },
+      firestore
+    );
+  }
 }
 
 export async function getAssessmentsByPatient(patientId: string): Promise<Assessment[]> {
-  const q = query(collection(db, FIRESTORE_COLLECTIONS.ASSESSMENTS), where('patientId', '==', patientId));
+  const q = query(
+    collection(db, FIRESTORE_COLLECTIONS.ASSESSMENTS),
+    where('patientId', '==', patientId)
+  );
   const snapshot = await getDocs(q);
-  return snapshot.docs.map(d => ({ id: d.id, ...(d.data() as Omit<Assessment, 'id'>) }));
+  return snapshot.docs.map((d) => ({ id: d.id, ...(d.data() as Omit<Assessment, 'id'>) }));
 }


### PR DESCRIPTION
## Summary
- log creation and update of patients with audit log
- record audit entries when creating or submitting assessments
- expand audit-logs test to cover patient and assessment flows

## Testing
- `npm run lint` *(fails: eslint violations)*
- `npm run typecheck` *(fails: type errors)*
- `npm test` *(fails: Firebase emulator and environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_685932a9712083249b3ed5aa5c705370