### PR TITLE
Add insights logging

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -216,6 +216,12 @@ match /auditLogs/{id} {
   allow update, delete: if false;
 }
 
+match /insights_logs/{id} {
+  allow create: if isSignedIn();
+  allow read: if isAdmin();
+  allow update, delete: if false;
+}
+
 match /{document=**} {
   allow read, write: if false;
 }

--- a/src/app/api/insights/route.ts
+++ b/src/app/api/insights/route.ts
@@ -43,10 +43,10 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    await adminAuth().verifyIdToken(token);
+    const decoded = await adminAuth().verifyIdToken(token);
     const body = await request.json();
     const input = GenerateSessionInsightsInputSchema.parse(body);
-    const result = await generateSessionInsights(input);
+    const result = await generateSessionInsights(input, { userId: decoded.uid });
     return NextResponse.json(result);
   } catch (e) {
     if (e instanceof ZodError) {

--- a/src/lib/firestore-collections.ts
+++ b/src/lib/firestore-collections.ts
@@ -16,6 +16,7 @@ export const FIRESTORE_COLLECTIONS = {
   QUICK_NOTES: 'quickNotes',
   SCHEDULES: 'schedules',
   AUDIT_LOGS: 'auditLogs',
+  INSIGHTS_LOGS: 'insights_logs',
   CLINICAL_DATA: 'clinicalTabs',
 } as const;
 

--- a/src/services/insightsLogService.ts
+++ b/src/services/insightsLogService.ts
@@ -1,0 +1,20 @@
+import { addDoc, collection, type Firestore } from 'firebase/firestore';
+import { db } from '@/lib/firebase';
+import { FIRESTORE_COLLECTIONS } from '@/lib/firestore-collections';
+
+export interface InsightsLogEntry {
+  userId: string;
+  timestamp: string;
+  cost: number;
+}
+
+export async function writeInsightsLog(
+  entry: InsightsLogEntry,
+  firestore: Firestore = db,
+): Promise<string> {
+  const docRef = await addDoc(
+    collection(firestore, FIRESTORE_COLLECTIONS.INSIGHTS_LOGS),
+    entry,
+  );
+  return docRef.id;
+}


### PR DESCRIPTION
## Summary
- track insights generation usage cost
- store insights logs in Firestore
- update auth API route to save userId
- set Firestore rules for new `insights_logs` collection

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'jest')*
- `npx eslint src/ai/flows/generate-session-insights.ts` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6859ecbdfc40832497378d90a490a769