### PR TITLE
Enhance login page and styling

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,7 +34,13 @@ module.exports = [
     },
   },
   {
-    files: ['**/*.config.ts', 'tailwind.config.ts', 'eslint.config.js', 'jest.config.ts'],
+    files: [
+      '**/*.config.ts',
+      'tailwind.config.ts',
+      'eslint.config.js',
+      'jest.config.ts',
+      'jest.config.js',
+    ],
     languageOptions: {
       parser: tsParser,
       globals: globals.node,

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
-const nextJest = require('next/jest')
-const createJestConfig = nextJest({ dir: './' })
+const nextJest = require('next/jest');
+const createJestConfig = nextJest({ dir: './' });
 
 const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/setupTests.ts', '<rootDir>/jest.setup.ts'],
@@ -15,6 +15,9 @@ const customJestConfig = {
       statements: 85,
     },
   },
-}
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};
 
-module.exports = createJestConfig(customJestConfig)
+module.exports = createJestConfig(customJestConfig);

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -16,6 +16,9 @@ const customJestConfig = {
       statements: 85,
     },
   },
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
 };
 
 export default createJestConfig(customJestConfig);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,6 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
+@import url('https://api.fontshare.com/v2/css?f[]=clash-display@600&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -10,19 +13,19 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
+    --background: 0 0% 96%;
     --foreground: 240 10% 3.9%;
     --card: 0 0% 100%;
     --card-foreground: 240 10% 3.9%;
     --popover: 0 0% 100%;
     --popover-foreground: 240 10% 3.9%;
-    --primary: 346.8 77.2% 49.8%;
-    --primary-foreground: 355.7 100% 97.3%;
+    --primary: 256 100% 87%;
+    --primary-foreground: 240 10% 3.9%;
     --secondary: 240 4.8% 95.9%;
     --secondary-foreground: 240 5.9% 10%;
     --muted: 240 4.8% 95.9%;
     --muted-foreground: #4b5563;
-    --accent: 240 4.8% 95.9%; /* Default accent if not specified otherwise */
+    --accent: 170 40% 60%;
     --accent-foreground: 240 5.9% 10%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
@@ -39,13 +42,13 @@
     --card-foreground: 0 0% 95%;
     --popover: 0 0% 9%;
     --popover-foreground: 0 0% 95%;
-    --primary: 346.8 77.2% 49.8%; /* Keeping primary same for dark, adjust if needed */
-    --primary-foreground: 355.7 100% 97.3%;
+    --primary: 256 100% 87%;
+    --primary-foreground: 240 10% 3.9%;
     --secondary: 240 3.7% 15.9%;
     --secondary-foreground: 0 0% 98%;
     --muted: 240 3.7% 15.9%;
     --muted-foreground: #a3a3a3;
-    --accent: 240 3.7% 15.9%; /* Default dark accent */
+    --accent: 170 40% 60%;
     --accent-foreground: 0 0% 98%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
@@ -61,9 +64,16 @@
   }
   body {
     @apply bg-background text-foreground;
-    font-feature-settings: "rlig" 1, "calt" 1;
+    font-feature-settings:
+      'rlig' 1,
+      'calt' 1;
   }
-   h1, h2, h3, h4, h5, h6 {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     @apply font-headline;
   }
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,20 +1,24 @@
-'use client'
+'use client';
 
-import LoginForm from '@/components/forms/auth/login-form'
-import Link from 'next/link'
-import { Brain } from 'lucide-react'
+import LoginForm from '@/components/forms/auth/login-form';
+import Link from 'next/link';
+import { Brain } from 'lucide-react';
 
 export default function LoginPage() {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-background to-secondary p-4">
-      <div className="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[380px] rounded-xl shadow-sm p-4">
+      <div className="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[380px] rounded-xl bg-card border shadow-lg p-4">
         <div className="flex flex-col items-center space-y-2 text-center">
           <Link href="/" className="flex items-center gap-2 mb-4">
             <Brain className="w-10 h-10 text-primary" />
             <h1 className="text-4xl font-headline font-bold text-primary">Thalamus</h1>
           </Link>
-          <h2 className="text-2xl font-headline font-semibold tracking-tight text-foreground">Entrar</h2>
-          <p className="text-sm text-muted-foreground">Utilize suas credenciais para acessar o Thalamus.</p>
+          <h2 className="text-2xl font-headline font-semibold tracking-tight text-foreground">
+            Entrar
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Utilize suas credenciais para acessar o Thalamus.
+          </p>
         </div>
         <LoginForm />
         <p className="px-8 text-center text-sm text-muted-foreground">
@@ -25,5 +29,5 @@ export default function LoginPage() {
         </p>
       </div>
     </div>
-  )
+  );
 }

--- a/src/tests/login-form-render.test.tsx
+++ b/src/tests/login-form-render.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+jest.mock('@/lib/firebase', () => ({ auth: {} }));
+
+import LoginForm from '@/components/forms/auth/login-form';
+
+describe('LoginForm rendering', () => {
+  it('exibe r\u00f3tulos e mensagens de erro', async () => {
+    render(<LoginForm />);
+
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/senha/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/lembrar-me/i)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /entrar/i }));
+
+    expect(
+      await screen.findByText('Por favor, insira um endere\u00e7o de e-mail v\u00e1lido.')
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText('A senha deve ter pelo menos 6 caracteres.')
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- highlight login form card
- import brand fonts
- update global brand colors
- map path aliases in Jest config
- add LoginForm rendering test

## Testing
- `npx jest --config jest.config.js --runTestsByPath src/tests/login-form-render.test.tsx --coverage=false`

------
https://chatgpt.com/codex/tasks/task_e_6859f82887ec8324972137350a6a44f7