### PR TITLE
Add Firestore index for sessions

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -7,6 +7,15 @@
         { "fieldPath": "psychologistId", "order": "ASCENDING" },
         { "fieldPath": "appointmentDate", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "psychologistId", "order": "ASCENDING" },
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "date", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## Summary
- configure index to query sessions by psychologist, user, and date

## Testing
- `./run-tests.sh` *(fails: puppeteer download 403)*

------
https://chatgpt.com/codex/tasks/task_e_6859f2f2d7648324b84de0fb6e25d5a3