### PR TITLE
Atualiza documentação de trilha de auditoria

### DIFF
--- a/docs/audit-trail-analysis.md
+++ b/docs/audit-trail-analysis.md
@@ -2,31 +2,38 @@
 
 ## 1. Gatilhos de Auditoria
 
-Nenhuma das operações de CRUD nos serviços `prontuarioService.ts` e `appointmentService.ts`, nem o endpoint de login em `src/app/api/login/route.ts`, executa chamadas para registrar logs de auditoria. As funções manipulam dados (ex.: criação de notas de sessão e agendamentos) sem gerar registros na coleção de auditoria.
+As operações de criação de notas de sessão e de agendamentos já utilizam o serviço `writeAuditLog` (em `src/services/auditLogService.ts`) para registrar entradas na coleção `auditLogs`. O endpoint de login (`src/app/api/login/route.ts`) também grava um log após a autenticação bem-sucedida. Atualizações e exclusões, entretanto, ainda não geram registros.
 
-**Recomendação:** implementar uma função utilitária para gravar um documento na coleção `auditLogs` a cada operação sensível, sendo chamada sempre que notas, agendamentos ou sessões de login forem criados, lidos, atualizados ou excluídos.
+Exemplo de chamada no endpoint de login:
+
+```ts
+await writeAuditLog(
+  {
+    userId: decoded.uid,
+    actionType: 'login',
+    timestamp: new Date().toISOString(),
+    targetResourceId: decoded.uid,
+  },
+  firestoreAdmin
+);
+```
+
+**Recomendação:** revisar cada serviço para garantir que chamadas ao `writeAuditLog` sejam feitas em todas as ações sensíveis (criação, leitura, atualização e exclusão).
 
 ## 2. Conteúdo do Log
 
-Não existe estrutura definida para os registros de auditoria no código atual. Assim, campos essenciais como `userId`, `actionType`, `timestamp` e `targetResourceId` não são salvos.
+O serviço `writeAuditLog` recebe objetos do tipo `AuditLogEntry`, que já definem os campos básicos do log: `userId`, `actionType`, `timestamp` e `targetResourceId`. Esses valores são persistidos diretamente na coleção `auditLogs`.
 
-**Recomendação:** definir um esquema para `auditLogs` contendo ao menos:
-
-- `userId`: identificador do usuário responsável pela ação;
-- `actionType`: descrição da ação (ex.: `createAppointment`, `login`);
-- `timestamp`: data e hora geradas no servidor;
-- `targetResourceId`: id do recurso afetado.
+**Recomendação:** manter esse esquema simples e garantir que cada chamada forneça as informações necessárias.
 
 ## 3. Imutabilidade do Log
 
-Não há regras de segurança para a coleção de auditoria. Sem regras específicas, usuários autenticados podem potencialmente alterar ou remover registros.
-
-**Recomendação:** adicionar ao `firestore.rules` a entrada abaixo para impedir modificações e exclusões:
+O arquivo `firestore.rules` já define restrições específicas para a coleção `auditLogs`, permitindo apenas a criação por usuários autenticados e leitura exclusiva por administradores. Atualizações e exclusões são bloqueadas.
 
 ```firestore
 match /auditLogs/{id} {
   allow create: if request.auth != null;
-  allow update, delete: if false;
   allow read: if isAdmin();
+  allow update, delete: if false;
 }
 ```


### PR DESCRIPTION
## Summary
- revisa documento `audit-trail-analysis.md`
- referencia serviço `writeAuditLog`, regras em `firestore.rules` e exemplo de uso no endpoint de login

## Testing
- `./run-tests.sh` *(falhou: erro ao baixar dependências para Firebase emulator)*

------
https://chatgpt.com/codex/tasks/task_e_685932a43c988324a5883afb1701df30