### PR TITLE
Add app hosting deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - id: auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Deploy to Firebase App Hosting
+        uses: google-github-actions/deploy-apphosting@v0
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          config_path: ./apphosting.yaml


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for deploying App Hosting

## Testing
- `bash ./run-tests.sh` *(fails: npm CI blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6859530524ac83248400b0ce115cfb87