### PR TITLE
Add Firestore session analytics

### DIFF
--- a/src/app/analytics/Charts.tsx
+++ b/src/app/analytics/Charts.tsx
@@ -18,13 +18,21 @@ interface Props {
   userRoles: { name: string; value: number }[];
   appointments: { day: string; total: number }[];
   notifications: { day: string; success: number }[];
+  sessionsByPsychologist: { name: string; sessions: number }[];
+  weeklySessions: { day: string; total: number }[];
 }
 
 const COLORS = ['#8884d8', '#82ca9d', '#ffc658'];
 
-export default function Charts({ userRoles, appointments, notifications }: Props) {
+export default function Charts({
+  userRoles,
+  appointments,
+  notifications,
+  sessionsByPsychologist,
+  weeklySessions,
+}: Props) {
   return (
-    <div className="grid gap-8 md:grid-cols-3">
+    <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
       <div className="h-64">
         <ResponsiveContainer>
           <PieChart>
@@ -55,6 +63,28 @@ export default function Charts({ userRoles, appointments, notifications }: Props
             <YAxis />
             <Tooltip />
             <Line type="monotone" dataKey="success" stroke="#82ca9d" />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+      <div className="h-64">
+        <ResponsiveContainer>
+          <BarChart data={sessionsByPsychologist} layout="vertical">
+            <CartesianGrid strokeDasharray="3 3" horizontal={false} />
+            <XAxis type="number" />
+            <YAxis type="category" dataKey="name" width={80} />
+            <Tooltip />
+            <Bar dataKey="sessions" fill="#8884d8" />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+      <div className="h-64">
+        <ResponsiveContainer>
+          <LineChart data={weeklySessions}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="day" />
+            <YAxis />
+            <Tooltip />
+            <Line type="monotone" dataKey="total" stroke="#82ca9d" />
           </LineChart>
         </ResponsiveContainer>
       </div>


### PR DESCRIPTION
## Summary
- compute psychologist sessions, weekly totals, and average duration in `analytics/page.tsx`
- show new metrics in `Charts` with additional charts
- display average session duration using `StatsCard`

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest' and 'node')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f0ff18c88324a69955afbbfb829c