### PR TITLE
Add audit log hooks

### DIFF
--- a/__tests__/audit-logs-extended.test.ts
+++ b/__tests__/audit-logs-extended.test.ts
@@ -1,0 +1,109 @@
+import { initializeTestEnvironment } from '@firebase/rules-unit-testing';
+import { readFileSync } from 'fs';
+import { Firestore, getDocs, collection } from 'firebase/firestore';
+
+let createTask: any;
+let updateTask: any;
+let deleteTaskFunc: any;
+let createWaitingListEntry: any;
+let updateWaitingListEntry: any;
+let deleteWaitingListEntry: any;
+let addNotification: any;
+let markNotificationRead: any;
+let deleteNotification: any;
+let markAllNotificationsRead: any;
+let clearReadNotifications: any;
+
+let testEnv: Awaited<ReturnType<typeof initializeTestEnvironment>>;
+
+beforeAll(async () => {
+  const hostPort = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8083';
+  const [host, portStr] = hostPort.split(':');
+  const port = parseInt(portStr, 10);
+
+  testEnv = await initializeTestEnvironment({
+    projectId: 'demo-project',
+    firestore: {
+      host,
+      port,
+      rules: readFileSync('firestore.rules', 'utf8'),
+    },
+  });
+
+  const auth = { uid: 'therapist1', role: 'Psychologist' };
+  const db = testEnv.authenticatedContext(auth.uid, auth).firestore();
+
+  jest.doMock('../src/lib/firebase', () => ({
+    db,
+    auth: { currentUser: { uid: auth.uid } },
+  }));
+
+  ({ createTask, updateTask, deleteTask: deleteTaskFunc } = await import(
+    '../src/services/taskService'
+  ));
+  ({
+    createWaitingListEntry,
+    updateWaitingListEntry,
+    deleteWaitingListEntry,
+  } = await import('../src/services/waitingListService'));
+  ({
+    addNotification,
+    markNotificationRead,
+    deleteNotification,
+    markAllNotificationsRead,
+    clearReadNotifications,
+  } = await import('../src/services/notificationService'));
+});
+
+afterAll(async () => {
+  if (testEnv) await testEnv.cleanup();
+  jest.resetModules();
+});
+
+function getDb(auth: { uid: string; role: string }): Firestore {
+  return testEnv.authenticatedContext(auth.uid, auth).firestore();
+}
+
+test('audit log created for tasks, waiting list and notifications', async () => {
+  const auth = { uid: 'therapist1', role: 'Psychologist' };
+  const db = getDb(auth);
+
+  // Tasks
+  const taskId = await createTask(
+    {
+      title: 'T1',
+      dueDate: '2024-01-01',
+      assignedTo: auth.uid,
+      status: 'Pendente',
+      priority: 'Alta',
+    },
+    db,
+  );
+  await updateTask(taskId, { status: 'Concluída' }, db);
+  await deleteTaskFunc(taskId, db);
+
+  // Waiting list
+  const wId = await createWaitingListEntry({ name: 'P1', priority: 'Média' }, db);
+  await updateWaitingListEntry(wId, { notes: 'ok' }, db);
+  await deleteWaitingListEntry(wId, db);
+
+  // Notifications
+  const n1 = await addNotification(
+    auth.uid,
+    { type: 'info', message: 'm1', date: new Date().toISOString(), read: false },
+    db,
+  );
+  await markNotificationRead(auth.uid, n1, true, db);
+  await markAllNotificationsRead(auth.uid, db);
+  await clearReadNotifications(auth.uid, db);
+  const n2 = await addNotification(
+    auth.uid,
+    { type: 'info', message: 'm2', date: new Date().toISOString(), read: false },
+    db,
+  );
+  await deleteNotification(auth.uid, n2, db);
+
+  const logsSnap = await getDocs(collection(db, 'auditLogs'));
+  expect(logsSnap.size).toBe(12);
+});
+

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -1,4 +1,4 @@
-import { messaging, db } from '@/lib/firebase'; // Alterado de @/services/firebase
+import { messaging, db, auth } from '@/lib/firebase';
 import { getToken } from 'firebase/messaging';
 import {
   doc,
@@ -16,6 +16,8 @@ import {
   onSnapshot,
   Unsubscribe,
 } from 'firebase/firestore';
+import { type Firestore } from 'firebase/firestore';
+import { writeAuditLog } from './auditLogService';
 
 export interface Notification {
   id: string;
@@ -53,31 +55,108 @@ export function listenToNotifications(userId: string, callback: (n: Notification
   });
 }
 
-export async function addNotification(userId: string, data: Omit<Notification, 'id'>): Promise<string> {
-  const ref = await addDoc(collection(db, 'users', userId, 'notifications'), data);
+export async function addNotification(
+  userId: string,
+  data: Omit<Notification, 'id'>,
+  firestore: Firestore = db,
+): Promise<string> {
+  const ref = await addDoc(collection(firestore, 'users', userId, 'notifications'), data);
+  const uid = auth.currentUser?.uid;
+  if (uid) {
+    await writeAuditLog(
+      {
+        userId: uid,
+        actionType: 'addNotification',
+        timestamp: new Date().toISOString(),
+        targetResourceId: ref.id,
+      },
+      firestore,
+    );
+  }
   return ref.id;
 }
 
-export async function markNotificationRead(userId: string, notifId: string, read = true): Promise<void> {
-  await updateDoc(doc(db, 'users', userId, 'notifications', notifId), { read });
+export async function markNotificationRead(
+  userId: string,
+  notifId: string,
+  read = true,
+  firestore: Firestore = db,
+): Promise<void> {
+  await updateDoc(doc(firestore, 'users', userId, 'notifications', notifId), { read });
+  const uid = auth.currentUser?.uid;
+  if (uid) {
+    await writeAuditLog(
+      {
+        userId: uid,
+        actionType: 'markNotificationRead',
+        timestamp: new Date().toISOString(),
+        targetResourceId: notifId,
+      },
+      firestore,
+    );
+  }
 }
 
-export async function deleteNotification(userId: string, notifId: string): Promise<void> {
-  await deleteDoc(doc(db, 'users', userId, 'notifications', notifId));
+export async function deleteNotification(
+  userId: string,
+  notifId: string,
+  firestore: Firestore = db,
+): Promise<void> {
+  await deleteDoc(doc(firestore, 'users', userId, 'notifications', notifId));
+  const uid = auth.currentUser?.uid;
+  if (uid) {
+    await writeAuditLog(
+      {
+        userId: uid,
+        actionType: 'deleteNotification',
+        timestamp: new Date().toISOString(),
+        targetResourceId: notifId,
+      },
+      firestore,
+    );
+  }
 }
 
-export async function markAllNotificationsRead(userId: string): Promise<void> {
-  const q = query(collection(db, 'users', userId, 'notifications'), where('read', '==', false));
+export async function markAllNotificationsRead(
+  userId: string,
+  firestore: Firestore = db,
+): Promise<void> {
+  const q = query(collection(firestore, 'users', userId, 'notifications'), where('read', '==', false));
   const snap = await getDocs(q);
-  const batch = writeBatch(db);
+  const batch = writeBatch(firestore);
   snap.docs.forEach(d => batch.update(d.ref, { read: true }));
   await batch.commit();
+  const uid = auth.currentUser?.uid;
+  if (uid) {
+    await writeAuditLog(
+      {
+        userId: uid,
+        actionType: 'markAllNotificationsRead',
+        timestamp: new Date().toISOString(),
+      },
+      firestore,
+    );
+  }
 }
 
-export async function clearReadNotifications(userId: string): Promise<void> {
-  const q = query(collection(db, 'users', userId, 'notifications'), where('read', '==', true));
+export async function clearReadNotifications(
+  userId: string,
+  firestore: Firestore = db,
+): Promise<void> {
+  const q = query(collection(firestore, 'users', userId, 'notifications'), where('read', '==', true));
   const snap = await getDocs(q);
-  const batch = writeBatch(db);
+  const batch = writeBatch(firestore);
   snap.docs.forEach(d => batch.delete(d.ref));
   await batch.commit();
+  const uid = auth.currentUser?.uid;
+  if (uid) {
+    await writeAuditLog(
+      {
+        userId: uid,
+        actionType: 'clearReadNotifications',
+        timestamp: new Date().toISOString(),
+      },
+      firestore,
+    );
+  }
 }

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -11,11 +11,13 @@ import {
   query,
   where,
   orderBy,
+  type Firestore,
 } from 'firebase/firestore';
-import { db } from '@/lib/firebase';
+import { db, auth } from '@/lib/firebase';
 import { FIRESTORE_COLLECTIONS } from '@/lib/firestore-collections';
 import type { Task } from '@/types';
 import { format } from 'date-fns';
+import { writeAuditLog } from './auditLogService';
 
 export async function getTasks(): Promise<Task[]> {
   const q = query(collection(db, FIRESTORE_COLLECTIONS.TASKS), orderBy('dueDate'));
@@ -35,15 +37,64 @@ export async function getTasksForDate(date: Date): Promise<Task[]> {
   return snap.docs.map((d) => ({ id: d.id, ...(d.data() as Omit<Task, 'id'>) }));
 }
 
-export async function createTask(data: Omit<Task, 'id'>): Promise<string> {
-  const docRef = await addDoc(collection(db, FIRESTORE_COLLECTIONS.TASKS), data);
+export async function createTask(
+  data: Omit<Task, 'id'>,
+  firestore: Firestore = db,
+): Promise<string> {
+  const docRef = await addDoc(
+    collection(firestore, FIRESTORE_COLLECTIONS.TASKS),
+    data,
+  );
+  const uid = auth.currentUser?.uid;
+  if (uid) {
+    await writeAuditLog(
+      {
+        userId: uid,
+        actionType: 'createTask',
+        timestamp: new Date().toISOString(),
+        targetResourceId: docRef.id,
+      },
+      firestore,
+    );
+  }
   return docRef.id;
 }
 
-export async function updateTask(id: string, updates: Partial<Omit<Task, 'id'>>): Promise<void> {
-  await updateDoc(doc(db, FIRESTORE_COLLECTIONS.TASKS, id), updates);
+export async function updateTask(
+  id: string,
+  updates: Partial<Omit<Task, 'id'>>,
+  firestore: Firestore = db,
+): Promise<void> {
+  await updateDoc(doc(firestore, FIRESTORE_COLLECTIONS.TASKS, id), updates);
+  const uid = auth.currentUser?.uid;
+  if (uid) {
+    await writeAuditLog(
+      {
+        userId: uid,
+        actionType: 'updateTask',
+        timestamp: new Date().toISOString(),
+        targetResourceId: id,
+      },
+      firestore,
+    );
+  }
 }
 
-export async function deleteTask(id: string): Promise<void> {
-  await deleteDoc(doc(db, FIRESTORE_COLLECTIONS.TASKS, id));
+export async function deleteTask(
+  id: string,
+  firestore: Firestore = db,
+): Promise<void> {
+  await deleteDoc(doc(firestore, FIRESTORE_COLLECTIONS.TASKS, id));
+  const uid = auth.currentUser?.uid;
+  if (uid) {
+    await writeAuditLog(
+      {
+        userId: uid,
+        actionType: 'deleteTask',
+        timestamp: new Date().toISOString(),
+        targetResourceId: id,
+      },
+      firestore,
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- log task, waiting list and notification mutations
- allow passing Firestore instance to support emulator usage
- add coverage for these logs using Firestore test environment

## Testing
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:8084)*

------
https://chatgpt.com/codex/tasks/task_e_6859371df19c8324930b9b6fc8e58813