### PR TITLE
Add audit step and playwright tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Audit dependencies
+        run: npm audit --audit-level=high
+
       - name: Lint
         run: npm run lint
 
@@ -37,6 +40,9 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Run Playwright tests
+        run: npx playwright test
 
       - name: Test and Coverage
         run: npm run coverage


### PR DESCRIPTION
## Summary
- run security audit step in CI
- add Playwright e2e tests in CI

## Testing
- `npm run coverage` *(fails: ECONNREFUSED / missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_685952f9ad9c8324b3ee5d4aca8d113a