### PR TITLE
Fix Tailwind PostCSS plugin

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -2,7 +2,6 @@
 /* eslint-env node */
 module.exports = {
   plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
+    '@tailwindcss/postcss': {},
   },
 };


### PR DESCRIPTION
## Summary
- update PostCSS config to use `@tailwindcss/postcss`

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: puppeteer download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6859daf50cf0832484f3c572aeb839f1