### PR TITLE
Fix run-tests script

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -5,5 +5,11 @@ SCRIPT_DIR="$(dirname "$0")"
 echo "📦 Instalando dependências via npm..."
 npm ci
 
-echo "🔥 Rodando testes com Firebase Emulator via Volta..."
-npx firebase emulators:exec --project="${FIREBASE_PROJECT:-thalamus-dev}" --only firestore "npm run coverage -- --runInBand"
+echo "🔍 Verificando instalação do Jest..."
+if ! npx --no-install jest --version >/dev/null 2>&1; then
+  echo "❌ Jest não encontrado. Verifique a instalação das dependências." >&2
+  exit 1
+fi
+
+echo "🔥 Iniciando Firebase Emulator e executando testes..."
+npx firebase emulators:exec --project="${FIREBASE_PROJECT:-thalamus-dev}" --only firestore "npm run test:all -- --runInBand"


### PR DESCRIPTION
## Summary
- verify Jest installation before running tests
- run Firebase emulator and execute `npm run test:all`

## Testing
- `./run-tests.sh` *(fails: Failed to download puppeteer due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6859c25ebc2c8324923d513dd2b97156