### PR TITLE
Add deploy documentation

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,35 @@
+# Deploy da Aplicação
+
+Este guia resume como executar o projeto via Docker e como publicá-lo na Vercel.
+
+## Docker
+
+1. Gere a imagem do app:
+
+   ```bash
+   docker build -t thalamus .
+   ```
+
+2. Copie `env.example` para `.env` e preencha os valores conforme seu ambiente.
+
+3. Inicie os serviços:
+
+   ```bash
+   docker-compose up -d
+   ```
+
+   O `docker-compose` lê as variáveis definidas no `.env`.
+
+## Vercel
+
+1. Crie um novo projeto e associe este repositório à Vercel.
+2. Defina todas as variáveis listadas em `env.example` nas configurações do projeto.
+3. Utilize o comando de build padrão:
+
+   ```bash
+   npm run build
+   ```
+
+   A Vercel irá executar `next start` automaticamente após o build.
+
+Com as variáveis configuradas, cada push para a branch principal gerará um deploy automático.

--- a/env.example
+++ b/env.example
@@ -42,4 +42,6 @@ NEXT_PUBLIC_DISABLE_AUTH="false"
 NEXT_PUBLIC_SENTRY_DSN=""
 SENTRY_DSN=""
 SENTRY_AUTH_TOKEN="" # Token para upload de sourcemaps via Sentry CLI
+# Opcional: define o nome do release para o Sentry
+SENTRY_RELEASE=""
 LHCI_GITHUB_APP_TOKEN=""


### PR DESCRIPTION
## Summary
- document docker and Vercel deploy process
- update `.env.example` with `SENTRY_RELEASE`

## Testing
- `./run-tests.sh` *(fails: Firestore emulator shutdown)*

------
https://chatgpt.com/codex/tasks/task_e_6859577394248324b29100669c6a65c1