### PR TITLE
Ajustes de usabilidade e acessibilidade

### DIFF
--- a/src/app/(app)/groups/edit/[id]/page.tsx
+++ b/src/app/(app)/groups/edit/[id]/page.tsx
@@ -9,6 +9,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Edit, FileWarning } from 'lucide-react';
 import Link from 'next/link';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import Heading from '@/components/ui/heading';
 
 export default function EditGroupPage() {
   const params = useParams();
@@ -97,9 +98,12 @@ export default function EditGroupPage() {
 
   return (
     <div className="space-y-6">
+      <Link href="/groups" className="text-sm text-primary hover:underline" prefetch={false}>
+        ← Voltar a Grupos
+      </Link>
       <div className="flex items-center gap-2">
         <Edit className="h-7 w-7 text-primary" />
-        <h1 className="text-3xl font-headline font-bold">Editar Grupo: {groupData.name}</h1>
+        <Heading level={1}>Editar Grupo: {groupData.name}</Heading>
       </div>
       <GroupForm initialData={groupData} groupId={groupId} />
     </div>

--- a/src/app/(app)/groups/new/page.tsx
+++ b/src/app/(app)/groups/new/page.tsx
@@ -3,13 +3,14 @@
 
 import GroupForm from "@/components/forms/group-form";
 import { Users as UsersIcon } from "lucide-react"; // Renamed to avoid conflict with page name
+import Heading from "@/components/ui/heading";
 
 export default function NewGroupPage() {
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-2">
         <UsersIcon className="h-7 w-7 text-primary" />
-        <h1 className="text-3xl font-headline font-bold">Criar Novo Grupo Terapêutico</h1>
+        <Heading level={1}>Criar Novo Grupo Terapêutico</Heading>
       </div>
       <GroupForm />
     </div>

--- a/src/app/(app)/groups/page.tsx
+++ b/src/app/(app)/groups/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
+import PrimaryButton from '@/components/ui/primary-button';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import {
   Table,
@@ -65,12 +66,12 @@ export default function TherapeuticGroupsPage() {
           <h1 className="text-3xl font-headline font-bold">Grupos Terapêuticos</h1>
         </div>
         <RequireRole role="Admin">
-          <Button asChild className="bg-accent hover:bg-accent/90 text-accent-foreground">
+          <PrimaryButton asChild>
             <Link href="/groups/new" className="inline-flex items-center gap-2">
               <PlusCircle className="h-4 w-4" />
               Criar Novo Grupo
             </Link>
-          </Button>
+          </PrimaryButton>
         </RequireRole>
       </div>
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -21,7 +21,7 @@
     --secondary: 240 4.8% 95.9%;
     --secondary-foreground: 240 5.9% 10%;
     --muted: 240 4.8% 95.9%;
-    --muted-foreground: 240 3.8% 46.1%;
+    --muted-foreground: #4b5563;
     --accent: 240 4.8% 95.9%; /* Default accent if not specified otherwise */
     --accent-foreground: 240 5.9% 10%;
     --destructive: 0 84.2% 60.2%;
@@ -44,7 +44,7 @@
     --secondary: 240 3.7% 15.9%;
     --secondary-foreground: 0 0% 98%;
     --muted: 240 3.7% 15.9%;
-    --muted-foreground: 0 0% 63.9%;
+    --muted-foreground: #a3a3a3;
     --accent: 240 3.7% 15.9%; /* Default dark accent */
     --accent-foreground: 0 0% 98%;
     --destructive: 0 62.8% 30.6%;

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -10,7 +10,7 @@ import { Check } from "lucide-react"
 import { cn } from "@/shared/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/src/components/ui/heading.tsx
+++ b/src/components/ui/heading.tsx
@@ -1,0 +1,14 @@
+"use client";
+import { cn } from "@/shared/utils";
+interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
+  level?: 1 | 2 | 3;
+}
+export default function Heading({ level = 1, className, ...props }: HeadingProps) {
+  const Tag = (`h${level}`) as keyof JSX.IntrinsicElements;
+  const sizes: Record<number, string> = {
+    1: "text-3xl",
+    2: "text-2xl",
+    3: "text-xl",
+  };
+  return <Tag className={cn("font-headline font-bold", sizes[level], className)} {...props} />;
+}

--- a/src/components/ui/primary-button.tsx
+++ b/src/components/ui/primary-button.tsx
@@ -1,0 +1,16 @@
+"use client";
+import React from "react";
+import { Button, ButtonProps } from "./button";
+import { cn } from "@/shared/utils";
+
+export default function PrimaryButton({ className, ...props }: ButtonProps) {
+  return (
+    <Button
+      className={cn(
+        "bg-primary text-white hover:bg-primary/90",
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -62,7 +62,7 @@ const config = {
         },
         muted: {
           DEFAULT: 'hsl(var(--muted))',
-          foreground: 'hsl(var(--muted-foreground))',
+          foreground: '#4b5563',
         },
         accent: {
           DEFAULT: 'hsl(var(--accent))',


### PR DESCRIPTION
## Summary
- link de retorno em edição de grupos
- componente `<Heading>` e refactor
- botão principal centralizado
- realce de foco visível em botões
- cor de `muted-foreground` ajustada para melhor contraste

## Testing
- `npm test` *(falhou: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68595f6339e88324bf8ab2c8db50ed20