### PR TITLE
Implement group service and integrate pages

### DIFF
--- a/__tests__/groups.service.test.ts
+++ b/__tests__/groups.service.test.ts
@@ -1,0 +1,75 @@
+import { initializeTestEnvironment } from '@firebase/rules-unit-testing';
+import { readFileSync } from 'fs';
+import { Firestore } from 'firebase/firestore';
+
+let createGroup: any;
+let fetchGroups: any;
+let updateGroup: any;
+let deleteGroup: any;
+
+let testEnv: Awaited<ReturnType<typeof initializeTestEnvironment>>;
+
+beforeAll(async () => {
+  const hostPort = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8084';
+  const [host, portStr] = hostPort.split(':');
+  const port = parseInt(portStr, 10);
+
+  testEnv = await initializeTestEnvironment({
+    projectId: 'demo-project',
+    firestore: {
+      host,
+      port,
+      rules: readFileSync('firestore.rules', 'utf8'),
+    },
+  });
+
+  const auth = { uid: 'therapist1', role: 'Psychologist' };
+  const db = testEnv.authenticatedContext(auth.uid, auth).firestore();
+
+  jest.doMock('../src/lib/firebase', () => ({
+    db,
+    auth: { currentUser: { uid: auth.uid } },
+  }));
+
+  ({ createGroup, fetchGroups, updateGroup, deleteGroup } = await import(
+    '../src/services/groupService'
+  ));
+});
+
+afterAll(async () => {
+  if (testEnv) await testEnv.cleanup();
+  jest.resetModules();
+});
+
+function getDb(auth: { uid: string; role: string }): Firestore {
+  return testEnv.authenticatedContext(auth.uid, auth).firestore();
+}
+
+test('create, update and delete group', async () => {
+  const auth = { uid: 'therapist1', role: 'Psychologist' };
+  const db = getDb(auth);
+
+  const groupId = await createGroup(
+    {
+      name: 'Grupo Teste',
+      psychologistId: auth.uid,
+      patientIds: ['p1', 'p2'],
+      dayOfWeek: 'monday',
+      startTime: '10:00',
+      endTime: '11:00',
+    },
+    db
+  );
+
+  let groups = await fetchGroups(db);
+  expect(groups.length).toBe(1);
+  expect(groups[0].id).toBe(groupId);
+
+  await updateGroup(groupId, { endTime: '11:30' }, db);
+  groups = await fetchGroups(db);
+  expect(groups[0].endTime).toBe('11:30');
+
+  await deleteGroup(groupId, db);
+  groups = await fetchGroups(db);
+  expect(groups.length).toBe(0);
+});

--- a/firestore.rules
+++ b/firestore.rules
@@ -197,6 +197,13 @@ service cloud.firestore {
       allow update, delete: if isAdmin(); // Apenas admin pode deletar (em casos excepcionais)
     }
 
