### PR TITLE
Add SENTRY_AUTH_TOKEN documentation and script

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ _Ao adicionar `FIREBASE_PRIVATE_KEY` ao seu arquivo `.env.local` ou variável de
 - `NEXT_PUBLIC_FIREBASE_VAPID_KEY`: Chave VAPID para Firebase Cloud Messaging (Web Push). Encontrada no Console do Firebase -> Configurações do Projeto -> Cloud Messaging -> Web configuration -> Web Push certificates.
 - `NEXT_PUBLIC_DISABLE_AUTH`: Quando definido como `true`, desativa temporariamente o sistema de login. Por padrão esta variável é `false`, exigindo autenticação real.
 - `SENTRY_DSN`: DSN do Sentry usado pelas Cloud Functions para registrar erros.
+- `SENTRY_AUTH_TOKEN`: Token utilizado pelo Sentry CLI para enviar sourcemaps durante o build.
 
 ## Importante sobre Segurança
 
@@ -182,6 +183,7 @@ Principais variáveis usadas:
 - `NEXT_PUBLIC_FIREBASE_EMULATOR_HOST`
 - `NEXT_PUBLIC_DISABLE_AUTH`
 - `SENTRY_DSN`
+- `SENTRY_AUTH_TOKEN`
 - `NEXT_PUBLIC_SENTRY_DSN`
 - `LHCI_GITHUB_APP_TOKEN`
 

--- a/docs/phase4-reliability.md
+++ b/docs/phase4-reliability.md
@@ -33,6 +33,6 @@ A seguir estão os principais pontos a serem avaliados e implementados.
 
 ## 6. Monitoramento de Erros com Sentry
 
-- Integrar o SDK do Sentry no cliente e servidor, usando as variáveis `NEXT_PUBLIC_SENTRY_DSN` e `SENTRY_DSN`.
+- Integrar o SDK do Sentry no cliente e servidor, usando as variáveis `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_DSN` e `SENTRY_AUTH_TOKEN` para upload de sourcemaps.
 - Envolver rotas de API e componentes críticos com `ErrorBoundary` ou blocos `try/catch` que reportam para o Sentry.
 - Analisar periodicamente os erros coletados para priorizar correções.

--- a/env.example
+++ b/env.example
@@ -41,4 +41,5 @@ NEXT_PUBLIC_DISABLE_AUTH="false"
 # Sentry
 NEXT_PUBLIC_SENTRY_DSN=""
 SENTRY_DSN=""
+SENTRY_AUTH_TOKEN="" # Token para upload de sourcemaps via Sentry CLI
 LHCI_GITHUB_APP_TOKEN=""

--- a/functions/README.md
+++ b/functions/README.md
@@ -16,4 +16,4 @@ firebase deploy --only functions
 
 ## Configuração
 
-Defina a variável de ambiente `SENTRY_DSN` nas configurações das Functions para habilitar o envio de erros ao Sentry.
+Defina as variáveis `SENTRY_DSN` e `SENTRY_AUTH_TOKEN` nas configurações das Functions para habilitar o envio de erros ao Sentry e o upload de sourcemaps.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev": "next dev",
     "dev:force": "lsof -ti:9003 | xargs kill -9 || true && sleep 2 && next dev --turbopack -p 9003",
     "start": "next start",
-    "build": "next build",
+    "build": "next build && ./scripts/sentry-release.sh",
     "genkit:dev": "genkit start -- tsx src/ai/dev.ts",
     "genkit:watch": "genkit start -- tsx --watch src/ai/dev.ts",
     "lint": "eslint . --ext .ts,.tsx",
@@ -42,7 +42,8 @@
     "docker:build": "docker build -t meu-app-web .",
     "docker:functions:build": "docker build -t meu-app-func functions/ -f functions/Dockerfile.functions",
     "docker:up": "docker-compose up --build",
-    "docker:down": "docker-compose down"
+    "docker:down": "docker-compose down",
+    "sentry:release": "./scripts/sentry-release.sh"
   },
   "dependencies": {
     "@genkit-ai/core": "^1.13.0",

--- a/scripts/sentry-release.sh
+++ b/scripts/sentry-release.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ -z "${SENTRY_AUTH_TOKEN:-}" ]; then
+  echo "SENTRY_AUTH_TOKEN nao definido; pulando upload para o Sentry" >&2
+  exit 0
+fi
+
+RELEASE=${SENTRY_RELEASE:-$(git rev-parse --short HEAD)}
+
+npx sentry-cli releases new "$RELEASE"
+npx sentry-cli releases set-commits "$RELEASE" --auto
+npx sentry-cli releases files "$RELEASE" upload-sourcemaps .next --rewrite
+npx sentry-cli releases finalize "$RELEASE"


### PR DESCRIPTION
## Summary
- document `SENTRY_AUTH_TOKEN` on env.example and docs
- show how to use the token during deployment via `sentry-release.sh`
- call the script from the build step

## Testing
- `npm ci`
- `npm test` *(fails: ECONNREFUSED for Firebase emulators)*

------
https://chatgpt.com/codex/tasks/task_e_685953038708832485d6656f05f2e675