### PR TITLE
Implement basic Cloud Logging

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,11 +1,50 @@
-import pino from 'pino';
+import pino from 'pino'
 
-const logger = pino({
-  timestamp: pino.stdTimeFunctions.isoTime,
-});
+const base = pino({ timestamp: pino.stdTimeFunctions.isoTime })
 
-export function logAction(userId: string, action: string, meta: Record<string, unknown> = {}) {
-  logger.info({ userId, action, meta });
+export type LogLevel = 'info' | 'warn' | 'error'
+
+let cloudLog: any
+
+async function sendToCloud(level: LogLevel, payload: Record<string, unknown>) {
+  try {
+    if (!cloudLog) {
+      const { Logging } = await import('@google-cloud/logging')
+      const logging = new Logging()
+      cloudLog = logging.log(process.env.GOOGLE_CLOUD_LOG_NAME || 'web')
+    }
+    const entry = cloudLog.entry({ severity: level.toUpperCase() }, payload)
+    await cloudLog.write(entry)
+  } catch (err) {
+    base.error({ action: 'cloud_logging_error', meta: { error: err } })
+  }
 }
 
-export default logger;
+export function log(level: LogLevel, payload: Record<string, unknown>) {
+  base[level](payload)
+  if (typeof window === 'undefined') {
+    void sendToCloud(level, payload)
+  }
+}
+
+export function logAction(
+  userId: string,
+  action: string,
+  meta: Record<string, unknown> = {}
+) {
+  log('info', { userId, action, meta })
+}
+
+const logger = {
+  info(payload: Record<string, unknown>) {
+    log('info', payload)
+  },
+  warn(payload: Record<string, unknown>) {
+    log('warn', payload)
+  },
+  error(payload: Record<string, unknown>) {
+    log('error', payload)
+  },
+}
+
+export default logger


### PR DESCRIPTION
## Summary
- add Cloud Logging integration using @google-cloud/logging
- expose `log()` and per-level helpers

## Testing
- `npm test` *(fails: Cannot find module 'next/jest')*


------
https://chatgpt.com/codex/tasks/task_e_6859f7d7c2e48324aed3606ec4a5914e