### PR TITLE
Fix firestore rules formatting

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,7 +3,6 @@ rules\_version = '2';
 service cloud.firestore {
 match /databases/{database}/documents {
 
-```
 // --- Funções de Apoio (Helpers) ---
 
 function isSignedIn() {
@@ -205,7 +204,6 @@ match /auditLogs/{id} {
 match /{document=**} {
   allow read, write: if false;
 }
-```
 
 }
 }


### PR DESCRIPTION
## Summary
- remove stray code fence markers from `firestore.rules`
- validate Firestore rules with emulator

## Testing
- `npx firebase --config=firebase.temp.json emulators:exec --project=thalamus-dev 'echo Firestore rules validated'`

------
https://chatgpt.com/codex/tasks/task_e_6859530c66508324ba0d52a73d607052