### PR TITLE
Adiciona cobertura de testes e cenários E2E

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Thalamus
 
+![Coverage](https://img.shields.io/codecov/c/github/SEU_USUARIO/SEU_REPO)
+
 Plataforma web para gestão de clínicas de psicologia, com agenda integrada, prontuários seguros e funcionalidades auxiliadas por IA. O projeto é baseado em **Next.js** e **Firebase**, utilizando **TypeScript** e **Tailwind CSS** no frontend e **Cloud Functions** no backend. Fluxos de IA são implementados com **Genkit** e Google AI.
 
 ## Tecnologias Principais

--- a/e2e/appointment.spec.ts
+++ b/e2e/appointment.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+async function login(page) {
+  await page.goto('/login');
+  await page.fill('input[name="email"]', process.env.TEST_EMAIL!);
+  await page.fill('input[name="password"]', process.env.TEST_PASSWORD!);
+  await page.click('button[type="submit"]');
+  await page.waitForURL('**/dashboard');
+}
+
+test.describe('Agendamento', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test('cria novo agendamento', async ({ page }) => {
+    await page.goto('/schedule/new');
+    await page.fill('input[name="title"]', 'Consulta de teste');
+    await page.click('button[type="submit"]');
+    await expect(page.getByText('Consulta de teste')).toBeVisible();
+  });
+});

--- a/e2e/login.spec.ts
+++ b/e2e/login.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Login', () => {
+  test('autenticacao valida redireciona para dashboard', async ({ page }) => {
+    await page.goto('/login');
+    await page.fill('input[name="email"]', process.env.TEST_EMAIL!);
+    await page.fill('input[name="password"]', process.env.TEST_PASSWORD!);
+    await page.click('button[type="submit"]');
+    await page.waitForURL('**/dashboard');
+    await expect(page).toHaveURL(/dashboard/);
+  });
+
+  test('login invalido exibe erro', async ({ page }) => {
+    await page.goto('/login');
+    await page.fill('input[name="email"]', 'wrong@example.com');
+    await page.fill('input[name="password"]', 'invalid');
+    await page.click('button[type="submit"]');
+    await expect(page.getByText(/erro ao fazer login/i)).toBeVisible();
+  });
+
+  test('logout redireciona para login', async ({ page }) => {
+    await page.goto('/login');
+    await page.fill('input[name="email"]', process.env.TEST_EMAIL!);
+    await page.fill('input[name="password"]', process.env.TEST_PASSWORD!);
+    await page.click('button[type="submit"]');
+    await page.waitForURL('**/dashboard');
+    await page.click('button[aria-label="Menu do usuário"]');
+    await page.getByText('Sair').click();
+    await page.waitForURL('**/login');
+    await expect(page).toHaveURL(/login/);
+  });
+});

--- a/e2e/notification.spec.ts
+++ b/e2e/notification.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+async function login(page) {
+  await page.goto('/login');
+  await page.fill('input[name="email"]', process.env.TEST_EMAIL!);
+  await page.fill('input[name="password"]', process.env.TEST_PASSWORD!);
+  await page.click('button[type="submit"]');
+  await page.waitForURL('**/dashboard');
+}
+
+test.describe('Notificacoes', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test('badge de notificacao visivel apos agendar', async ({ page }) => {
+    await page.goto('/schedule/new');
+    await page.fill('input[name="title"]', 'Notificacao Teste');
+    await page.click('button[type="submit"]');
+    await page.click('button[aria-label="Ver notificações"]');
+    await expect(page.getByText('Notificacao Teste')).toBeVisible();
+  });
+});

--- a/env.test.example
+++ b/env.test.example
@@ -1,0 +1,3 @@
+E2E_BASE_URL=http://localhost:3000
+TEST_EMAIL=test@example.com
+TEST_PASSWORD=secret123

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,17 @@ const createJestConfig = nextJest({ dir: './' })
 const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/setupTests.ts'],
   testEnvironment: 'jsdom',
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+  coverageReporters: ['html', 'text'],
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+  },
 }
 
 module.exports = createJestConfig(customJestConfig)

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:all": "jest --coverage",
+    "coverage": "jest --coverage",
+    "e2e": "playwright test",
     "ci": "./scripts/ci.sh",
     "studio:init": "chmod +x ./scripts/studio-init.sh && ./scripts/studio-init.sh",
     "start:local": "./scripts/start.sh",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from '@playwright/test';
+import * as dotenv from 'dotenv';
+
+dotenv.config({ path: '.env.test' });
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30000,
+  use: {
+    baseURL: process.env.E2E_BASE_URL || 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  webServer: process.env.CI
+    ? {
+        command: 'npm run start',
+        port: 3000,
+        timeout: 120 * 1000,
+      }
+    : undefined,
+});

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -6,4 +6,4 @@ echo "📦 Instalando dependências via npm..."
 npm ci
 
 echo "🔥 Rodando testes com Firebase Emulator via Volta..."
-npx firebase emulators:exec --project="${FIREBASE_PROJECT:-thalamus-dev}" --only firestore "npx jest --runInBand"
+npx firebase emulators:exec --project="${FIREBASE_PROJECT:-thalamus-dev}" --only firestore "npm run coverage -- --runInBand"


### PR DESCRIPTION
## Principais mudanças

- Configuração do Jest para gerar cobertura em HTML e exigir mínimo de 80%
- Badge de coverage adicionado ao README
- Workflow de CI atualizado para rodar `npm run coverage`
- Inclusão do Playwright para testes E2E com exemplos de login, agendamento e notificações

### E2E
- Login com credenciais válidas, erro de autenticação e logout
- Criação de agendamento simples
- Exibição de notificação após agendamento

------
https://chatgpt.com/codex/tasks/task_e_6859477f2d548324aca268ccf78f0527