### PR TITLE
Implement schedule conflict checker

### DIFF
--- a/__tests__/scheduler.test.ts
+++ b/__tests__/scheduler.test.ts
@@ -1,0 +1,121 @@
+import { initializeTestEnvironment } from '@firebase/rules-unit-testing';
+import { readFileSync } from 'fs';
+import { Firestore, doc, setDoc } from 'firebase/firestore';
+
+let checkScheduleConflict: any;
+let testEnv: Awaited<ReturnType<typeof initializeTestEnvironment>>;
+
+beforeAll(async () => {
+  const hostPort = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8084';
+  const [host, portStr] = hostPort.split(':');
+  const port = parseInt(portStr, 10);
+
+  testEnv = await initializeTestEnvironment({
+    projectId: 'demo-project',
+    firestore: {
+      host,
+      port,
+      rules: readFileSync('firestore.rules', 'utf8'),
+    },
+  });
+
+  const auth = { uid: 'psy1', role: 'Psychologist' };
+  const db = testEnv.authenticatedContext(auth.uid, auth).firestore();
+
+  jest.doMock('../src/lib/firebase', () => ({
+    db,
+  }));
+
+  ({ checkScheduleConflict } = await import('../src/lib/scheduler'));
+});
+
+afterAll(async () => {
+  if (testEnv) await testEnv.cleanup();
+  jest.resetModules();
+});
+
+function getDb(auth: { uid: string; role: string }): Firestore {
+  return testEnv.authenticatedContext(auth.uid, auth).firestore();
+}
+
+test('detects conflict with existing appointment', async () => {
+  const auth = { uid: 'psy1', role: 'Psychologist' };
+  const db = getDb(auth);
+  await setDoc(doc(db, 'appointments/a1'), {
+    psychologistId: auth.uid,
+    appointmentDate: '2024-01-01',
+    startTime: '09:00',
+    endTime: '10:00',
+    type: 'Consulta',
+    status: 'Scheduled',
+  });
+
+  const conflict = await checkScheduleConflict(
+    {
+      appointmentDate: '2024-01-01',
+      startTime: '09:30',
+      endTime: '10:30',
+      psychologistId: auth.uid,
+    },
+    db
+  );
+  expect(conflict).toBe(true);
+});
+
+test('block slot logic', async () => {
+  const auth = { uid: 'psy1', role: 'Psychologist' };
+  const db = getDb(auth);
+  await setDoc(doc(db, 'appointments/block1'), {
+    psychologistId: auth.uid,
+    appointmentDate: '2024-01-01',
+    startTime: '13:00',
+    endTime: '14:00',
+    type: 'Blocked Slot',
+    status: 'Blocked',
+  });
+
+  const conflictForPatient = await checkScheduleConflict(
+    {
+      appointmentDate: '2024-01-01',
+      startTime: '13:30',
+      endTime: '13:45',
+      psychologistId: auth.uid,
+    },
+    db
+  );
+  expect(conflictForPatient).toBe(true);
+
+  const conflictForBlock = await checkScheduleConflict(
+    {
+      appointmentDate: '2024-01-01',
+      startTime: '13:30',
+      endTime: '13:45',
+      psychologistId: auth.uid,
+      isBlockTime: true,
+    },
+    db
+  );
+  expect(conflictForBlock).toBe(false);
+});
+
+test('detects conflict with group session', async () => {
+  const auth = { uid: 'psy1', role: 'Psychologist' };
+  const db = getDb(auth);
+  await setDoc(doc(db, 'groups/g1'), {
+    psychologistId: auth.uid,
+    dayOfWeek: 'monday',
+    startTime: '15:00',
+    endTime: '16:00',
+  });
+
+  const conflict = await checkScheduleConflict(
+    {
+      appointmentDate: '2024-01-01',
+      startTime: '15:30',
+      endTime: '16:00',
+      psychologistId: auth.uid,
+    },
+    db
+  );
+  expect(conflict).toBe(true);
+});

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -1,0 +1,69 @@
+import { collection, getDocs, query, where, type Firestore } from 'firebase/firestore';
+import { parse, getDay } from 'date-fns';
+import { db } from './firebase';
+import { FIRESTORE_COLLECTIONS } from './firestore-collections';
+
+const dayOfWeekMap: Record<string, number> = {
+  sunday: 0,
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
+};
+
+export interface ConflictCheckInput {
+  appointmentDate: string; // yyyy-MM-dd
+  startTime: string; // HH:mm
+  endTime: string; // HH:mm
+  psychologistId: string;
+  isBlockTime?: boolean;
+}
+
+export async function checkScheduleConflict(
+  data: ConflictCheckInput,
+  firestore: Firestore = db
+): Promise<boolean> {
+  const { appointmentDate, startTime, endTime, psychologistId, isBlockTime = false } = data;
+
+  const apptQuery = query(
+    collection(firestore, FIRESTORE_COLLECTIONS.APPOINTMENTS),
+    where('psychologistId', '==', psychologistId),
+    where('appointmentDate', '==', appointmentDate)
+  );
+  const apptSnap = await getDocs(apptQuery);
+  const timeOverlap = (aStart: string, aEnd: string) => startTime < aEnd && endTime > aStart;
+
+  const individualConflict = apptSnap.docs.some((doc) => {
+    const appt = doc.data() as Record<string, any>;
+    if (appt.status === 'CancelledByPatient' || appt.status === 'CancelledByClinic') {
+      return false;
+    }
+    if (isBlockTime && appt.type === 'Blocked Slot') {
+      return false;
+    }
+    if (!isBlockTime && appt.type === 'Blocked Slot') {
+      return timeOverlap(appt.startTime, appt.endTime);
+    }
+    return timeOverlap(appt.startTime, appt.endTime);
+  });
+
+  if (individualConflict) return true;
+
+  const dayIndex = getDay(parse(appointmentDate, 'yyyy-MM-dd', new Date()));
+  const groupQuery = query(
+    collection(firestore, FIRESTORE_COLLECTIONS.GROUPS),
+    where('psychologistId', '==', psychologistId)
+  );
+  const groupSnap = await getDocs(groupQuery);
+
+  const groupConflict = groupSnap.docs.some((doc) => {
+    const group = doc.data() as Record<string, any>;
+    const groupDay = dayOfWeekMap[(group.dayOfWeek || '').toLowerCase()];
+    if (groupDay !== dayIndex) return false;
+    return timeOverlap(group.startTime, group.endTime);
+  });
+
+  return groupConflict;
+}


### PR DESCRIPTION
## Summary
- add scheduler utility to detect schedule conflicts
- cover scenarios with overlapping appointments, block times, and groups

## Testing
- `npm run lint` *(fails: cannot satisfy Prettier rules)*
- `npm run typecheck` *(fails with TS errors)*
- `npm run test:all` *(fails: emulator and module issues)*

------
https://chatgpt.com/codex/tasks/task_e_6859e28aec8c83248997148d87ace987