+    // Coleção de Grupos Terapêuticos (Groups)
+    match /groups/{id} {
+      allow read: if isStaff();
+      allow create: if (isPsychologist() && request.auth.uid == request.resource.data.psychologistId) || isAdmin();
+      allow update, delete: if (isPsychologist() && request.auth.uid == resource.data.psychologistId) || isAdmin();
+    }
+
     // Coleção de Tarefas (Tasks)
     match /tasks/{id} {
       allow read, update: if isStaff();

--- a/src/app/(app)/groups/edit/[id]/page.tsx
+++ b/src/app/(app)/groups/edit/[id]/page.tsx
@@ -1,19 +1,17 @@
+'use client';
 
-"use client";
-
-import React, { useEffect, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
-import GroupForm, { type GroupFormValues } from "@/components/forms/group-form";
-import { mockTherapeuticGroups } from "@/app/(app)/groups/page";
-import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/ui/skeleton";
-import { Users, Edit, FileWarning } from "lucide-react";
-import Link from "next/link";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import GroupForm, { type GroupFormValues } from '@/components/forms/group-form';
+import { fetchGroups } from '@/services/groupService';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Edit, FileWarning } from 'lucide-react';
+import Link from 'next/link';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
 
 export default function EditGroupPage() {
   const params = useParams();
-  const router = useRouter();
   const groupId = params.id as string;
 
   const [groupData, setGroupData] = useState<GroupFormValues | null>(null);
@@ -21,27 +19,32 @@ export default function EditGroupPage() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (groupId) {
-      const foundGroup = mockTherapeuticGroups.find(g => g.id === groupId);
-      if (foundGroup) {
-        setGroupData({
-          name: foundGroup.name,
-          description: foundGroup.description || "",
-          psychologistId: foundGroup.psychologistId,
-          patientIds: foundGroup.participants.map(p => p.id),
-          dayOfWeek: foundGroup.dayOfWeek,
-          startTime: foundGroup.startTime,
-          endTime: foundGroup.endTime,
-          meetingAgenda: foundGroup.meetingAgenda || "",
-        });
-      } else {
-        setError("Grupo não encontrado.");
-      }
+    if (!groupId) {
+      setError('ID do grupo não fornecido.');
       setLoading(false);
-    } else {
-      setError("ID do grupo não fornecido.");
-      setLoading(false);
+      return;
     }
+
+    fetchGroups()
+      .then((list) => {
+        const found = list.find((g) => g.id === groupId);
+        if (found) {
+          setGroupData({
+            name: found.name,
+            description: found.description || '',
+            psychologistId: found.psychologistId,
+            patientIds: found.patientIds || [],
+            dayOfWeek: found.dayOfWeek,
+            startTime: found.startTime,
+            endTime: found.endTime,
+            meetingAgenda: found.meetingAgenda || '',
+          });
+        } else {
+          setError('Grupo não encontrado.');
+        }
+      })
+      .catch(() => setError('Erro ao carregar grupo.'))
+      .finally(() => setLoading(false));
   }, [groupId]);
 
   if (loading) {
@@ -52,7 +55,9 @@ export default function EditGroupPage() {
           <h1 className="text-3xl font-headline font-bold">Carregando Grupo...</h1>
         </div>
         <Card className="shadow-lg">
-          <CardHeader><Skeleton className="h-8 w-1/3" /></CardHeader>
+          <CardHeader>
+            <Skeleton className="h-8 w-1/3" />
+          </CardHeader>
           <CardContent className="space-y-4">
             <Skeleton className="h-10 w-full" />
             <Skeleton className="h-20 w-full" />
@@ -60,7 +65,9 @@ export default function EditGroupPage() {
             <Skeleton className="h-10 w-1/2" />
             <Skeleton className="h-40 w-full" /> {/* For patient selection */}
             <Skeleton className="h-20 w-full" />
-            <div className="flex justify-end"><Skeleton className="h-10 w-24" /></div>
+            <div className="flex justify-end">
+              <Skeleton className="h-10 w-24" />
+            </div>
           </CardContent>
         </Card>
       </div>
@@ -72,11 +79,9 @@ export default function EditGroupPage() {
       <div className="space-y-6 text-center py-10">
         <FileWarning className="mx-auto h-16 w-16 text-destructive" />
         <h1 className="text-3xl font-headline font-bold text-destructive">
-          {error || "Grupo não encontrado"}
+          {error || 'Grupo não encontrado'}
         </h1>
-        <p className="text-muted-foreground">
-          Não foi possível carregar o grupo para edição.
-        </p>
+        <p className="text-muted-foreground">Não foi possível carregar o grupo para edição.</p>
         <Button variant="outline" asChild>
           <Link href="/groups">Voltar para Grupos</Link>
         </Button>

--- a/src/app/(app)/groups/page.tsx
+++ b/src/app/(app)/groups/page.tsx
@@ -1,82 +1,61 @@
+'use client';
 
-"use client"; 
-
-import React from 'react'; 
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from "@/components/ui/card";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
-import { Users, PlusCircle, Search, Filter, MoreHorizontal, CalendarPlus, Trash2, Edit } from "lucide-react";
-import Link from "next/link";
-import { Badge } from "@/components/ui/badge";
+import React, { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Users,
+  PlusCircle,
+  Search,
+  Filter,
+  MoreHorizontal,
+  CalendarPlus,
+  Trash2,
+  Edit,
+} from 'lucide-react';
+import Link from 'next/link';
+import { Badge } from '@/components/ui/badge';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
-import type { GroupResource } from '@/types/group';
-
-export const mockTherapeuticGroups = [
-  {
-    id: "grp1",
-    name: "Grupo de Apoio à Ansiedade",
-    psychologist: "Dr. Silva",
-    psychologistId: "psy1",
-    membersCount: 2, 
-    schedule: "Terças, 18:00 - 19:30",
-    dayOfWeek: "tuesday",
-    startTime: "18:00",
-    endTime: "19:30",
-    nextSession: "2024-08-06T18:00:00Z",
-    description: "Um grupo focado em fornecer apoio mútuo e estratégias de enfrentamento para indivíduos que lidam com ansiedade. As sessões incluem discussões, técnicas de relaxamento e compartilhamento de experiências.",
-    participants: [
-      { id: "1", name: "Alice Wonderland", avatarUrl: "https://placehold.co/100x100/D0BFFF/4F3A76?text=AW", dataAiHint: "female avatar" },
-      { id: "2", name: "Bob O Construtor", avatarUrl: "https://placehold.co/100x100/70C1B3/FFFFFF?text=BC", dataAiHint: "male builder" },
-    ],
-    meetingAgenda: "Sessão 1: Apresentações e estabelecimento de metas do grupo.\nSessão 2: Entendendo os mecanismos da ansiedade e identificando gatilhos pessoais.\nSessão 3: Introdução a técnicas de respiração e relaxamento muscular progressivo.\nSessão 4: Estratégias de reestruturação cognitiva para pensamentos ansiogênicos.\nSessão 5: Exposição gradual e dessensibilização sistemática (discussão e planejamento).",
-    resources: [
-      { id: "grp1res1", name: "Folha de Exercício: Roda da Vida", type: "pdf", uploadDate: "2024-07-20", description: "Atividade para autoavaliação das áreas da vida.", dataAiHint: "documento exercício" },
-      { id: "grp1res2", name: "Áudio: Meditação Guiada para Ansiedade (5 min)", type: "link", url: "#", uploadDate: "2024-07-21", description: "Link para meditação no YouTube/SoundCloud.", dataAiHint: "áudio meditação" }
-    ] as GroupResource[],
-  },
-  {
-    id: "grp2",
-    name: "Habilidades Sociais para Adolescentes",
-    psychologist: "Dra. Jones",
-    psychologistId: "psy2",
-    membersCount: 2, 
-    schedule: "Quintas, 16:00 - 17:00",
-    dayOfWeek: "thursday",
-    startTime: "16:00",
-    endTime: "17:00",
-    nextSession: "2024-08-08T16:00:00Z",
-    description: "Este grupo ajuda adolescentes a desenvolver e praticar habilidades sociais essenciais em um ambiente seguro e de apoio. Foco em comunicação, assertividade e resolução de conflitos.",
-    participants: [
-      { id: "3", name: "Charlie Brown", avatarUrl: "https://placehold.co/100x100/FCEEAC/E6B325?text=CB", dataAiHint: "boy character" },
-      { id: "4", name: "Diana Prince", avatarUrl: "https://placehold.co/100x100/E6B325/FFFFFF?text=DP", dataAiHint: "female hero" },
-    ],
-    meetingAgenda: "Encontro 1: Quebra-gelo e comunicação verbal básica (escuta ativa, iniciar conversas).\nEncontro 2: Comunicação não-verbal (linguagem corporal, contato visual).\nEncontro 3: Assertividade vs. Agressividade vs. Passividade.\nEncontro 4: Lidando com feedback e críticas.\nEncontro 5: Resolução de conflitos interpessoais.",
-    resources: [
-      { id: "grp2res1", name: "Cartões de Cenários Sociais", type: "pdf", uploadDate: "2024-07-18", description: "Situações para role-playing.", dataAiHint: "documento cartões" }
-    ] as GroupResource[],
-  },
-  {
-    id: "grp3",
-    name: "Grupo de Luto e Perdas",
-    psychologist: "Dr. Silva",
-    psychologistId: "psy1",
-    membersCount: 0, 
-    schedule: "Segundas, 10:00 - 11:30",
-    dayOfWeek: "monday",
-    startTime: "10:00",
-    endTime: "11:30",
-    nextSession: "2024-08-05T10:00:00Z",
-    description: "Um espaço para processar o luto e encontrar apoio após a perda de um ente querido. O grupo oferece um ambiente de compreensão e ferramentas para lidar com a dor.",
-    participants: [], 
-    meetingAgenda: "Semana 1: Introdução ao processo de luto e compartilhamento de histórias.\nSemana 2: Validando emoções e lidando com a saudade.\nSemana 3: Rituais de despedida e ressignificação.\nSemana 4: Encontrando novo sentido e reconstruindo o futuro.",
-    resources: [] as GroupResource[],
-  },
-];
+import type { GroupRecord } from '@/services/groupService';
+import { fetchGroups } from '@/services/groupService';
 
 export default function TherapeuticGroupsPage() {
+  const [groups, setGroups] = useState<GroupRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchGroups()
+      .then(setGroups)
+      .catch(() => setError('Erro ao carregar grupos.'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const dayOfWeekDisplay: Record<string, string> = {
+    monday: 'Segundas',
+    tuesday: 'Terças',
+    wednesday: 'Quartas',
+    thursday: 'Quintas',
+    friday: 'Sextas',
+    saturday: 'Sábados',
+    sunday: 'Domingos',
+  };
+
   return (
     <div className="space-y-6">
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
@@ -95,11 +74,16 @@ export default function TherapeuticGroupsPage() {
       <Card className="shadow-sm">
         <CardHeader>
           <CardTitle className="font-headline">Gerenciar Grupos Terapêuticos</CardTitle>
-          <CardDescription>Visualize, crie e gerencie os grupos terapêuticos da clínica.</CardDescription>
+          <CardDescription>
+            Visualize, crie e gerencie os grupos terapêuticos da clínica.
+          </CardDescription>
           <div className="flex flex-col sm:flex-row gap-2 pt-4">
             <div className="relative flex-1">
               <Search className="absolute left-2.5 top-3 h-4 w-4 text-muted-foreground" />
-              <input placeholder="Buscar grupos..." className="w-full bg-transparent pl-8 pr-3 py-2 border border-input rounded-md focus:outline-none focus:ring-2 focus:ring-ring" />
+              <input
+                placeholder="Buscar grupos..."
+                className="w-full bg-transparent pl-8 pr-3 py-2 border border-input rounded-md focus:outline-none focus:ring-2 focus:ring-ring"
+              />
             </div>
             <Button variant="outline">
               <Filter className="mr-2 h-4 w-4" /> Filtros
@@ -107,7 +91,11 @@ export default function TherapeuticGroupsPage() {
           </div>
         </CardHeader>
         <CardContent>
-          {mockTherapeuticGroups.length > 0 ? (
+          {loading ? (
+            <p className="text-sm text-muted-foreground">Carregando...</p>
+          ) : error ? (
+            <p className="text-sm text-destructive">{error}</p>
+          ) : groups.length > 0 ? (
             <div className="overflow-x-auto">
               <Table>
                 <TableHeader>
@@ -121,19 +109,23 @@ export default function TherapeuticGroupsPage() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {mockTherapeuticGroups.map(group => (
+                  {groups.map((group) => (
                     <TableRow key={group.id}>
                       <TableCell className="font-medium">
                         <Link href={`/groups/${group.id}`} className="hover:underline text-accent">
                           {group.name}
                         </Link>
                       </TableCell>
-                      <TableCell>{group.psychologist}</TableCell>
+                      <TableCell>{group.psychologistId}</TableCell>
                       <TableCell className="text-center">
-                        <Badge variant="secondary">{group.participants.length}</Badge>
+                        <Badge variant="secondary">{group.patientIds?.length || 0}</Badge>
                       </TableCell>
-                      <TableCell>{group.schedule}</TableCell>
-                      <TableCell>{group.nextSession ? format(new Date(group.nextSession), "P 'às' HH:mm", { locale: ptBR }) : "N/A"}</TableCell>
+                      <TableCell>{`${dayOfWeekDisplay[group.dayOfWeek] || group.dayOfWeek}, ${group.startTime} - ${group.endTime}`}</TableCell>
+                      <TableCell>
+                        {group.nextSession
+                          ? format(new Date(group.nextSession), "P 'às' HH:mm", { locale: ptBR })
+                          : 'N/A'}
+                      </TableCell>
                       <TableCell className="text-right">
                         <DropdownMenu>
                           <DropdownMenuTrigger asChild>
@@ -171,18 +163,20 @@ export default function TherapeuticGroupsPage() {
               </Table>
             </div>
           ) : (
-             <div className="text-center py-10">
+            <div className="text-center py-10">
               <Users className="mx-auto h-12 w-12 text-muted-foreground" />
-              <h3 className="mt-2 text-sm font-medium text-foreground">Nenhum grupo terapêutico encontrado</h3>
+              <h3 className="mt-2 text-sm font-medium text-foreground">
+                Nenhum grupo terapêutico encontrado
+              </h3>
               <p className="mt-1 text-sm text-muted-foreground">Comece criando um novo grupo.</p>
-               <Button asChild className="mt-4 bg-accent hover:bg-accent/90 text-accent-foreground">
-                  <Link href="/groups/new" className="inline-flex items-center gap-2">
-                    <PlusCircle className="h-4 w-4" />
-                    Criar Novo Grupo
-                  </Link>
-               </Button>
+              <Button asChild className="mt-4 bg-accent hover:bg-accent/90 text-accent-foreground">
+                <Link href="/groups/new" className="inline-flex items-center gap-2">
+                  <PlusCircle className="h-4 w-4" />
+                  Criar Novo Grupo
+                </Link>
+              </Button>
             </div>
-           )}
+          )}
         </CardContent>
       </Card>
     </div>

--- a/src/components/schedule/appointment-calendar.tsx
+++ b/src/components/schedule/appointment-calendar.tsx
@@ -1,15 +1,41 @@
+'use client';
 
-"use client";
-
-import React, { useState, useMemo, useEffect, useCallback } from 'react';
-import { Card, CardContent } from "@/components/ui/card";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { Button } from "@/components/ui/button";
-import { Clock, User, PlusCircle, Edit, Trash2, FileText, CheckCircle, AlertTriangle, XCircle, Check, Ban, UserCheck, UserX, RepeatIcon, GripVertical, CalendarX2, Users as UsersIcon, ChevronDown } from 'lucide-react';
-import { format, startOfWeek, endOfWeek, eachDayOfInterval, addDays, subDays, isSameMonth, isSameDay, parse, getDay, parseISO } from 'date-fns';
+import React, { useState, useEffect, useCallback } from 'react';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Button } from '@/components/ui/button';
+import {
+  Clock,
+  User,
+  PlusCircle,
+  Edit,
+  Trash2,
+  FileText,
+  CheckCircle,
+  AlertTriangle,
+  Check,
+  Ban,
+  UserCheck,
+  UserX,
+  RepeatIcon,
+  GripVertical,
+  CalendarX2,
+  Users as UsersIcon,
+  ChevronDown,
+} from 'lucide-react';
+import {
+  format,
+  startOfWeek,
+  endOfWeek,
+  eachDayOfInterval,
+  addDays,
+  isSameMonth,
+  isSameDay,
+  parse,
+  getDay,
+} from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import Link from 'next/link';
-import { cn } from "@/shared/utils";
+import { cn } from '@/shared/utils';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -20,7 +46,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   AlertDialogTrigger,
-} from "@/components/ui/alert-dialog";
+} from '@/components/ui/alert-dialog';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -28,79 +54,97 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { useToast } from "@/hooks/use-toast";
-import type { Appointment, AppointmentsByDate, AppointmentStatus } from "@/types/appointment";
+} from '@/components/ui/dropdown-menu';
+import { useToast } from '@/hooks/use-toast';
+import type { Appointment, AppointmentsByDate, AppointmentStatus } from '@/types/appointment';
 import { getInitialMockAppointments } from '@/services/appointmentService';
 import InfoDisplay from '@/components/ui/info-display';
-import { mockTherapeuticGroups } from '@/app/(app)/groups/page';
-
+import { fetchGroups, type GroupRecord } from '@/services/groupService';
 
 const mockPsychologists = [
-  { id: "psy1", name: "Dr. Silva" },
-  { id: "psy2", name: "Dra. Jones" },
-  { id: "all", name: "Todos os Psicólogos" },
+  { id: 'psy1', name: 'Dr. Silva' },
+  { id: 'psy2', name: 'Dra. Jones' },
+  { id: 'all', name: 'Todos os Psicólogos' },
 ];
 
 export { getInitialMockAppointments } from '@/services/appointmentService';
 
 const dayOfWeekMapping: Record<string, number> = {
-  sunday: 0, monday: 1, tuesday: 2, wednesday: 3, thursday: 4, friday: 5, saturday: 6,
+  sunday: 0,
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
 };
 
 const getStatusStyles = (status: AppointmentStatus, isGroupSession?: boolean): string => {
-    if (isGroupSession) {
-      return "bg-purple-500/15 text-purple-700 dark:text-purple-300 hover:bg-purple-500/25 border-l-4 border-purple-500";
-    }
-    switch (status) {
-        case "Scheduled":
-        case "Confirmed":
-            return "bg-accent/15 text-accent-foreground hover:bg-accent/25 border-l-4 border-accent";
-        case "Completed":
-            return "bg-primary/15 text-primary-foreground hover:bg-primary/25 border-l-4 border-primary";
-        case "Blocked":
-            return "bg-muted/70 text-muted-foreground hover:bg-muted border-l-4 border-slate-400";
-        case "CancelledByPatient":
-        case "CancelledByClinic":
-        case "NoShow":
-            return "bg-destructive/10 text-destructive-foreground hover:bg-destructive/20 border-l-4 border-destructive";
-        case "Rescheduled":
-            return "bg-yellow-500/15 text-yellow-700 dark:text-yellow-300 dark:bg-yellow-700/25 hover:bg-yellow-500/25 dark:hover:bg-yellow-700/35 border-l-4 border-yellow-500";
-        default:
-            return "bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300 border-l-4 border-slate-300";
-    }
+  if (isGroupSession) {
+    return 'bg-purple-500/15 text-purple-700 dark:text-purple-300 hover:bg-purple-500/25 border-l-4 border-purple-500';
+  }
+  switch (status) {
+    case 'Scheduled':
+    case 'Confirmed':
+      return 'bg-accent/15 text-accent-foreground hover:bg-accent/25 border-l-4 border-accent';
+    case 'Completed':
+      return 'bg-primary/15 text-primary-foreground hover:bg-primary/25 border-l-4 border-primary';
+    case 'Blocked':
+      return 'bg-muted/70 text-muted-foreground hover:bg-muted border-l-4 border-slate-400';
+    case 'CancelledByPatient':
+    case 'CancelledByClinic':
+    case 'NoShow':
+      return 'bg-destructive/10 text-destructive-foreground hover:bg-destructive/20 border-l-4 border-destructive';
+    case 'Rescheduled':
+      return 'bg-yellow-500/15 text-yellow-700 dark:text-yellow-300 dark:bg-yellow-700/25 hover:bg-yellow-500/25 dark:hover:bg-yellow-700/35 border-l-4 border-yellow-500';
+    default:
+      return 'bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300 border-l-4 border-slate-300';
+  }
 };
 
-const getStatusIcon = (status: AppointmentStatus, className: string = "w-3.5 h-3.5 mr-1.5 inline-block", isGroupSession?: boolean) => {
-    if (isGroupSession) {
-      return <UsersIcon className={cn(className, "text-purple-600/80 dark:text-purple-400/80")} />;
-    }
-    switch (status) {
-        case "Scheduled": return <Clock className={cn(className, "text-accent-foreground/80")} />;
-        case "Confirmed": return <UserCheck className={cn(className, "text-accent-foreground/80")} />;
-        case "Completed": return <CheckCircle className={cn(className, "text-primary-foreground/80")} />;
-        case "CancelledByPatient": return <UserX className={cn(className, "text-destructive-foreground/80")} />;
-        case "CancelledByClinic": return <Ban className={cn(className, "text-destructive-foreground/80")} />;
-        case "Blocked": return <AlertTriangle className={cn(className, "text-muted-foreground/80")} />;
-        case "NoShow": return <UserX className={cn(className, "text-destructive-foreground/80")} />;
-        case "Rescheduled": return <RepeatIcon className={cn(className, "text-yellow-600/80 dark:text-yellow-400/80")} />;
-        default: return <Clock className={cn(className, "text-slate-500/80")} />;
-    }
+const getStatusIcon = (
+  status: AppointmentStatus,
+  className: string = 'w-3.5 h-3.5 mr-1.5 inline-block',
+  isGroupSession?: boolean
+) => {
+  if (isGroupSession) {
+    return <UsersIcon className={cn(className, 'text-purple-600/80 dark:text-purple-400/80')} />;
+  }
+  switch (status) {
+    case 'Scheduled':
+      return <Clock className={cn(className, 'text-accent-foreground/80')} />;
+    case 'Confirmed':
+      return <UserCheck className={cn(className, 'text-accent-foreground/80')} />;
+    case 'Completed':
+      return <CheckCircle className={cn(className, 'text-primary-foreground/80')} />;
+    case 'CancelledByPatient':
+      return <UserX className={cn(className, 'text-destructive-foreground/80')} />;
+    case 'CancelledByClinic':
+      return <Ban className={cn(className, 'text-destructive-foreground/80')} />;
+    case 'Blocked':
+      return <AlertTriangle className={cn(className, 'text-muted-foreground/80')} />;
+    case 'NoShow':
+      return <UserX className={cn(className, 'text-destructive-foreground/80')} />;
+    case 'Rescheduled':
+      return <RepeatIcon className={cn(className, 'text-yellow-600/80 dark:text-yellow-400/80')} />;
+    default:
+      return <Clock className={cn(className, 'text-slate-500/80')} />;
+  }
 };
 
 const getStatusLabel = (status: AppointmentStatus): string => {
-    const labels: Record<AppointmentStatus, string> = {
-        Scheduled: "Agendado",
-        Completed: "Realizada",
-        CancelledByPatient: "Cancelado (Paciente)",
-        CancelledByClinic: "Cancelado (Clínica)",
-        Blocked: "Bloqueado",
-        Confirmed: "Confirmado",
-        NoShow: "Falta",
-        Rescheduled: "Remarcado",
-    };
-    return labels[status] || status;
-}
+  const labels: Record<AppointmentStatus, string> = {
+    Scheduled: 'Agendado',
+    Completed: 'Realizada',
+    CancelledByPatient: 'Cancelado (Paciente)',
+    CancelledByClinic: 'Cancelado (Clínica)',
+    Blocked: 'Bloqueado',
+    Confirmed: 'Confirmado',
+    NoShow: 'Falta',
+    Rescheduled: 'Remarcado',
+  };
+  return labels[status] || status;
+};
 
 const getDayIdFromDate = (date: Date): string => {
   const dayIndex = getDay(date);
@@ -109,7 +153,7 @@ const getDayIdFromDate = (date: Date): string => {
 };
 
 interface AppointmentCalendarProps {
-  view: "Month" | "Week" | "Day";
+  view: 'Month' | 'Week' | 'Day';
   currentDate: Date;
   filters: {
     psychologistId: string;
@@ -118,284 +162,457 @@ interface AppointmentCalendarProps {
     dateTo?: Date;
   };
   workingDaysOfWeek?: string[];
-  onAppointmentsUpdate?: (appointments: AppointmentsByDate) => void;
 }
 
 const defaultWorkingDays = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday'];
 
-const timeSlots = Array.from({ length: 12 }, (_, i) => `${String(i + 8).padStart(2, '0')}:00`); 
-const ROW_HEIGHT_CLASS = "h-16"; 
+const timeSlots = Array.from({ length: 12 }, (_, i) => `${String(i + 8).padStart(2, '0')}:00`);
+const ROW_HEIGHT_CLASS = 'h-16';
 
-function AppointmentCalendarComponent({ view, currentDate, filters, workingDaysOfWeek = defaultWorkingDays, onAppointmentsUpdate }: AppointmentCalendarProps) {
+function AppointmentCalendarComponent({
+  view,
+  currentDate,
+  filters,
+  workingDaysOfWeek = defaultWorkingDays,
+  onAppointmentsUpdate,
+}: AppointmentCalendarProps) {
   const [selectedDate, setSelectedDate] = useState<Date | undefined>(currentDate);
-  const [appointmentsState, setAppointmentsState] = useState<AppointmentsByDate>(() => getInitialMockAppointments());
+  const [appointmentsState, setAppointmentsState] = useState<AppointmentsByDate>(() =>
+    getInitialMockAppointments()
+  );
+  const [groups, setGroups] = useState<GroupRecord[]>([]);
   const { toast } = useToast();
 
   useEffect(() => {
     setAppointmentsState(getInitialMockAppointments());
   }, []);
 
-  const getAppointmentsForDay = useCallback((dayDate: Date): Appointment[] => {
-    const dateStr = format(dayDate, "yyyy-MM-dd");
-    const dayJsIndex = dayDate.getDay(); 
+  useEffect(() => {
+    fetchGroups()
+      .then(setGroups)
+      .catch(() => {});
+  }, []);
 
-    const individualAppointments = (appointmentsState[dateStr] || []).filter(appt => {
-      const matchesPsychologist = filters.psychologistId === "all" || appt.psychologistId === filters.psychologistId;
-      const matchesStatus = filters.status === "All" || appt.status === filters.status;
-      const apptDateObj = parse(dateStr, "yyyy-MM-dd", new Date());
-      const matchesDateFrom = !filters.dateFrom || apptDateObj >= new Date(new Date(filters.dateFrom).setUTCHours(0,0,0,0));
-      const matchesDateTo = !filters.dateTo || apptDateObj <= new Date(new Date(filters.dateTo).setUTCHours(23,59,59,999));
-      return matchesPsychologist && matchesStatus && matchesDateFrom && matchesDateTo;
-    });
+  const getAppointmentsForDay = useCallback(
+    (dayDate: Date): Appointment[] => {
+      const dateStr = format(dayDate, 'yyyy-MM-dd');
+      const dayJsIndex = dayDate.getDay();
 
-    const groupSessionsForDay: Appointment[] = mockTherapeuticGroups
-      .filter(group => {
-        const groupDayIndex = dayOfWeekMapping[group.dayOfWeek.toLowerCase()];
-        const matchesPsychologist = filters.psychologistId === "all" || group.psychologistId === filters.psychologistId;
-        const matchesStatus = filters.status === "All" || filters.status === "Scheduled"; 
-        return groupDayIndex === dayJsIndex && matchesPsychologist && matchesStatus;
-      })
-      .map(group => ({
-        id: `group-${group.id}-${dateStr}`,
-        startTime: group.startTime,
-        endTime: group.endTime,
-        patient: group.name, 
-        type: "Sessão em Grupo",
-        psychologistId: group.psychologistId,
-        status: "Scheduled" as AppointmentStatus, 
-        isGroupSession: true,
-        groupId: group.id,
-        blockReason: group.name, 
-        notes: group.meetingAgenda ? `Roteiro: ${group.meetingAgenda.substring(0, 50)}...` : undefined,
-      }));
+      const individualAppointments = (appointmentsState[dateStr] || []).filter((appt) => {
+        const matchesPsychologist =
+          filters.psychologistId === 'all' || appt.psychologistId === filters.psychologistId;
+        const matchesStatus = filters.status === 'All' || appt.status === filters.status;
+        const apptDateObj = parse(dateStr, 'yyyy-MM-dd', new Date());
+        const matchesDateFrom =
+          !filters.dateFrom ||
+          apptDateObj >= new Date(new Date(filters.dateFrom).setUTCHours(0, 0, 0, 0));
+        const matchesDateTo =
+          !filters.dateTo ||
+          apptDateObj <= new Date(new Date(filters.dateTo).setUTCHours(23, 59, 59, 999));
+        return matchesPsychologist && matchesStatus && matchesDateFrom && matchesDateTo;
+      });
 
-    return [...individualAppointments, ...groupSessionsForDay].sort((a, b) => a.startTime.localeCompare(b.startTime));
-  }, [appointmentsState, filters]);
+      const groupSessionsForDay: Appointment[] = groups
+        .filter((group) => {
+          const groupDayIndex = dayOfWeekMapping[group.dayOfWeek.toLowerCase()];
+          const matchesPsychologist =
+            filters.psychologistId === 'all' || group.psychologistId === filters.psychologistId;
+          const matchesStatus = filters.status === 'All' || filters.status === 'Scheduled';
+          return groupDayIndex === dayJsIndex && matchesPsychologist && matchesStatus;
+        })
+        .map((group) => ({
+          id: `group-${group.id}-${dateStr}`,
+          startTime: group.startTime,
+          endTime: group.endTime,
+          patient: group.name,
+          type: 'Sessão em Grupo',
+          psychologistId: group.psychologistId,
+          status: 'Scheduled' as AppointmentStatus,
+          isGroupSession: true,
+          groupId: group.id,
+          blockReason: group.name,
+          notes: group.meetingAgenda
+            ? `Roteiro: ${group.meetingAgenda.substring(0, 50)}...`
+            : undefined,
+        }));
 
+      return [...individualAppointments, ...groupSessionsForDay].sort((a, b) =>
+        a.startTime.localeCompare(b.startTime)
+      );
+    },
+    [appointmentsState, filters, groups]
+  );
 
-  const handleDeleteAppointment = useCallback((appointmentId: string, appointmentPatient: string, dayDate: Date) => {
-    if (appointmentId.startsWith('group-')) {
-        toast({ title: "Ação Não Permitida", description: "Sessões de grupo são gerenciadas na página de Grupos.", variant: "default" });
+  const handleDeleteAppointment = useCallback(
+    (appointmentId: string, appointmentPatient: string, dayDate: Date) => {
+      if (appointmentId.startsWith('group-')) {
+        toast({
+          title: 'Ação Não Permitida',
+          description: 'Sessões de grupo são gerenciadas na página de Grupos.',
+          variant: 'default',
+        });
         return;
-    }
-    const dateStr = format(dayDate, "yyyy-MM-dd");
-    setAppointmentsState(prev => {
-        const updatedAppointmentsForDate = (prev[dateStr] || []).filter(appt => appt.id !== appointmentId);
-        const newState = { ...prev, [dateStr]: updatedAppointmentsForDate };
-        if (onAppointmentsUpdate) onAppointmentsUpdate(newState);
-        return newState;
-    });
-    toast({ title: "Agendamento Excluído", description: `O agendamento de ${appointmentPatient} foi excluído.` });
-  }, [onAppointmentsUpdate, toast]);
-
-  const handleUpdateStatus = useCallback((appointment: Appointment, newStatus: AppointmentStatus, dayDate: Date) => {
-    if (appointment.isGroupSession) {
-        toast({ title: "Ação Não Permitida", description: "Status de sessões de grupo não pode ser alterado aqui.", variant: "default" });
-        return;
-    }
-    const dateStr = format(dayDate, "yyyy-MM-dd");
-    setAppointmentsState(prev => {
-        const updatedAppointmentsForDate = (prev[dateStr] || []).map(appt =>
-            appt.id === appointment.id ? { ...appt, status: newStatus } : appt
+      }
+      const dateStr = format(dayDate, 'yyyy-MM-dd');
+      setAppointmentsState((prev) => {
+        const updatedAppointmentsForDate = (prev[dateStr] || []).filter(
+          (appt) => appt.id !== appointmentId
         );
         const newState = { ...prev, [dateStr]: updatedAppointmentsForDate };
         if (onAppointmentsUpdate) onAppointmentsUpdate(newState);
         return newState;
-    });
-    toast({ title: "Status Atualizado", description: `Status de ${appointment.patient} alterado para ${getStatusLabel(newStatus)}.` });
-  }, [onAppointmentsUpdate, toast]);
+      });
+      toast({
+        title: 'Agendamento Excluído',
+        description: `O agendamento de ${appointmentPatient} foi excluído.`,
+      });
+    },
+    [onAppointmentsUpdate, toast]
+  );
+
+  const handleUpdateStatus = useCallback(
+    (appointment: Appointment, newStatus: AppointmentStatus, dayDate: Date) => {
+      if (appointment.isGroupSession) {
+        toast({
+          title: 'Ação Não Permitida',
+          description: 'Status de sessões de grupo não pode ser alterado aqui.',
+          variant: 'default',
+        });
+        return;
+      }
+      const dateStr = format(dayDate, 'yyyy-MM-dd');
+      setAppointmentsState((prev) => {
+        const updatedAppointmentsForDate = (prev[dateStr] || []).map((appt) =>
+          appt.id === appointment.id ? { ...appt, status: newStatus } : appt
+        );
+        const newState = { ...prev, [dateStr]: updatedAppointmentsForDate };
+        if (onAppointmentsUpdate) onAppointmentsUpdate(newState);
+        return newState;
+      });
+      toast({
+        title: 'Status Atualizado',
+        description: `Status de ${appointment.patient} alterado para ${getStatusLabel(newStatus)}.`,
+      });
+    },
+    [onAppointmentsUpdate, toast]
+  );
 
   const renderAppointmentPopover = (appt: Appointment, dayDate: Date) => (
     <Popover key={appt.id}>
       <PopoverTrigger asChild>
         <div
           className={cn(
-            "w-full p-1.5 rounded cursor-pointer shadow-sm transition-colors leading-tight hover:bg-zinc-50",
-            "flex items-center gap-1.5 text-xs",
+            'w-full p-1.5 rounded cursor-pointer shadow-sm transition-colors leading-tight hover:bg-zinc-50',
+            'flex items-center gap-1.5 text-xs',
             getStatusStyles(appt.status, appt.isGroupSession)
           )}
         >
-          {getStatusIcon(appt.status, "w-3 h-3 mr-1", appt.isGroupSession)}
+          {getStatusIcon(appt.status, 'w-3 h-3 mr-1', appt.isGroupSession)}
           <div className="flex-grow truncate">
             <span className="font-semibold">{appt.startTime}</span>
             <span className="ml-1">
-              {appt.type === "Blocked Slot" ? `Bloqueio: ${appt.blockReason || 'Motivo não especificado'}` : appt.patient}
+              {appt.type === 'Blocked Slot'
+                ? `Bloqueio: ${appt.blockReason || 'Motivo não especificado'}`
+                : appt.patient}
             </span>
-            {filters.psychologistId === "all" && appt.psychologistId && appt.type !== "Blocked Slot" && !appt.isGroupSession && (
-              <span className="text-[0.65rem] opacity-80 ml-0.5">
-                ({mockPsychologists.find(p => p.id === appt.psychologistId)?.name.match(/\b(\w)/g)?.join('') || '??'})
-              </span>
-            )}
+            {filters.psychologistId === 'all' &&
+              appt.psychologistId &&
+              appt.type !== 'Blocked Slot' &&
+              !appt.isGroupSession && (
+                <span className="text-[0.65rem] opacity-80 ml-0.5">
+                  (
+                  {mockPsychologists
+                    .find((p) => p.id === appt.psychologistId)
+                    ?.name.match(/\b(\w)/g)
+                    ?.join('') || '??'}
+                  )
+                </span>
+              )}
           </div>
         </div>
       </PopoverTrigger>
       <PopoverContent className="w-72 p-0 shadow-xl rounded-lg border bg-popover">
-          <div className="p-4 space-y-2">
-              <h4 className="font-headline text-md">{appt.type === "Blocked Slot" ? `Horário Bloqueado: ${appt.blockReason}` : appt.patient}</h4>
-              <InfoDisplay label="Tipo" value={appt.type} icon={appt.isGroupSession ? UsersIcon : GripVertical} className="p-0 bg-transparent"/>
-              <InfoDisplay label="Horário" value={`${appt.startTime} - ${appt.endTime}`} icon={Clock} className="p-0 bg-transparent"/>
-                <InfoDisplay label="Status" value={getStatusLabel(appt.status)} icon={getStatusIcon(appt.status, "w-4 h-4 mr-1", appt.isGroupSession)} className="p-0 bg-transparent"/>
-              {appt.psychologistId && <InfoDisplay label="Com" value={mockPsychologists.find(p => p.id === appt.psychologistId)?.name || appt.psychologistId} icon={User} className="p-0 bg-transparent"/> }
-              {appt.notes && !appt.isGroupSession && <InfoDisplay label="Notas" value={appt.notes} icon={Edit} className="p-0 bg-transparent"/>}
-              {appt.isGroupSession && appt.notes && <InfoDisplay label="Roteiro (Início)" value={appt.notes} icon={FileText} className="p-0 bg-transparent"/>}
+        <div className="p-4 space-y-2">
+          <h4 className="font-headline text-md">
+            {appt.type === 'Blocked Slot' ? `Horário Bloqueado: ${appt.blockReason}` : appt.patient}
+          </h4>
+          <InfoDisplay
+            label="Tipo"
+            value={appt.type}
+            icon={appt.isGroupSession ? UsersIcon : GripVertical}
+            className="p-0 bg-transparent"
+          />
+          <InfoDisplay
+            label="Horário"
+            value={`${appt.startTime} - ${appt.endTime}`}
+            icon={Clock}
+            className="p-0 bg-transparent"
+          />
+          <InfoDisplay
+            label="Status"
+            value={getStatusLabel(appt.status)}
+            icon={getStatusIcon(appt.status, 'w-4 h-4 mr-1', appt.isGroupSession)}
+            className="p-0 bg-transparent"
+          />
+          {appt.psychologistId && (
+            <InfoDisplay
+              label="Com"
+              value={
+                mockPsychologists.find((p) => p.id === appt.psychologistId)?.name ||
+                appt.psychologistId
+              }
+              icon={User}
+              className="p-0 bg-transparent"
+            />
+          )}
+          {appt.notes && !appt.isGroupSession && (
+            <InfoDisplay
+              label="Notas"
+              value={appt.notes}
+              icon={Edit}
+              className="p-0 bg-transparent"
+            />
+          )}
+          {appt.isGroupSession && appt.notes && (
+            <InfoDisplay
+              label="Roteiro (Início)"
+              value={appt.notes}
+              icon={FileText}
+              className="p-0 bg-transparent"
+            />
+          )}
+        </div>
+        <div className="flex flex-col gap-1.5 p-3 border-t bg-muted/30 rounded-b-lg">
+          {appt.isGroupSession && appt.groupId && (
+            <Button size="sm" variant="outline" asChild className="w-full">
+              <Link href={`/groups/${appt.groupId}`} className="inline-flex items-center gap-2">
+                <UsersIcon className="h-3.5 w-3.5" />
+                Ver Detalhes do Grupo
+              </Link>
+            </Button>
+          )}
+          {!appt.isGroupSession && appt.patientId && (
+            <Button size="sm" variant="outline" asChild className="w-full">
+              <Link
+                href={`/patients/${appt.patientId}?tab=notes&date=${format(dayDate, 'yyyy-MM-dd')}`}
+                className="inline-flex items-center gap-2"
+              >
+                <FileText className="h-3.5 w-3.5" />
+                Iniciar Anotação
+              </Link>
+            </Button>
+          )}
+          <div className="flex gap-2 w-full">
+            <Button size="sm" variant="outline" asChild className="flex-1">
+              <Link
+                href={
+                  appt.isGroupSession ? `/groups/edit/${appt.groupId}` : `/schedule/edit/${appt.id}`
+                }
+                className="inline-flex items-center gap-2"
+              >
+                <Edit className="h-3.5 w-3.5" />
+                {appt.isGroupSession ? 'Gerenciar Grupo' : 'Editar'}
+              </Link>
+            </Button>
+            {!appt.isGroupSession && (
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    className="flex-1 bg-destructive/90 hover:bg-destructive text-destructive-foreground"
+                  >
+                    <span className="inline-flex items-center gap-2">
+                      <Trash2 className="h-3.5 w-3.5" />
+                      Excluir
+                    </span>
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Confirmar Exclusão</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      Tem certeza que deseja excluir o agendamento de {appt.patient || 'Bloqueio'}{' '}
+                      às {appt.startTime} em {format(dayDate, 'P', { locale: ptBR })}? Esta ação não
+                      pode ser desfeita.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={() =>
+                        handleDeleteAppointment(appt.id, appt.patient || 'Bloqueio', dayDate)
+                      }
+                      className="bg-destructive hover:bg-destructive/90"
+                    >
+                      Excluir
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            )}
           </div>
-          <div className="flex flex-col gap-1.5 p-3 border-t bg-muted/30 rounded-b-lg">
-              {appt.isGroupSession && appt.groupId && (
-                    <Button size="sm" variant="outline" asChild className="w-full">
-                        <Link href={`/groups/${appt.groupId}`} className="inline-flex items-center gap-2">
-                              <UsersIcon className="h-3.5 w-3.5"/>
-                              Ver Detalhes do Grupo
-                        </Link>
-                    </Button>
-              )}
-              {!appt.isGroupSession && appt.patientId && (
-                    <Button size="sm" variant="outline" asChild className="w-full">
-                        <Link href={`/patients/${appt.patientId}?tab=notes&date=${format(dayDate, "yyyy-MM-dd")}`} className="inline-flex items-center gap-2">
-                              <FileText className="h-3.5 w-3.5"/>
-                              Iniciar Anotação
-                        </Link>
-                    </Button>
-              )}
-              <div className="flex gap-2 w-full">
-                    <Button size="sm" variant="outline" asChild className="flex-1">
-                      <Link href={appt.isGroupSession ? `/groups/edit/${appt.groupId}` : `/schedule/edit/${appt.id}`} className="inline-flex items-center gap-2">
-                          <Edit className="h-3.5 w-3.5"/>
-                          {appt.isGroupSession ? "Gerenciar Grupo" : "Editar"}
-                      </Link>
-                    </Button>
-                  {!appt.isGroupSession && (
-                    <AlertDialog>
-                    <AlertDialogTrigger asChild>
-                          <Button size="sm" variant="destructive" className="flex-1 bg-destructive/90 hover:bg-destructive text-destructive-foreground">
-                            <span className="inline-flex items-center gap-2">
-                              <Trash2 className="h-3.5 w-3.5"/>
-                              Excluir
-                            </span>
-                          </Button>
-                    </AlertDialogTrigger>
-                    <AlertDialogContent>
-                        <AlertDialogHeader><AlertDialogTitle>Confirmar Exclusão</AlertDialogTitle>
-                        <AlertDialogDescription>Tem certeza que deseja excluir o agendamento de {appt.patient || "Bloqueio"} às {appt.startTime} em {format(dayDate, "P", { locale: ptBR })}? Esta ação não pode ser desfeita.</AlertDialogDescription>
-                        </AlertDialogHeader>
-                        <AlertDialogFooter>
-                        <AlertDialogCancel>Cancelar</AlertDialogCancel>
-                        <AlertDialogAction onClick={() => handleDeleteAppointment(appt.id, appt.patient || "Bloqueio", dayDate)} className="bg-destructive hover:bg-destructive/90">Excluir</AlertDialogAction>
-                        </AlertDialogFooter>
-                    </AlertDialogContent>
-                    </AlertDialog>
-                  )}
-              </div>
-              {!appt.isGroupSession && appt.type !== "Blocked Slot" && (
-              <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                      <Button size="sm" variant="outline" className="w-full">
-                        <span className="inline-flex items-center gap-2">
-                          <Check className="h-3.5 w-3.5" />
-                          Marcar Status
-                          <ChevronDown className="ml-auto h-3.5 w-3.5 opacity-70"/>
-                        </span>
-                      </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent className="w-56">
-                  <DropdownMenuLabel>Atualizar Status</DropdownMenuLabel><DropdownMenuSeparator />
-                  {(["Scheduled", "Confirmed", "Completed", "NoShow", "Rescheduled", "CancelledByPatient", "CancelledByClinic"] as AppointmentStatus[]).map(statusOpt => (
-                      <DropdownMenuItem key={statusOpt} onClick={() => handleUpdateStatus(appt, statusOpt, dayDate)} disabled={appt.status === statusOpt}>
-                      {getStatusIcon(statusOpt, "w-4 h-4 mr-2")} {getStatusLabel(statusOpt)}
-                      </DropdownMenuItem>
-                  ))}
-                  </DropdownMenuContent>
-              </DropdownMenu>
-              )}
-          </div>
+          {!appt.isGroupSession && appt.type !== 'Blocked Slot' && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button size="sm" variant="outline" className="w-full">
+                  <span className="inline-flex items-center gap-2">
+                    <Check className="h-3.5 w-3.5" />
+                    Marcar Status
+                    <ChevronDown className="ml-auto h-3.5 w-3.5 opacity-70" />
+                  </span>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent className="w-56">
+                <DropdownMenuLabel>Atualizar Status</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                {(
+                  [
+                    'Scheduled',
+                    'Confirmed',
+                    'Completed',
+                    'NoShow',
+                    'Rescheduled',
+                    'CancelledByPatient',
+                    'CancelledByClinic',
+                  ] as AppointmentStatus[]
+                ).map((statusOpt) => (
+                  <DropdownMenuItem
+                    key={statusOpt}
+                    onClick={() => handleUpdateStatus(appt, statusOpt, dayDate)}
+                    disabled={appt.status === statusOpt}
+                  >
+                    {getStatusIcon(statusOpt, 'w-4 h-4 mr-2')} {getStatusLabel(statusOpt)}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
       </PopoverContent>
     </Popover>
   );
 
-  const renderDayTimelineCell = useCallback((dayDate: Date, isCurrentMonthView: boolean = true, cellKeySuffix: string) => {
-    const dayAppointments = getAppointmentsForDay(dayDate);
-    const isSelected = selectedDate && isSameDay(dayDate, selectedDate);
-    const isToday = isSameDay(dayDate, new Date());
-    const dayId = getDayIdFromDate(dayDate);
-    const isWorkingDay = workingDaysOfWeek.includes(dayId);
+  const renderDayTimelineCell = useCallback(
+    (dayDate: Date, isCurrentMonthView: boolean = true, cellKeySuffix: string) => {
+      const dayAppointments = getAppointmentsForDay(dayDate);
+      const isSelected = selectedDate && isSameDay(dayDate, selectedDate);
+      const isToday = isSameDay(dayDate, new Date());
+      const dayId = getDayIdFromDate(dayDate);
+      const isWorkingDay = workingDaysOfWeek.includes(dayId);
 
-    if (view === "Day" && !isWorkingDay) {
+      if (view === 'Day' && !isWorkingDay) {
         return (
-            <div
-                key={`day-timeline-${dayDate.toISOString()}-${cellKeySuffix}`}
-                className="p-2 flex-1 bg-muted/50 border-r border-b flex flex-col items-center justify-center text-center relative"
-            >
-                <CalendarX2 className="w-12 h-12 text-muted-foreground mb-2" />
-                <p className="font-semibold text-muted-foreground">Dia não trabalhado</p>
-                <p className="text-xs text-muted-foreground">{format(dayDate, "EEEE", { locale: ptBR })}</p>
-            </div>
-        );
-    }
-    
-    return (
-      <div 
-        key={`day-timeline-${dayDate.toISOString()}-${cellKeySuffix}`}
-        className={cn(
-          "flex-1 flex flex-col relative", 
-          !isCurrentMonthView && view === "Month" && "bg-muted/30 text-muted-foreground/50",
-          !isWorkingDay && view !== "Day" && "bg-muted/40 text-muted-foreground/60",
-          isSelected && isWorkingDay && "ring-1 ring-accent ring-inset z-10", 
-          isToday && isWorkingDay && !isSelected && "bg-accent/5",
-          view !== "Month" && "border-r" 
-        )}
-        onClick={() => view === "Month" && isWorkingDay && setSelectedDate(dayDate)}
-      >
-        {view === "Month" && (
-           <div className={cn("text-sm font-medium text-center rounded-full w-6 h-6 flex items-center justify-center mb-1 ml-1 mt-1 self-start",
-            isSelected && isWorkingDay ? 'bg-accent text-accent-foreground font-bold' : 'text-foreground',
-            isToday && isWorkingDay && !isSelected && 'bg-accent/60 text-accent-foreground',
-            (!isCurrentMonthView || !isWorkingDay) && 'opacity-50'
-          )}>
-            {format(dayDate, "d")}
+          <div
+            key={`day-timeline-${dayDate.toISOString()}-${cellKeySuffix}`}
+            className="p-2 flex-1 bg-muted/50 border-r border-b flex flex-col items-center justify-center text-center relative"
+          >
+            <CalendarX2 className="w-12 h-12 text-muted-foreground mb-2" />
+            <p className="font-semibold text-muted-foreground">Dia não trabalhado</p>
+            <p className="text-xs text-muted-foreground">
+              {format(dayDate, 'EEEE', { locale: ptBR })}
+            </p>
           </div>
-        )}
-        
-        { (view === "Week" || view === "Day") && isWorkingDay && (
-            <div className="flex-grow relative">
-                {timeSlots.map((timeSlot) => (
-                    <div key={timeSlot} className={cn(ROW_HEIGHT_CLASS, "border-b relative p-1 flex flex-col gap-0.5 overflow-hidden")}> 
-                        {dayAppointments
-                            .filter(appt => appt.startTime.startsWith(timeSlot.substring(0,2))) 
-                            .map(appt => renderAppointmentPopover(appt, dayDate))
-                        }
-                        <Button variant="ghost" size="icon" className="absolute bottom-0 right-0 h-6 w-6 opacity-0 hover:opacity-100 focus:opacity-100 transition-opacity" asChild>
-                             <Link href={`/schedule/new?date=${format(dayDate, "yyyy-MM-dd")}&time=${timeSlot}`}>
-                               <span className="inline-flex items-center gap-2">
-                                 <PlusCircle className="h-4 w-4" />
-                                 <span className="sr-only">Adicionar</span>
-                               </span>
-                             </Link>
-                        </Button>
-                    </div>
-                ))}
-            </div>
-        )}
-        { view === "Month" && isWorkingDay && (
-            <div className="mt-1 space-y-1 text-xs overflow-y-auto flex-grow p-1">
-                {dayAppointments.map(appt => renderAppointmentPopover(appt, dayDate))}
-                 <Button variant="ghost" size="icon" className="absolute bottom-1 right-1 h-7 w-7 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity" asChild>
-                    <Link href={`/schedule/new?date=${format(dayDate, "yyyy-MM-dd")}`}>
-                      <span className="inline-flex items-center gap-2"><PlusCircle className="h-5 w-5" /><span className="sr-only">Adicionar</span></span>
-                    </Link>
-                </Button>
-            </div>
-        )}
-        { !isWorkingDay && (view === "Week" || view === "Day") && (
-            <div className="flex-grow flex items-center justify-center text-xs text-muted-foreground/70 p-2">
-            </div>
-        )}
-         { !isWorkingDay && view === "Month" && (
-            <div className="flex-grow flex items-center justify-center text-xs text-muted-foreground/70 p-2">
-            </div>
-        )}
-      </div>
-    );
-  }, [getAppointmentsForDay, selectedDate, workingDaysOfWeek, view, handleDeleteAppointment, handleUpdateStatus, filters.psychologistId]);
+        );
+      }
 
+      return (
+        <div
+          key={`day-timeline-${dayDate.toISOString()}-${cellKeySuffix}`}
+          className={cn(
+            'flex-1 flex flex-col relative',
+            !isCurrentMonthView && view === 'Month' && 'bg-muted/30 text-muted-foreground/50',
+            !isWorkingDay && view !== 'Day' && 'bg-muted/40 text-muted-foreground/60',
+            isSelected && isWorkingDay && 'ring-1 ring-accent ring-inset z-10',
+            isToday && isWorkingDay && !isSelected && 'bg-accent/5',
+            view !== 'Month' && 'border-r'
+          )}
+          onClick={() => view === 'Month' && isWorkingDay && setSelectedDate(dayDate)}
+        >
+          {view === 'Month' && (
+            <div
+              className={cn(
+                'text-sm font-medium text-center rounded-full w-6 h-6 flex items-center justify-center mb-1 ml-1 mt-1 self-start',
+                isSelected && isWorkingDay
+                  ? 'bg-accent text-accent-foreground font-bold'
+                  : 'text-foreground',
+                isToday && isWorkingDay && !isSelected && 'bg-accent/60 text-accent-foreground',
+                (!isCurrentMonthView || !isWorkingDay) && 'opacity-50'
+              )}
+            >
+              {format(dayDate, 'd')}
+            </div>
+          )}
+
+          {(view === 'Week' || view === 'Day') && isWorkingDay && (
+            <div className="flex-grow relative">
+              {timeSlots.map((timeSlot) => (
+                <div
+                  key={timeSlot}
+                  className={cn(
+                    ROW_HEIGHT_CLASS,
+                    'border-b relative p-1 flex flex-col gap-0.5 overflow-hidden'
+                  )}
+                >
+                  {dayAppointments
+                    .filter((appt) => appt.startTime.startsWith(timeSlot.substring(0, 2)))
+                    .map((appt) => renderAppointmentPopover(appt, dayDate))}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="absolute bottom-0 right-0 h-6 w-6 opacity-0 hover:opacity-100 focus:opacity-100 transition-opacity"
+                    asChild
+                  >
+                    <Link
+                      href={`/schedule/new?date=${format(dayDate, 'yyyy-MM-dd')}&time=${timeSlot}`}
+                    >
+                      <span className="inline-flex items-center gap-2">
+                        <PlusCircle className="h-4 w-4" />
+                        <span className="sr-only">Adicionar</span>
+                      </span>
+                    </Link>
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+          {view === 'Month' && isWorkingDay && (
+            <div className="mt-1 space-y-1 text-xs overflow-y-auto flex-grow p-1">
+              {dayAppointments.map((appt) => renderAppointmentPopover(appt, dayDate))}
+              <Button
+                variant="ghost"
+                size="icon"
+                className="absolute bottom-1 right-1 h-7 w-7 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
+                asChild
+              >
+                <Link href={`/schedule/new?date=${format(dayDate, 'yyyy-MM-dd')}`}>
+                  <span className="inline-flex items-center gap-2">
+                    <PlusCircle className="h-5 w-5" />
+                    <span className="sr-only">Adicionar</span>
+                  </span>
+                </Link>
+              </Button>
+            </div>
+          )}
+          {!isWorkingDay && (view === 'Week' || view === 'Day') && (
+            <div className="flex-grow flex items-center justify-center text-xs text-muted-foreground/70 p-2"></div>
+          )}
+          {!isWorkingDay && view === 'Month' && (
+            <div className="flex-grow flex items-center justify-center text-xs text-muted-foreground/70 p-2"></div>
+          )}
+        </div>
+      );
+    },
+    [
+      getAppointmentsForDay,
+      selectedDate,
+      workingDaysOfWeek,
+      view,
+      handleDeleteAppointment,
+      handleUpdateStatus,
+      filters.psychologistId,
+    ]
+  );
 
   const renderMonthView = useCallback(() => {
     const firstDayOfMonth = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1);
@@ -404,65 +621,98 @@ function AppointmentCalendarComponent({ view, currentDate, filters, workingDaysO
     const monthEnd = endOfWeek(lastDayOfMonth, { locale: ptBR, weekStartsOn: 1 });
     const daysInGrid = eachDayOfInterval({ start: monthStart, end: monthEnd });
     const dayNames = Array.from({ length: 7 }, (_, i) => {
-        const tempDate = addDays(startOfWeek(new Date(), { weekStartsOn: 1}), i);
-        return format(tempDate, "EEEEEE", { locale: ptBR });
+      const tempDate = addDays(startOfWeek(new Date(), { weekStartsOn: 1 }), i);
+      return format(tempDate, 'EEEEEE', { locale: ptBR });
     });
 
     return (
-        <div className="grid grid-cols-7 gap-px bg-border border-l border-t flex-grow">
-            {dayNames.map(dayName => (<div key={dayName} className="py-0.5 text-center text-xs font-medium text-muted-foreground bg-card border-r border-b capitalize">{dayName}</div>))}
-            {daysInGrid.map((day, index) => renderDayTimelineCell(day, isSameMonth(day, currentDate), `month-${index}`))}
-        </div>
+      <div className="grid grid-cols-7 gap-px bg-border border-l border-t flex-grow">
+        {dayNames.map((dayName) => (
+          <div
+            key={dayName}
+            className="py-0.5 text-center text-xs font-medium text-muted-foreground bg-card border-r border-b capitalize"
+          >
+            {dayName}
+          </div>
+        ))}
+        {daysInGrid.map((day, index) =>
+          renderDayTimelineCell(day, isSameMonth(day, currentDate), `month-${index}`)
+        )}
+      </div>
     );
   }, [currentDate, renderDayTimelineCell]);
 
-
   const renderWeekOrDayView = useCallback(() => {
-    const daysToRender = view === "Week" 
-      ? eachDayOfInterval({ start: startOfWeek(currentDate, { weekStartsOn: 1, locale: ptBR }), end: endOfWeek(currentDate, { weekStartsOn: 1, locale: ptBR }) })
-      : [currentDate];
-    
-    const dayHeaders = view === "Week" 
-      ? daysToRender.map(day => format(day, "EEE d", { locale: ptBR }))
-      : [format(currentDate, "EEEE, d 'de' MMMM", { locale: ptBR })];
+    const daysToRender =
+      view === 'Week'
+        ? eachDayOfInterval({
+            start: startOfWeek(currentDate, { weekStartsOn: 1, locale: ptBR }),
+            end: endOfWeek(currentDate, { weekStartsOn: 1, locale: ptBR }),
+          })
+        : [currentDate];
+
+    const dayHeaders =
+      view === 'Week'
+        ? daysToRender.map((day) => format(day, 'EEE d', { locale: ptBR }))
+        : [format(currentDate, "EEEE, d 'de' MMMM", { locale: ptBR })];
 
     return (
       <div className="flex flex-col h-full">
-        <div className={cn("grid bg-card border-t border-l", view === "Week" ? "grid-cols-[64px_repeat(7,1fr)]" : "grid-cols-[64px_1fr]")}>
-            <div className="h-10 border-b border-r"></div> 
-            {dayHeaders.map((header, index) => (
-                <div key={`header-${index}`} className="h-10 py-1 text-center text-xs font-medium text-muted-foreground border-b border-r capitalize flex items-center justify-center">
-                    {header}
-                </div>
-            ))}
+        <div
+          className={cn(
+            'grid bg-card border-t border-l',
+            view === 'Week' ? 'grid-cols-[64px_repeat(7,1fr)]' : 'grid-cols-[64px_1fr]'
+          )}
+        >
+          <div className="h-10 border-b border-r"></div>
+          {dayHeaders.map((header, index) => (
+            <div
+              key={`header-${index}`}
+              className="h-10 py-1 text-center text-xs font-medium text-muted-foreground border-b border-r capitalize flex items-center justify-center"
+            >
+              {header}
+            </div>
+          ))}
         </div>
-        <div className={cn("flex flex-1")}>
-            <div className="w-16 border-l border-r bg-card flex flex-col shrink-0">
-                {timeSlots.map(time => (
-                    <div key={time} className={cn(ROW_HEIGHT_CLASS, "flex items-center justify-center text-xs text-muted-foreground border-b")}>
-                        {time}
-                    </div>
-                ))}
-            </div>
-            <div className="flex-1 flex overflow-x-auto" tabIndex={0}>
-                <div className={cn("flex min-w-max", view === "Week" && "md:min-w-full", "flex-grow")}>
-                     {daysToRender.map((day, index) => (
-                       <div key={day.toISOString()} className={cn("flex-1", view === "Week" ? "min-w-[140px] sm:min-w-[160px] md:min-w-0" : "", "flex flex-col")}> 
-                           {renderDayTimelineCell(day, true, `${view.toLowerCase()}-${index}`)}
-                       </div>
-                    ))}
+        <div className={cn('flex flex-1')}>
+          <div className="w-16 border-l border-r bg-card flex flex-col shrink-0">
+            {timeSlots.map((time) => (
+              <div
+                key={time}
+                className={cn(
+                  ROW_HEIGHT_CLASS,
+                  'flex items-center justify-center text-xs text-muted-foreground border-b'
+                )}
+              >
+                {time}
+              </div>
+            ))}
+          </div>
+          <div className="flex-1 flex overflow-x-auto" tabIndex={0}>
+            <div className={cn('flex min-w-max', view === 'Week' && 'md:min-w-full', 'flex-grow')}>
+              {daysToRender.map((day, index) => (
+                <div
+                  key={day.toISOString()}
+                  className={cn(
+                    'flex-1',
+                    view === 'Week' ? 'min-w-[140px] sm:min-w-[160px] md:min-w-0' : '',
+                    'flex flex-col'
+                  )}
+                >
+                  {renderDayTimelineCell(day, true, `${view.toLowerCase()}-${index}`)}
                 </div>
+              ))}
             </div>
+          </div>
         </div>
       </div>
     );
   }, [currentDate, view, renderDayTimelineCell, workingDaysOfWeek]);
 
-
   return (
     <div className="p-0 sm:p-1 md:p-2 h-full flex flex-col">
-      {view === "Month" && renderMonthView()}
-      {(view === "Week" || view === "Day") && renderWeekOrDayView()}
+      {view === 'Month' && renderMonthView()}
+      {(view === 'Week' || view === 'Day') && renderWeekOrDayView()}
     </div>
   );
 }

--- a/src/lib/firestore-collections.ts
+++ b/src/lib/firestore-collections.ts
@@ -4,6 +4,7 @@ export const FIRESTORE_COLLECTIONS = {
   APPOINTMENTS: 'appointments',
   ASSESSMENTS: 'assessments',
   TASKS: 'tasks',
+  GROUPS: 'groups',
   WAITING_LIST: 'waitingList',
   CHATS: 'chats',
   NOTIFICATIONS: 'notifications',

--- a/src/services/groupService.ts
+++ b/src/services/groupService.ts
@@ -1,0 +1,106 @@
+import {
+  collection,
+  getDocs,
+  addDoc,
+  setDoc,
+  deleteDoc,
+  doc,
+  query,
+  where,
+  type Firestore,
+} from 'firebase/firestore';
+import { db, auth } from '@/lib/firebase';
+import { FIRESTORE_COLLECTIONS } from '@/lib/firestore-collections';
+import { writeAuditLog } from './auditLogService';
+import * as Sentry from '@sentry/nextjs';
+import type { GroupResource } from '@/types/group';
+
+export interface GroupInput {
+  name: string;
+  description?: string;
+  psychologistId: string;
+  patientIds: string[];
+  dayOfWeek: string;
+  startTime: string;
+  endTime: string;
+  meetingAgenda?: string;
+  nextSession?: string;
+  resources?: GroupResource[];
+}
+
+export interface GroupRecord extends GroupInput {
+  id: string;
+  ownerId: string;
+}
+
+export async function fetchGroups(firestore: Firestore = db): Promise<GroupRecord[]> {
+  try {
+    const uid = auth.currentUser?.uid;
+    if (!uid) return [];
+    const q = query(
+      collection(firestore, FIRESTORE_COLLECTIONS.GROUPS),
+      where('ownerId', '==', uid)
+    );
+    const snap = await getDocs(q);
+    return snap.docs.map((d) => ({ id: d.id, ...(d.data() as Omit<GroupRecord, 'id'>) }));
+  } catch (err) {
+    Sentry.captureException(err);
+    console.error('Erro ao buscar grupos', err);
+    return [];
+  }
+}
+
+export async function createGroup(data: GroupInput, firestore: Firestore = db): Promise<string> {
+  const uid = auth.currentUser?.uid;
+  if (!uid) throw new Error('Usuário não autenticado');
+  const docRef = await addDoc(collection(firestore, FIRESTORE_COLLECTIONS.GROUPS), {
+    ...data,
+    ownerId: uid,
+  });
+  await writeAuditLog(
+    {
+      userId: uid,
+      actionType: 'createGroup',
+      timestamp: new Date().toISOString(),
+      targetResourceId: docRef.id,
+    },
+    firestore
+  );
+  return docRef.id;
+}
+
+export async function updateGroup(
+  id: string,
+  data: Partial<GroupInput>,
+  firestore: Firestore = db
+): Promise<void> {
+  await setDoc(doc(firestore, FIRESTORE_COLLECTIONS.GROUPS, id), data, { merge: true });
+  const uid = auth.currentUser?.uid;
+  if (uid) {
+    await writeAuditLog(
+      {
+        userId: uid,
+        actionType: 'updateGroup',
+        timestamp: new Date().toISOString(),
+        targetResourceId: id,
+      },
+      firestore
+    );
+  }
+}
+
+export async function deleteGroup(id: string, firestore: Firestore = db): Promise<void> {
+  await deleteDoc(doc(firestore, FIRESTORE_COLLECTIONS.GROUPS, id));
+  const uid = auth.currentUser?.uid;
+  if (uid) {
+    await writeAuditLog(
+      {
+        userId: uid,
+        actionType: 'deleteGroup',
+        timestamp: new Date().toISOString(),
+        targetResourceId: id,
+      },
+      firestore
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add new `groupService` with CRUD operations
- fetch groups from Firestore in groups pages
- update appointment calendar and API route to read groups from Firestore
- include Firestore security rules for groups
- add Firestore emulator test for groups service

## Testing
- `npx eslint "src/app/(app)/groups/edit/[id]/page.tsx" "src/app/(app)/groups/page.tsx" "src/app/api/createAppointment/route.ts" "src/components/schedule/appointment-calendar.tsx" src/lib/firestore-collections.ts src/services/groupService.ts __tests__/groups.service.test.ts --fix`
- `npx jest __tests__/groups.service.test.ts --runInBand` *(fails: FetchError ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68593a86fd908324abd52de8a26e501e