### PR TITLE
Add signup page with form validation

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,9 +1,70 @@
+'use client'
 
-import SignUpForm from "@/components/forms/auth/signup-form";
-import { Brain } from "lucide-react";
-import Link from "next/link";
+import * as React from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import * as z from 'zod'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { Brain } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { Card, CardContent } from '@/components/ui/card'
+import { useToast } from '@/hooks/use-toast'
+
+const signupSchema = z.object({
+  name: z.string().min(1, 'Nome obrigatório.'),
+  email: z.string().email('E-mail inválido.'),
+  password: z.string().min(8, 'A senha deve ter pelo menos 8 caracteres.'),
+})
+
+type SignUpFormValues = z.infer<typeof signupSchema>
 
 export default function SignUpPage() {
+  const router = useRouter()
+  const { toast } = useToast()
+  const [isLoading, setIsLoading] = React.useState(false)
+
+  const form = useForm<SignUpFormValues>({
+    resolver: zodResolver(signupSchema),
+    defaultValues: { name: '', email: '', password: '' },
+  })
+
+  async function onSubmit(data: SignUpFormValues) {
+    setIsLoading(true)
+    try {
+      const res = await fetch('/api/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: data.email, password: data.password }),
+      })
+      if (!res.ok) {
+        const { error } = await res.json()
+        toast({
+          title: 'Erro ao criar conta',
+          description: error ?? 'Falha ao cadastrar usuário.',
+          variant: 'destructive',
+        })
+        return
+      }
+      toast({ title: 'Conta criada', description: 'Use suas credenciais para entrar.' })
+      router.push('/login')
+    } catch {
+      toast({ title: 'Erro ao criar conta', variant: 'destructive' })
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-background to-secondary p-4">
       <div className="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[420px] rounded-xl shadow-sm p-4">
@@ -19,17 +80,63 @@ export default function SignUpPage() {
             Junte-se ao Thalamus para otimizar seu consultório.
           </p>
         </div>
-        <SignUpForm />
+        <Card className="shadow-lg">
+          <CardContent className="pt-6">
+            <Form {...form}>
+              <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                <FormField
+                  control={form.control}
+                  name="name"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Nome</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Nome Completo" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="email"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Email</FormLabel>
+                      <FormControl>
+                        <Input type="email" autoComplete="email" placeholder="nome@exemplo.com" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="password"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Senha</FormLabel>
+                      <FormControl>
+                        <Input type="password" autoComplete="new-password" placeholder="••••••••" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <Button type="submit" className="w-full bg-accent hover:bg-accent/90 text-accent-foreground" disabled={isLoading}>
+                  {isLoading ? 'Criando Conta...' : 'Criar Conta'}
+                </Button>
+              </form>
+            </Form>
+          </CardContent>
+        </Card>
         <p className="px-8 text-center text-sm text-muted-foreground">
-          Já tem uma conta?{" "}
-          <Link
-            href="/login"
-            className="underline underline-offset-4 hover:text-primary"
-          >
+          Já tem uma conta?{' '}
+          <Link href="/login" className="underline underline-offset-4 hover:text-primary">
             Entrar
           </Link>
         </p>
       </div>
     </div>
-  );
+  )
 }


### PR DESCRIPTION
## Summary
- implement Signup page using react-hook-form and Zod
- send POST `/api/signup` on submit

## Testing
- `npm install` *(fails: unable to download puppeteer)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859c69da774832490e5dff2ad76cf38