### PR TITLE
Fix CI to run tests with Firebase emulator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           node-version: 20.11.0
 
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
       - name: Cache node_modules
         uses: actions/cache@v3
         with:
@@ -45,7 +48,7 @@ jobs:
         run: npx playwright test
 
       - name: Test and Coverage
-        run: npm run coverage
+        run: npx firebase emulators:exec --project=thalamus-dev --only firestore "npm run test:all -- --runInBand"
 
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2


### PR DESCRIPTION
## Summary
- update Node.js workflow to install Firebase CLI
- run Jest tests with Firebase emulator

## Testing
- `./run-tests.sh` *(fails: Failed to download Chromium due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6859c2d06c78832488cfda39cd31cdbc