### PR TITLE
Add Sentry error reporting

### DIFF
--- a/scripts/backup.js
+++ b/scripts/backup.js
@@ -3,6 +3,7 @@ const { getFirestore } = require('firebase-admin/firestore');
 const { getStorage } = require('firebase-admin/storage');
 const path = require('path');
 const fs = require('fs').promises;
+const Sentry = require('@sentry/node');
 
 initializeApp({
   credential: cert({
@@ -36,6 +37,7 @@ async function run() {
 }
 
 run().catch(err => {
+  Sentry.captureException(err);
   console.error(err);
   process.exit(1);
 });

--- a/src/app/(app)/patients/[id]/page.tsx
+++ b/src/app/(app)/patients/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
+import * as Sentry from '@sentry/nextjs';
 import type { Patient } from '@/types/patient';
 import { fetchPatient } from '@/services/patientService';
 
@@ -21,6 +22,7 @@ export default function PatientDetailPage() {
           setPatient(data);
         }
       } catch (err) {
+        Sentry.captureException(err);
         console.error('Falha ao carregar paciente', err);
       } finally {
         setLoading(false);

--- a/src/app/(app)/patients/page.tsx
+++ b/src/app/(app)/patients/page.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import * as Sentry from '@sentry/nextjs';
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { UserPlus, Search, Filter, Users } from "lucide-react";
@@ -31,6 +32,7 @@ export default function PatientsPage() {
         const list = await fetchPatients();
         setPatients(list);
       } catch (err) {
+        Sentry.captureException(err);
         console.error('Falha ao carregar pacientes', err);
       } finally {
         setLoading(false);

--- a/src/app/api/admin/setUserRole/route.ts
+++ b/src/app/api/admin/setUserRole/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth as adminAuth } from 'firebase-admin';
+import * as Sentry from '@sentry/nextjs';
 
 export async function POST(request: NextRequest) {
   try {
@@ -22,6 +23,7 @@ export async function POST(request: NextRequest) {
     await adminAuth().setCustomUserClaims(uid, { role });
     return NextResponse.json({ success: true });
   } catch (e) {
+    Sentry.captureException(e);
     console.error('Erro ao definir papel', e);
     return NextResponse.json({ error: 'Erro interno' }, { status: 500 });
   }

--- a/src/app/api/ai/report-draft/route.ts
+++ b/src/app/api/ai/report-draft/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import * as Sentry from '@sentry/nextjs';
 import {
   generateReportDraft,
   GenerateReportDraftInputSchema,
@@ -18,6 +19,7 @@ export async function POST(req: Request) {
         { status: 400 },
       );
     }
+    Sentry.captureException(e);
     console.error("Error generating report draft:", e);
     return NextResponse.json(
       { error: "Failed to generate report draft" },

--- a/src/app/api/ai/session-insights/route.ts
+++ b/src/app/api/ai/session-insights/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import * as Sentry from '@sentry/nextjs';
 import {
   generateSessionInsights,
   GenerateSessionInsightsInputSchema,
@@ -18,6 +19,7 @@ export async function POST(req: Request) {
         { status: 400 },
       );
     }
+    Sentry.captureException(e);
     console.error("Error generating session insights:", e);
     return NextResponse.json(
       { error: "Failed to generate session insights" },

--- a/src/app/api/ai/session-note-template/route.ts
+++ b/src/app/api/ai/session-note-template/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import * as Sentry from '@sentry/nextjs';
 import {
   generateSessionNoteTemplate,
   GenerateSessionNoteTemplateInputSchema,
@@ -18,6 +19,7 @@ export async function POST(req: Request) {
         { status: 400 },
       );
     }
+    Sentry.captureException(e);
     console.error("Error generating session note template:", e);
     return NextResponse.json(
       { error: "Failed to generate session note template" },

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -8,6 +8,7 @@ import { useChatStore } from '@/stores/chatStore';
 import { db } from '@/lib/firebase'; // Alterado de @/services/firebase
 import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
 import { useToast } from '@/hooks/use-toast';
+import * as Sentry from '@sentry/nextjs';
 
 interface MessageInputProps {
   chatId: string;
@@ -44,6 +45,7 @@ export default function MessageInput({ chatId }: MessageInputProps) {
       });
       setNewMessage('');
     } catch (error) {
+      Sentry.captureException(error);
       console.error("Error sending message: ", error);
       toast({
         title: "Erro ao Enviar Mensagem",

--- a/src/components/clinical-formulation/FormulationMap.tsx
+++ b/src/components/clinical-formulation/FormulationMap.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import React, { useCallback, useState, useEffect, useMemo, useRef } from 'react';
+import * as Sentry from '@sentry/nextjs';
 import ReactFlow, {
   Controls,
   Background,
@@ -245,6 +246,7 @@ const FormulationMap: React.FC = () => {
     if (!mapContainerRef.current) return;
     if (!document.fullscreenElement) {
       mapContainerRef.current.requestFullscreen().catch(err => {
+        Sentry.captureException(err);
         console.error("Error attempting to enable full-screen mode: " + err.message + " (" + err.name + ")");
       });
     } else {

--- a/src/components/forms/appointment-form.tsx
+++ b/src/components/forms/appointment-form.tsx
@@ -42,6 +42,7 @@ import { ptBR } from 'date-fns/locale';
 import { useToast } from '@/hooks/use-toast';
 import useAuth from '@/hooks/use-auth';
 import { insertOrUpdateEvent, hasTokens } from '@/services/googleCalendar';
+import * as Sentry from '@sentry/nextjs';
 
 const mockPatients = [
   { id: '1', name: 'Alice Wonderland' },
@@ -314,6 +315,7 @@ export default function AppointmentForm({ appointmentData }: AppointmentFormProp
             end: { dateTime: end.toISOString() },
           });
         } catch (err) {
+          Sentry.captureException(err);
           console.error('Erro ao sincronizar com Google Calendar', err);
         }
       }
@@ -327,6 +329,7 @@ export default function AppointmentForm({ appointmentData }: AppointmentFormProp
       });
       router.push('/schedule');
     } catch (e) {
+      Sentry.captureException(e);
       console.error(e);
       toast({
         title: 'Erro Inesperado',

--- a/src/components/forms/auth/login-form.tsx
+++ b/src/components/forms/auth/login-form.tsx
@@ -28,6 +28,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { useRouter } from 'next/navigation';
 import { auth } from '@/lib/firebase';
 import { useToast } from '@/hooks/use-toast';
+import * as Sentry from '@sentry/nextjs';
 
 const loginSchema = z.object({
   email: z.string().email({ message: 'Por favor, insira um endereço de e-mail válido.' }),
@@ -67,6 +68,7 @@ export default function LoginForm() {
       });
       router.push('/dashboard');
     } catch (error) {
+      Sentry.captureException(error);
       console.error('DEBUG: Erro detalhado do Firebase Auth:', error);
       let errorMessage = 'Erro ao fazer login.';
 

--- a/src/components/forms/patient-form.tsx
+++ b/src/components/forms/patient-form.tsx
@@ -6,6 +6,7 @@ import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
+import * as Sentry from '@sentry/nextjs';
 import {
   Form,
   FormControl,
@@ -96,6 +97,7 @@ export default function PatientForm({ patientData }: PatientFormProps) {
       }
       router.push('/patients');
     } catch (err) {
+      Sentry.captureException(err);
       console.error(err);
       toast({ title: 'Erro ao salvar paciente', variant: 'destructive' });
     } finally {

--- a/src/components/forms/task-form.tsx
+++ b/src/components/forms/task-form.tsx
@@ -40,6 +40,7 @@ import { ptBR } from 'date-fns/locale';
 import { useToast } from '@/hooks/use-toast';
 import type { Task, TaskPriority, TaskStatus } from '@/types';
 import { createTask, updateTask } from '@/services/taskService';
+import * as Sentry from '@sentry/nextjs';
 
 const taskFormSchema = z.object({
   title: z.string().min(3, { message: 'O título deve ter pelo menos 3 caracteres.' }),
@@ -126,6 +127,7 @@ export default function TaskForm({ initialData, isEditMode = false }: TaskFormPr
       }
       router.push('/tasks');
     } catch (err) {
+      Sentry.captureException(err);
       console.error(err);
       toast({
         title: 'Erro',

--- a/src/components/forms/template-editor.tsx
+++ b/src/components/forms/template-editor.tsx
@@ -16,6 +16,7 @@ import { useForm } from "react-hook-form";
 import { Form } from "@/components/ui/form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
+import * as Sentry from '@sentry/nextjs';
 
 interface TemplateEditorProps {
   templateId?: string; 
@@ -103,6 +104,7 @@ export default function TemplateEditor({
         description: "Um rascunho de modelo foi gerado e preenchido no editor.",
       });
     } catch (error) {
+      Sentry.captureException(error);
       console.error("Erro ao gerar modelo:", error);
       toast({
         title: "Falha na Geração com IA",

--- a/src/components/forms/waiting-list-form.tsx
+++ b/src/components/forms/waiting-list-form.tsx
@@ -6,6 +6,7 @@ import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
+import * as Sentry from '@sentry/nextjs';
 import {
   Form,
   FormControl,
@@ -117,6 +118,7 @@ export default function WaitingListForm({ initialData, entryId }: WaitingListFor
       }
       router.push('/waiting-list');
     } catch (err) {
+      Sentry.captureException(err);
       console.error(err);
       toast({
         title: 'Erro',

--- a/src/components/patients/session-note-card.tsx
+++ b/src/components/patients/session-note-card.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/components/ui/dialog";
 import { Textarea } from '../ui/textarea';
 import { useToast } from '@/hooks/use-toast';
+import * as Sentry from '@sentry/nextjs';
 
 interface SessionNote {
   id: string;
@@ -67,6 +68,7 @@ function SessionNoteCardComponent({ note, patientName, therapistName = "Psicólo
       setInsights(result);
       toast({ title: "Insights Gerados" });
     } catch (e) {
+      Sentry.captureException(e);
       console.error("Falha ao gerar insights:", e);
       setErrorInsights("Falha ao gerar insights. Por favor, tente novamente.");
     } finally {
@@ -99,6 +101,7 @@ function SessionNoteCardComponent({ note, patientName, therapistName = "Psicólo
       setReportDraft(result.draftContent);
       toast({ title: "Rascunho de relatório gerado" });
     } catch (e) {
+      Sentry.captureException(e);
       console.error("Falha ao gerar rascunho de relatório:", e);
       setErrorReport(`Falha ao gerar rascunho de ${reportTypeName}. Por favor, tente novamente.`);
     } finally {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -3,6 +3,7 @@
 
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
+import * as Sentry from '@sentry/nextjs'
 import { cva, type VariantProps } from "class-variance-authority"
 import { Check } from "lucide-react"
 
@@ -56,9 +57,11 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       (children as React.ReactElement).type !== React.Fragment;
 
     if (asChild && !hasSingleValidChild) {
-      console.error(
+      const err = new Error(
         "Button with asChild expects a single React element child that is not a Fragment. Rendering a default <button> instead."
       )
+      Sentry.captureException(err)
+      console.error(err)
     }
 
     const Comp = asChild && hasSingleValidChild ? Slot : "button"

--- a/src/components/ui/copy-button.tsx
+++ b/src/components/ui/copy-button.tsx
@@ -4,6 +4,7 @@ import { Clipboard, Check } from "lucide-react";
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { copyToClipboard } from "@/utils/copyToClipboard";
+import * as Sentry from '@sentry/nextjs';
 
 interface CopyButtonProps {
   value: string;
@@ -21,6 +22,7 @@ export default function CopyButton({ value, className }: CopyButtonProps) {
         setTimeout(() => setCopied(false), 1500);
       }
     } catch (e) {
+      Sentry.captureException(e);
       console.error("Failed to copy", e);
     }
   };

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -4,6 +4,7 @@
 import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
 import { Slot } from "@radix-ui/react-slot"
+import * as Sentry from '@sentry/nextjs'
 import {
   Controller,
   FormProvider,
@@ -117,9 +118,11 @@ const FormControl = React.forwardRef<
     (children as React.ReactElement).type !== React.Fragment
 
   if (!hasSingleValidChild) {
-    console.error(
+    const err = new Error(
       "FormControl expects a single React element child. Rendering a <div> wrapper instead."
     )
+    Sentry.captureException(err)
+    console.error(err)
   }
 
   const Comp: any = hasSingleValidChild ? Slot : "div"

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -4,6 +4,7 @@
 
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
+import * as Sentry from '@sentry/nextjs'
 import { VariantProps, cva } from "class-variance-authority"
 import { PanelLeft } from "lucide-react"
 
@@ -578,9 +579,11 @@ const SidebarMenuButton = React.forwardRef<HTMLButtonElement, SidebarMenuButtonP
       (children as React.ReactElement).type !== React.Fragment
 
     if (ownAsChildProp && !hasSingleValidChild) {
-      console.error(
+      const err = new Error(
         "SidebarMenuButton with asChild expects a single React element child. Rendering a <button> instead."
       )
+      Sentry.captureException(err)
+      console.error(err)
     }
 
     const Comp = ownAsChildProp && hasSingleValidChild ? Slot : "button";

--- a/src/features/auth/hooks/useAuth.ts
+++ b/src/features/auth/hooks/useAuth.ts
@@ -1,5 +1,6 @@
 
 import { useEffect, useState } from 'react';
+import * as Sentry from '@sentry/nextjs';
 import {
   getAuth,
   onAuthStateChanged,
@@ -35,6 +36,7 @@ export default function useAuth() {
           role: (tokenResult.claims.role as string | undefined) ?? null,
         });
       } catch (error) {
+        Sentry.captureException(error);
         console.error('Erro ao obter token do usuário', error);
         setUser({
           uid: firebaseUser.uid,

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,5 +1,6 @@
 
 import { initializeApp, getApps, getApp, type FirebaseApp } from 'firebase/app';
+import * as Sentry from '@sentry/nextjs';
 import { getAuth, connectAuthEmulator, type Auth } from 'firebase/auth';
 import { getFirestore, connectFirestoreEmulator, type Firestore } from 'firebase/firestore';
 import { getStorage, connectStorageEmulator, type FirebaseStorage } from 'firebase/storage';
@@ -69,6 +70,7 @@ if (process.env.NODE_ENV === 'development') {
     // console.info(`Functions Emulator connected to ${host}:${functionsPort}`);
     
   } catch (error) {
+    Sentry.captureException(error);
     console.error('Error connecting to Firebase Emulators:', error);
   }
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server';
+import * as Sentry from '@sentry/nextjs';
 
 const PUBLIC_PATHS = ['/login'];
 
@@ -27,6 +28,7 @@ export async function middleware(request: NextRequest) {
         return NextResponse.next();
       }
     } catch (err) {
+      Sentry.captureException(err);
       globalThis.console.error('Erro ao verificar token', err);
     }
   }

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -12,6 +12,7 @@ import type {
   GenerateSessionNoteTemplateInput,
   GenerateSessionNoteTemplateOutput,
 } from '@/ai/flows/generate-session-note-template';
+import * as Sentry from '@sentry/nextjs';
 
 export const DEFAULT_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutos
 
@@ -67,6 +68,7 @@ async function requestAI<T>(url: string, body: unknown, ttlMs = DEFAULT_CACHE_TT
     }
     return data;
   } catch (e) {
+    Sentry.captureException(e);
     console.error('Erro na comunicação com o serviço de IA:', e);
     throw new Error(
       'Não foi possível conectar ao serviço de IA. Verifique sua conexão e tente novamente.'

--- a/src/services/authRole.ts
+++ b/src/services/authRole.ts
@@ -2,6 +2,7 @@
 'use client';
 
 import { getAuth, getIdTokenResult } from 'firebase/auth';
+import * as Sentry from '@sentry/nextjs';
 
 export type UserRole = 'Admin' | 'Psychologist' | 'Secretary';
 
@@ -15,6 +16,7 @@ export async function getCurrentUserRole(): Promise<UserRole | null> {
     const role = claims.role as UserRole | undefined;
     return role ?? null;
   } catch (error) {
+    Sentry.captureException(error);
     console.error('Erro ao obter role do usuário', error);
     return null;
   }

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -16,6 +16,7 @@ import {
   onSnapshot,
   Unsubscribe,
 } from 'firebase/firestore';
+import * as Sentry from '@sentry/nextjs';
 
 export interface Notification {
   id: string;
@@ -40,6 +41,7 @@ export async function registerFcmToken(userId: string): Promise<string | null> {
     }
     return token;
   } catch (err) {
+    Sentry.captureException(err);
     console.error('Unable to get FCM token', err);
     return null;
   }

--- a/src/services/patientService.ts
+++ b/src/services/patientService.ts
@@ -16,6 +16,7 @@ import type { Patient } from '@/types/patient';
 import { FIRESTORE_COLLECTIONS } from '@/lib/firestore-collections';
 import { encrypt, decrypt, type EncryptionResult } from '@/lib/crypto-utils';
 import { getEncryptionKey } from '@/lib/encryptionKey';
+import * as Sentry from '@sentry/nextjs';
 
 interface FirestorePatient {
   ownerId: string;
@@ -69,6 +70,7 @@ export async function fetchPatients(): Promise<Patient[]> {
       } as Patient;
     });
   } catch (err) {
+    Sentry.captureException(err);
     console.error('Erro ao buscar pacientes', err);
     return [];
   }
@@ -97,6 +99,7 @@ export async function fetchPatient(id: string): Promise<Patient | null> {
       lastAppointmentDate: data.lastAppointmentDate ?? null,
     } as Patient;
   } catch (err) {
+    Sentry.captureException(err);
     console.error('Erro ao buscar paciente', err);
     return null;
   }

--- a/src/utils/copyToClipboard.ts
+++ b/src/utils/copyToClipboard.ts
@@ -1,3 +1,5 @@
+import * as Sentry from '@sentry/nextjs';
+
 export async function copyToClipboard(text: string): Promise<boolean> {
   if (navigator.clipboard) {
     try {
@@ -21,6 +23,7 @@ export async function copyToClipboard(text: string): Promise<boolean> {
   try {
     success = document.execCommand('copy')
   } catch (err) {
+    Sentry.captureException(err)
     console.error('Fallback copy failed', err)
   }
   document.body.removeChild(textArea)


### PR DESCRIPTION
## Summary
- capture exceptions using Sentry across client and server code
- keep console.error logs after sending errors to Sentry

## Testing
- `npm test` *(fails: FetchError ECONNREFUSED, cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68593729ddac8324a1ca9bd3fe2b0cf9