### PR TITLE
Add community docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Código principal
+/src/ @brunenrique
+/functions/ @brunenrique
+/e2e/ @brunenrique
+
+# Regras do Firebase
+firestore.rules @brunenrique
+firestore.indexes.json @brunenrique
+storage.rules @brunenrique

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,129 @@
+# Pacto de Código de Conduta para Colaboradores
+
+## O nosso compromisso
+
+Nós, enquanto membros, colaboradores e administradores, comprometemo-nos a
+fazer da participação no nosso projeto uma experiência sem assédio para todos,
+independentemente da idade, diferença corporal, deficiência visível ou
+invisível, etnia, caraterísticas sexuais, identidade e expressão de género,
+nível de experiência, educação, estatuto socio-económico, nacionalidade, aspeto
+pessoal, raça, casta, cor, religião ou identidade e orientação sexual.
+
+Comprometemo-nos a agir e a interagir de forma a contribuir para um projeto
+aberto, acolhedor, diversificado, inclusivo e saudável.
+
+## Os nossos padrões
+
+Exemplos de comportamentos que contribuem para a criação de um ambiente
+positivo incluem:
+
+- Demonstrar empatia e bondade para com as outras pessoas
+- Respeitar as diferentes opiniões, pontos de vista e experiências
+- Dar e aceitar graciosamente feedback construtivo
+- Aceitar a responsabilidade e pedir desculpa às pessoas afectadas pelos nossos
+  erros, e aprender com a experiência
+- Concentrarmo-nos no que é melhor, não só para nós como indivíduos, mas para
+  todo o projeto
+
+Exemplos de comportamentos inaceitáveis por parte dos participantes incluem:
+
+- O uso de linguagem ou imagens sexualizadas, e atenção ou avanços sexuais de
+  qualquer tipo
+- Comentários insultuosos e/ou depreciativos e ataques pessoais ou
+  políticos (_Trolling_)
+- Assédio público ou privado
+- Publicar informação pessoal de outros sem permissão explícita, como, por
+  exemplo, endereços electrónicos ou moradas
+- Qualquer outra forma de conduta que possa ser considerada inapropriada num
+  ambiente profissional
+
+## As nossas responsabilidades
+
+Os administradores do projeto são responsáveis por clarificar e fazer cumprir
+as nossas normas de comportamento aceitável e tomarão medidas corretivas
+adequadas e justas em resposta a qualquer comportamento que considerem
+inadequado, ameaçador, ofensivo ou prejudicial.
+
+Os administradores do projeto têm o direito e a responsabilidade de remover,
+editar ou rejeitar comentários, commits, código, edições wiki, questões e outras
+contribuições que não estejam alinhadas com este Código de Conduta, e comunicarão
+os motivos das decisões de moderação quando apropriado.
+
+## Âmbito
+
+Este Código de Conduta aplica-se em todos os espaços do projeto e também se aplica
+quando um indivíduo está a representar oficialmente o projeto em espaços públicos.
+Exemplos de representação do nosso projeto incluem a utilização de um endereço de
+correio eletrónico oficial, uma publicação através de uma conta oficial nas redes
+sociais, ou atuar como representante nomeado num evento online ou offline.
+
+## Cumprimento
+
+Os casos de comportamento abusivo, de assédio ou de outro modo inaceitável podem ser
+comunicados contactando a equipa do projeto contato@example.com. Todas as
+queixas serão analisadas e investigadas de forma rápida e justa.
+
+A equipa do projeto é obrigada a manter a confidencialidade em relação ao elemento
+que reportou o incidente.
+
+## As nossas diretrizes
+
+Os administradores do projeto seguirão estas Diretrizes de Impacto no projeto para
+determinar as consequências de qualquer ação que considerem violar este Código de Conduta:
+
+### 1. Ação corretiva
+
+**Impacto no Projeto**: Uso de linguagem inapropriada ou outro comportamento
+considerado não profissional ou indesejável no projeto.
+
+**Consequência**: Uma advertência privada, por escrito, dos administradores do
+projeto, esclarecendo a natureza da violação e explicando por que razão o
+comportamento foi inadequado. Pode ser solicitado um pedido de desculpas público.
+
+### 2. Advertência
+
+**Impacto no Projeto**: Uma violação através de um único incidente ou série de ações.
+
+**Consequência**: Um aviso com consequências para a continuação do comportamento.
+Não interação com as pessoas envolvidas, incluindo interação não solicitada com os
+responsáveis pela aplicação do Código de Conduta, durante um determinado período de tempo.
+Isto inclui evitar interações em espaços comunitários, bem como em canais externos como as
+redes sociais. A violação destes termos pode levar a uma proibição temporária ou permanente.
+
+### 3. Proibição temporária
+
+**Impacto no Projeto**: Uma violação grave das normas do projeto, incluindo comportamento
+inadequado contínuo.
+
+**Consequência**: Proibição temporária de qualquer tipo de interação ou comunicação
+pública com o projeto durante um determinado período de tempo. Nenhuma interação
+pública ou privada com as pessoas envolvidas, incluindo interação não solicitada
+com os responsáveis pela aplicação do Código de Conduta, durante este período.
+A violação destes termos pode levar a uma proibição permanente.
+
+### 4. Proibição permanente
+
+**Impacto no projeto**: Demonstrar um padrão de violação das normas do projeto,
+incluindo comportamento inadequado contínuo, assédio a um indivíduo, ou agressão
+ou depreciação de classes de indivíduos.
+
+**Consequência**: Proibição permanente de qualquer tipo de interação pública no projeto.
+
+## Atribuição
+
+Este Código de Conduta foi adaptado do [Contributor Covenant][homepage],
+versão 2.1, disponível em
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+As Diretrizes de Impacto no Projeto foram inspiradas pela
+[Aplicação do código de conduta Mozilla][Mozilla CoC].
+
+Para obter respostas a perguntas comuns sobre este código de conduta, consulte
+as FAQ em [https://www.contributor-covenant.org/faq][FAQ]. As traduções estão
+disponíveis em [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Bruno Henrique
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Thalamus
 
 [![Build Status](https://github.com/seu-usuario/thalamus/actions/workflows/ci.yml/badge.svg)](https://github.com/seu-usuario/thalamus/actions/workflows/ci.yml) [![Release](https://img.shields.io/github/v/release/seu-usuario/thalamus)](https://github.com/seu-usuario/thalamus/releases/latest) [![Dependabot](https://img.shields.io/badge/dependabot-enabled-brightgreen?logo=dependabot)](https://github.com/seu-usuario/thalamus/pulls?q=is%3Apr+label%3Adependencies) [![CodeQL](https://github.com/seu-usuario/thalamus/actions/workflows/codeql.yml/badge.svg)](https://github.com/seu-usuario/thalamus/actions/workflows/codeql.yml) [![Coverage Status](https://coveralls.io/repos/github/seu-usuario/thalamus/badge.svg?branch=main)](https://coveralls.io/github/seu-usuario/thalamus?branch=main)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 Plataforma web para gestão de clínicas de psicologia, com agenda integrada, prontuários seguros e funcionalidades auxiliadas por IA. O projeto é baseado em **Next.js** e **Firebase**, utilizando **TypeScript** e **Tailwind CSS** no frontend e **Cloud Functions** no backend. Fluxos de IA são implementados com **Genkit** e Google AI.
 
@@ -188,6 +189,10 @@ Principais variáveis usadas:
 - `SENTRY_AUTH_TOKEN`
 - `NEXT_PUBLIC_SENTRY_DSN`
 - `LHCI_GITHUB_APP_TOKEN`
+
+## Como Contribuir
+
+Contribuições são bem-vindas! Consulte o [CONTRIBUTING.md](CONTRIBUTING.md) e o [Código de Conduta](CODE_OF_CONDUCT.md) antes de enviar pull requests.
 
 ## Solucao de Problemas
 


### PR DESCRIPTION
## Summary
- add MIT LICENSE
- document how to contribute and link Code of Conduct
- include license badge
- add Contributor Covenant v2.1
- set default CODEOWNERS

## Testing
- `npm install` *(fails: npm audit warnings)*
- `npm run test:all` *(fails to run tests: missing emulator and modules)*

------
https://chatgpt.com/codex/tasks/task_e_685956fa3b308324ab993984c7f59b7c