### PR TITLE
Add observability guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Plataforma web para gestão de clínicas de psicologia, com agenda integrada, pr
     - Você pode definir manualmente a senha chamando `setEncryptionPassword()` no início da aplicação ou configurando a variável de ambiente `ENCRYPTION_KEY`.
     - Sem essa senha, os dados sensíveis gravados no Firestore não poderão ser descriptografados.
 5.  **Inicie os Emuladores Firebase (em um terminal separado):**
-
     - É altamente recomendado usar os emuladores do Firebase para desenvolvimento local.
     - Se esta é a primeira vez, configure os emuladores: `firebase init emulators` (selecione Firestore, Storage, Functions).
     - Inicie os emuladores: `firebase emulators:start --project=demo-project`
@@ -142,6 +141,7 @@ Consulte [docs/blueprint.md](docs/blueprint.md) para uma visão geral das funcio
 Diretrizes adicionais sobre confiabilidade e processos de desenvolvimento estão em [docs/phase4-reliability.md](docs/phase4-reliability.md).
 Os principais fluxos de verificação manual encontram-se em [docs/fluxos-de-teste.md](docs/fluxos-de-teste.md).
 O passo a passo para gerar credenciais temporárias de staging está em [docs/staging-credentials.md](docs/staging-credentials.md).
+Detalhes sobre logs e alertas estão em [docs/observability.md](docs/observability.md).
 
 ## 🏗️ Containerização & Deploy
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,55 @@
+# Observabilidade
+
+Este guia apresenta os passos para registrar e monitorar eventos da aplicação, além de configurar alertas.
+
+## Instalação e Configuração do Logger
+
+1. O projeto utiliza um logger simples em `src/lib/logger.ts`.
+2. Para registrar ações no frontend, importe a função `logAction` e chame-a informando o `userId` e a descrição do evento:
+   ```ts
+   import { logAction } from '@/lib/logger';
+   logAction(user.uid, 'login_success');
+   ```
+3. Em Cloud Functions, utilize `functions.logger` para que as mensagens sejam enviadas ao Cloud Logging automaticamente:
+   ```ts
+   import * as functions from 'firebase-functions';
+   functions.logger.info('Role set on user creation', { uid });
+   ```
+
+## Visualizando Logs no Cloud Logging
+
+1. Acesse o [Console do GCP](https://console.cloud.google.com/).
+2. Selecione **Logging > Logs Explorer**.
+3. Utilize o seletor de recursos para filtrar pelos serviços utilizados (Cloud Functions ou Cloud Run).
+4. Pesquise pelos rótulos ou textos que foram enviados no logger.
+
+## Alertas no Sentry
+
+1. Crie uma conta no [Sentry](https://sentry.io/).
+2. Defina um novo projeto **Next.js** ou **Node.js** conforme a necessidade.
+3. No painel do projeto, acesse **Alerts > Create Alert**.
+4. Configure a regra desejada, como taxa de erros ou mensagens específicas.
+5. Salve e teste o alerta forçando um erro em ambiente de staging.
+
+## Alertas no Cloud Monitoring
+
+1. No [Console do GCP](https://console.cloud.google.com/), abra **Monitoring > Alerting**.
+2. Clique em **Criar política** e defina uma condição de métrica ou de logs.
+3. Para logs, selecione **Log-based** e forneça a consulta que deseja monitorar.
+4. Configure o canal de notificação (e-mail ou webhook) e salve.
+
+## Queries Úteis no Logs Explorer
+
+- Erros de Cloud Functions:
+  ```
+  resource.type="cloud_function"
+  severity>=ERROR
+  ```
+- Ações de login:
+  ```
+  jsonPayload.action="login_success"
+  ```
+- Consultar mensagens específicas do frontend:
+  ```
+  textPayload:"patient_created"
+  ```


### PR DESCRIPTION
## Summary
- document logging and alerting setup
- reference observability docs in README

## Testing
- `npm run lint` *(fails: prettier/prettier errors)*

------
https://chatgpt.com/codex/tasks/task_e_68596134f0388324a2fbe5923089dd41