### PR TITLE
feat(waiting-list): add status column

### DIFF
--- a/src/app/(app)/waiting-list/page.tsx
+++ b/src/app/(app)/waiting-list/page.tsx
@@ -32,7 +32,7 @@ import Link from 'next/link';
 import { Badge } from '@/components/ui/badge';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
-import { getWaitingList } from '@/services/waitingListService';
+import { getWaitingListEntries } from '@/services/waitingListService';
 import type { WaitingListEntry } from '@/types';
 import { Skeleton } from '@/components/ui/skeleton';
 
@@ -47,7 +47,7 @@ export default function WaitingListPage() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    getWaitingList().then((l) => {
+    getWaitingListEntries().then((l) => {
       setList(l);
       setLoading(false);
     });
@@ -92,6 +92,7 @@ export default function WaitingListPage() {
                     <TableHead>Nome</TableHead>
                     <TableHead>Psicólogo(a) Solicitado(a)</TableHead>
                     <TableHead>Data de Adição</TableHead>
+                    <TableHead>Status</TableHead>
                     <TableHead>Prioridade</TableHead>
                     <TableHead>Observações</TableHead>
                     <TableHead className="text-right">Ações</TableHead>
@@ -112,6 +113,7 @@ export default function WaitingListPage() {
                       <TableCell>
                         {format(new Date(item.dateAdded), 'P', { locale: ptBR })}
                       </TableCell>
+                      <TableCell>{item.status || priorityLabels[item.priority] || 'Pendente'}</TableCell>
                       <TableCell>
                         <Badge
                           variant={

--- a/src/services/waitingListService.ts
+++ b/src/services/waitingListService.ts
@@ -18,9 +18,16 @@ import {
 } from 'firebase/firestore';
 
 export async function getWaitingList(): Promise<WaitingListEntry[]> {
-  const q = query(collection(db, FIRESTORE_COLLECTIONS.WAITING_LIST), orderBy('dateAdded', 'desc'));
+  const q = query(
+    collection(db, FIRESTORE_COLLECTIONS.WAITING_LIST),
+    orderBy('dateAdded', 'desc'),
+  );
   const snap = await getDocs(q);
   return snap.docs.map((d) => ({ id: d.id, ...(d.data() as Omit<WaitingListEntry, 'id'>) }));
+}
+
+export async function getWaitingListEntries(): Promise<WaitingListEntry[]> {
+  return getWaitingList();
 }
 
 export async function getWaitingListEntryById(id: string): Promise<WaitingListEntry | undefined> {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,6 +18,7 @@ export interface WaitingListEntry {
   requestedPsychologist?: string;
   requestedPsychologistId?: string;
   dateAdded: string; // ISO date
+  status?: string;
   priority: TaskPriority;
   notes?: string;
   contactPhone?: string;


### PR DESCRIPTION
## Summary
- add `getWaitingListEntries` helper
- extend `WaitingListEntry` with optional `status`
- show patient status on waiting list page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d656e5f883249a7d4cdfb30e9495