### PR TITLE
Adicionar documentação de testes e script de usuário pentester

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ _Ao adicionar `FIREBASE_PRIVATE_KEY` ao seu arquivo `.env.local` ou variável de
 
 Consulte [docs/blueprint.md](docs/blueprint.md) para uma visão geral das funcionalidades planejadas.
 Diretrizes adicionais sobre confiabilidade e processos de desenvolvimento estão em [docs/phase4-reliability.md](docs/phase4-reliability.md).
+Os principais fluxos de verificação manual encontram-se em [docs/fluxos-de-teste.md](docs/fluxos-de-teste.md).
+O passo a passo para gerar credenciais temporárias de staging está em [docs/staging-credentials.md](docs/staging-credentials.md).
 
 ## 🏗️ Containerização & Deploy
 

--- a/docs/fluxos-de-teste.md
+++ b/docs/fluxos-de-teste.md
@@ -1,0 +1,22 @@
+# Fluxos Principais de Teste
+
+Este guia resume os cenários essenciais para validação manual da plataforma.
+
+## Cadastro
+
+1. Acessar `/signup`.
+2. Informar e‑mail, senha e aceitar os termos.
+3. Confirmar e verificar redirecionamento para o dashboard.
+
+## Criação de Prontuário
+
+1. Fazer login.
+2. Navegar para `Prontuários > Novo`.
+3. Preencher os dados do paciente e salvar.
+4. Conferir se o prontuário aparece na lista e se é possível abrir para edição.
+
+## Agendamento
+
+1. Estando autenticado, acessar `Agenda`.
+2. Selecionar data e hora, escolhendo o paciente.
+3. Salvar e confirmar se o evento surge na grade de compromissos.

--- a/docs/staging-credentials.md
+++ b/docs/staging-credentials.md
@@ -1,0 +1,15 @@
+# Credenciais Temporárias em Staging
+
+Para conceder acesso seguro aos ambientes de testes, utilize contas específicas com prazo de expiração curto.
+
+1. Execute o script `scripts/create-pentester-user.ts` informando e‑mail e senha desejados. O papel `pentester` é aplicado automaticamente.
+   ```bash
+   npx tsx scripts/create-pentester-user.ts teste@example.com SenhaForte123!
+   ```
+2. Registre a validade (ex.: 24h) e comunique o e‑mail e senha apenas por canal seguro (1Password ou mensagem criptografada).
+3. Ao final do período, desative ou exclua o usuário via Firebase Console ou CLI:
+   ```bash
+   firebase auth:delete <uid>
+   ```
+
+Esse procedimento garante que cada rodada de verificações use credenciais isoladas e descartáveis, reduzindo riscos de acesso não autorizado.

--- a/scripts/create-pentester-user.ts
+++ b/scripts/create-pentester-user.ts
@@ -1,0 +1,28 @@
+/* eslint-env node */
+/* eslint-disable no-undef */
+import { initializeApp, cert } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+import 'dotenv/config';
+
+initializeApp({
+  credential: cert({
+    projectId: process.env.FIREBASE_PROJECT_ID,
+    clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+    privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+  }),
+});
+
+async function run() {
+  const email = process.argv[2] || 'pentester@example.com';
+  const password = process.argv[3] || 'ChangeMe123!';
+
+  const auth = getAuth();
+  const user = await auth.createUser({ email, password });
+  await auth.setCustomUserClaims(user.uid, { role: 'pentester' });
+  console.warn(`Usuário ${email} criado com uid ${user.uid}`);
+}
+
+run().catch((err) => {
+  console.error('Erro ao criar usuário:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Resumo
- documentar fluxos principais de teste
- explicar geração de credenciais temporárias no staging
- script para criar usuário 'pentester' via Firebase Admin
- referência aos novos docs no README

## Testes
- `npm test` *(falha: Firebase emulators ausentes)*

------
https://chatgpt.com/codex/tasks/task_e_6859530e814483248d733e7ff06359f6