### PR TITLE
Fix logging in edge middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,11 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import * as Sentry from '@sentry/nextjs';
-import logger from '@/lib/logger';
+// logger based on console to ensure Edge compatibility
+const edgeLogger = {
+  error: console.error,
+  info: console.info,
+  warn: console.warn,
+};
 
 const PUBLIC_PATHS = ['/login'];
 
@@ -30,7 +35,7 @@ export async function middleware(request: NextRequest) {
       }
     } catch (err) {
       Sentry.captureException(err);
-      logger.error({ action: 'token_verify_error', meta: { error: err } });
+      edgeLogger.error({ action: 'token_verify_error', meta: { error: err } });
     }
   }
   return NextResponse.redirect(new globalThis.URL('/login', request.url));


### PR DESCRIPTION
## Summary
- use a console-based logger inside `middleware.ts`

## Testing
- `npm run lint` *(fails: prettier errors)*
- `npm test` *(fails: multiple Jest configs)*
- `npm run typecheck` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6859d0b419e08324b34bc814cb22e4ed