### PR TITLE
Add clinical data service

### DIFF
--- a/__tests__/clinical.service.test.ts
+++ b/__tests__/clinical.service.test.ts
@@ -1,0 +1,55 @@
+import { initializeTestEnvironment } from '@firebase/rules-unit-testing';
+import { readFileSync } from 'fs';
+import { Firestore } from 'firebase/firestore';
+
+let fetchClinicalData: any;
+let saveClinicalData: any;
+
+let testEnv: Awaited<ReturnType<typeof initializeTestEnvironment>>;
+
+beforeAll(async () => {
+  const hostPort = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8084';
+  const [host, portStr] = hostPort.split(':');
+  const port = parseInt(portStr, 10);
+
+  testEnv = await initializeTestEnvironment({
+    projectId: 'demo-project',
+    firestore: {
+      host,
+      port,
+      rules: readFileSync('firestore.rules', 'utf8'),
+    },
+  });
+
+  const auth = { uid: 'therapist1', role: 'Psychologist' };
+  const db = testEnv.authenticatedContext(auth.uid, auth).firestore();
+
+  jest.doMock('../src/lib/firebase', () => ({
+    db,
+    auth: { currentUser: { uid: auth.uid } },
+  }));
+
+  ({ fetchClinicalData, saveClinicalData } = await import('../src/services/clinicalService'));
+});
+
+afterAll(async () => {
+  if (testEnv) await testEnv.cleanup();
+  jest.resetModules();
+});
+
+function getDb(auth: { uid: string; role: string }): Firestore {
+  return testEnv.authenticatedContext(auth.uid, auth).firestore();
+}
+
+test('salva e busca clinical data', async () => {
+  const auth = { uid: 'therapist1', role: 'Psychologist' };
+  const db = getDb(auth);
+  const patientId = 'p1';
+  const tabId = 't1';
+
+  await saveClinicalData(patientId, tabId, { nodes: [1] } as any, db);
+
+  const data = await fetchClinicalData(patientId, tabId, db);
+  expect(data).not.toBeNull();
+  expect((data as any).nodes).toEqual([1]);
+});

--- a/firestore.rules
+++ b/firestore.rules
@@ -152,6 +152,10 @@ match /quickNotes/{id} {
   allow read, update, delete: if isStaff() && resource.data.ownerId == request.auth.uid;
 }
 
+match /patients/{patientId}/clinicalTabs/{tabId} {
+  allow read, write: if isStaff() && patientOwnedByUser(patientId);
+}
+
 match /groups/{id} {
   allow read: if isStaff();
   allow create: if (isPsychologist() && request.auth.uid == request.resource.data.psychologistId) || isAdmin();

--- a/src/lib/firestore-collections.ts
+++ b/src/lib/firestore-collections.ts
@@ -16,6 +16,7 @@ export const FIRESTORE_COLLECTIONS = {
   QUICK_NOTES: 'quickNotes',
   SCHEDULES: 'schedules',
   AUDIT_LOGS: 'auditLogs',
+  CLINICAL_DATA: 'clinicalTabs',
 } as const;
 
 export type FirestoreCollectionKeys = keyof typeof FIRESTORE_COLLECTIONS;

--- a/src/services/clinicalService.ts
+++ b/src/services/clinicalService.ts
@@ -1,9 +1,49 @@
-export async function fetchClinicalData(patientId: string, tabId: string) {
-  console.log('fetchClinicalData service', patientId, tabId);
-  return Promise.resolve();
+import { doc, getDoc, setDoc, type Firestore } from 'firebase/firestore';
+import { db } from '@/lib/firebase';
+import { FIRESTORE_COLLECTIONS } from '@/lib/firestore-collections';
+import type { TabSpecificFormulationData } from '@/types/clinicalTypes';
+import * as Sentry from '@sentry/nextjs';
+
+export async function fetchClinicalData(
+  patientId: string,
+  tabId: string,
+  firestore: Firestore = db
+): Promise<TabSpecificFormulationData | null> {
+  try {
+    const ref = doc(
+      firestore,
+      FIRESTORE_COLLECTIONS.PATIENTS,
+      patientId,
+      FIRESTORE_COLLECTIONS.CLINICAL_DATA,
+      tabId
+    );
+    const snap = await getDoc(ref);
+    return snap.exists() ? (snap.data() as TabSpecificFormulationData) : null;
+  } catch (err) {
+    Sentry.captureException(err);
+    console.error('Erro ao buscar dados clínicos', err);
+    return null;
+  }
 }
 
-export async function saveClinicalData(patientId: string, tabId: string, data: unknown) {
-  console.log('saveClinicalData service', patientId, tabId, data);
-  return Promise.resolve();
+export async function saveClinicalData(
+  patientId: string,
+  tabId: string,
+  data: Partial<TabSpecificFormulationData>,
+  firestore: Firestore = db
+): Promise<void> {
+  try {
+    const ref = doc(
+      firestore,
+      FIRESTORE_COLLECTIONS.PATIENTS,
+      patientId,
+      FIRESTORE_COLLECTIONS.CLINICAL_DATA,
+      tabId
+    );
+    await setDoc(ref, data, { merge: true });
+  } catch (err) {
+    Sentry.captureException(err);
+    console.error('Erro ao salvar dados clínicos', err);
+    throw err;
+  }
 }


### PR DESCRIPTION
## Summary
- support `CLINICAL_DATA` collection
- implement clinical data load/save helpers
- lock down new path in rules
- test saving and fetching clinical data

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run test:all` *(fails: connect ECONNREFUSED 127.0.0.1:8084)*

------
https://chatgpt.com/codex/tasks/task_e_6859432680b88324a72e7bf11b6d7269