### PR TITLE
Use auth role in analytics page

### DIFF
--- a/src/app/(app)/analytics/page.tsx
+++ b/src/app/(app)/analytics/page.tsx
@@ -31,6 +31,7 @@ import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
+import useAuth from '@/hooks/use-auth';
 import { checkUserRole } from '@/services/authRole';
 import { getTotalPatients, getSessionsThisMonth } from '@/services/metricsService';
 
@@ -129,8 +130,8 @@ const getOccupancyBadgeVariant = (
 // --- Component Definition ---
 export default function AnalyticsHubPage() {
   const router = useRouter();
-  // TODO: Replace with a real role from an auth hook
-  const userRole: 'Admin' | 'Psychologist' = 'Admin';
+  const { user } = useAuth();
+  const userRole = user?.role as 'Admin' | 'Psychologist' | undefined;
 
   const [overallStats, setOverallStats] = useState<OverallStats>({
     activePatients: 0,

--- a/src/features/dashboard/__tests__/AnalyticsPage.test.tsx
+++ b/src/features/dashboard/__tests__/AnalyticsPage.test.tsx
@@ -1,0 +1,24 @@
+import { render, waitFor } from '@testing-library/react';
+import AnalyticsHubPage from '@/app/(app)/analytics/page';
+import { checkUserRole } from '@/services/authRole';
+
+jest.mock('@/services/authRole');
+jest.mock('@/services/metricsService', () => ({
+  getTotalPatients: jest.fn().mockResolvedValue(0),
+  getSessionsThisMonth: jest.fn().mockResolvedValue(0),
+}));
+
+const replaceMock = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: replaceMock }),
+}));
+
+describe('AnalyticsHubPage', () => {
+  it('redireciona se o usuário não tem permissão', async () => {
+    (checkUserRole as jest.Mock).mockResolvedValue(false);
+    render(<AnalyticsHubPage />);
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith('/');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- remove static userRole and read from auth hook
- test analytics route redirect when unauthorized

## Testing
- `npm test` *(fails: cannot connect to firebase emulator)*

------
https://chatgpt.com/codex/tasks/task_e_685937258cd08324a29109f85f9098c2