### PR TITLE
Add Cloud Logging credentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN npm prune --production && yarn cache clean || true
 FROM node:20-alpine AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
+ENV GOOGLE_APPLICATION_CREDENTIALS=/app/credentials.json
+COPY credentials.json /app/credentials.json
 
 # Copy only necessary files from build stage
 COPY --from=build /app/package.json ./

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,19 @@
+steps:
+  - name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        cp credentials.json /workspace/credentials.json
+    env:
+      - 'GOOGLE_APPLICATION_CREDENTIALS=/workspace/credentials.json'
+  - name: 'gcr.io/cloud-builders/npm'
+    args: ['install']
+    env:
+      - 'GOOGLE_APPLICATION_CREDENTIALS=/workspace/credentials.json'
+  - name: 'gcr.io/cloud-builders/npm'
+    args: ['run','build']
+    env:
+      - 'GOOGLE_APPLICATION_CREDENTIALS=/workspace/credentials.json'
+images:
+  - 'gcr.io/$PROJECT_ID/thalamus'

--- a/docs/cloud-logging.md
+++ b/docs/cloud-logging.md
@@ -1,0 +1,15 @@
+# Cloud Logging
+
+Para que os logs do aplicativo apareçam no Google Cloud, é necessário habilitar a API **Cloud Logging** manualmente nos projetos `thalamus-prod` e `thalamus-staging`.
+
+```bash
+# Execute uma vez para cada projeto
+ gcloud services enable logging.googleapis.com --project=thalamus-prod
+ gcloud services enable logging.googleapis.com --project=thalamus-staging
+```
+
+Após habilitar, verifique localmente com o comando abaixo (substituindo pela sua chave de serviço):
+
+```bash
+gcloud logging write test-log "teste de envio" --project=thalamus-staging
+```

--- a/env.example
+++ b/env.example
@@ -45,3 +45,6 @@ SENTRY_AUTH_TOKEN="" # Token para upload de sourcemaps via Sentry CLI
 # Opcional: define o nome do release para o Sentry
 SENTRY_RELEASE=""
 LHCI_GITHUB_APP_TOKEN=""
+
+# Caminho para o JSON de credenciais do Google
+GOOGLE_APPLICATION_CREDENTIALS="credentials.json"

--- a/functions/Dockerfile.functions
+++ b/functions/Dockerfile.functions
@@ -1,5 +1,7 @@
 FROM node:20-alpine
 WORKDIR /usr/src/app
+ENV GOOGLE_APPLICATION_CREDENTIALS=/app/credentials.json
+COPY credentials.json /app/credentials.json
 
 # Install dependencies
 COPY package.json yarn.lock* package-lock.json* ./


### PR DESCRIPTION
## Summary
- allow runtime to load Google credentials
- provide credentials in functions build
- document Cloud Logging in env.example and docs
- add Cloud Build config to copy credentials

## Testing
- `npm run lint` *(fails: 4870 problems)*
- `npm run typecheck` *(fails to compile)*
- `npm run test:all` *(fails to run tests)*
- `gcloud logging write test-log "Hello"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685961074f748324bb5c389da6cc10e9