### PR TITLE
Implement email/password login route

### DIFF
--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -2,7 +2,7 @@
  * @openapi
  * /api/login:
  *   post:
- *     summary: Cria cookie de sessão a partir do idToken do Firebase.
+ *     summary: Autentica com email e senha pelo Firebase Auth.
  *     requestBody:
  *       required: true
  *       content:
@@ -10,13 +10,15 @@
  *           schema:
  *             type: object
  *             properties:
- *               idToken:
+ *               email:
+ *                 type: string
+ *               password:
  *                 type: string
  *     responses:
  *       '200':
  *         description: Sessão criada com sucesso.
  *       '400':
- *         description: Falta o idToken no corpo da requisição.
+ *         description: Dados ausentes.
  *       '500':
  *         description: Erro interno ao processar o login.
  */
@@ -28,33 +30,57 @@ import { auth as adminAuth } from 'firebase-admin';
 import { firestoreAdmin } from '@/lib/firebaseAdmin';
 import { writeAuditLog } from '@/services/auditLogService';
 
+const FIREBASE_API_KEY = process.env.NEXT_PUBLIC_FIREBASE_API_KEY;
+
 export async function POST(request: Request) {
   try {
-    const { idToken } = await request.json();
-    if (!idToken) {
-      return NextResponse.json({ error: 'Missing idToken' }, { status: 400 });
+    const { email, password } = await request.json();
+    if (!email || !password) {
+      return NextResponse.json({ error: 'Dados ausentes' }, { status: 400 });
     }
+
+    if (!FIREBASE_API_KEY) {
+      throw new Error('Firebase API key not configured');
+    }
+
+    const res = await fetch(
+      `https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=${FIREBASE_API_KEY}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password, returnSecureToken: true }),
+      }
+    );
+
+    if (!res.ok) {
+      return NextResponse.json({ error: 'Credenciais inválidas' }, { status: 401 });
+    }
+
+    const { idToken, localId } = await res.json();
+
+    const userRecord = await adminAuth().getUser(localId);
+    if (!userRecord.emailVerified) {
+      return NextResponse.json({ error: 'Email não verificado' }, { status: 401 });
+    }
+
     const expiresIn = 60 * 60 * 24 * 5 * 1000; // 5 days
-    const decoded = await adminAuth().verifyIdToken(idToken);
     await adminAuth().createSessionCookie(idToken, { expiresIn });
-    const userRecord = await adminAuth().getUser(decoded.uid);
     const role = userRecord.customClaims?.role || 'Psychologist';
-    const session = { user: { uid: decoded.uid, role } };
-    const response = NextResponse.json({ success: true });
+    const session = { user: { uid: localId, role } };
+    const response = NextResponse.json({ token: idToken });
     response.cookies.set('session', JSON.stringify(session), {
       httpOnly: true,
-      // eslint-disable-next-line no-undef
       secure: process.env.NODE_ENV === 'production',
       maxAge: expiresIn / 1000,
       path: '/',
     });
-    logger.info({ userId: decoded.uid, action: 'login_api' });
+    logger.info({ userId: localId, action: 'login_api' });
     await writeAuditLog(
       {
-        userId: decoded.uid,
+        userId: localId,
         actionType: 'login',
         timestamp: new Date().toISOString(),
-        targetResourceId: decoded.uid,
+        targetResourceId: localId,
       },
       firestoreAdmin
     );


### PR DESCRIPTION
## Summary
- update OpenAPI docs for login route
- implement POST `/api/login` to authenticate with Firebase using email and password

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: network access to npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6859ca2593a88324b9491312a47ba4f8