### PR TITLE
Add user feedback component and service

### DIFF
--- a/__tests__/firestore-rules.test.ts
+++ b/__tests__/firestore-rules.test.ts
@@ -173,4 +173,25 @@ describe('Firestore security rules', () => {
       await assertFails(chatRef.set({ participants: { [user1.sub]: true, missing: true } }));
     });
   });
+
+  describe('Feedback Rules', () => {
+    test('authenticated user can create feedback', async () => {
+      const auth = { sub: 'userFb', role: 'Psychologist' };
+      const db = getAuthedDb(auth);
+      await assertSucceeds(
+        db.collection('feedback').doc('fb1').set({
+          uid: auth.sub,
+          text: 'ok',
+          createdAt: '2024-01-01T00:00:00Z',
+        })
+      );
+    });
+
+    test('unauthenticated user cannot create feedback', async () => {
+      const db = testEnv.unauthenticatedContext().firestore();
+      await assertFails(
+        db.collection('feedback').doc('fb2').set({ uid: 'x', text: 'no' })
+      );
+    });
+  });
 });

--- a/__tests__/user-feedback.test.tsx
+++ b/__tests__/user-feedback.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserFeedback from '@/components/UserFeedback';
+
+const mockSubmit = jest.fn();
+jest.mock('@/services/feedbackService', () => ({
+  submitFeedback: (...args: any[]) => mockSubmit(...args),
+}));
+
+const mockToast = jest.fn();
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+jest.mock('@sentry/nextjs', () => ({
+  captureException: jest.fn(),
+}));
+
+describe('UserFeedback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('envia feedback digitado', async () => {
+    mockSubmit.mockResolvedValue('1');
+    render(<UserFeedback />);
+    await userEvent.type(
+      screen.getByLabelText(/sua sessão/i),
+      'muito boa'
+    );
+    await userEvent.click(screen.getByRole('button', { name: /enviar/i }));
+
+    await waitFor(() =>
+      expect(mockSubmit).toHaveBeenCalledWith('muito boa')
+    );
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Feedback enviado' })
+    );
+  });
+});
+

--- a/firestore.rules
+++ b/firestore.rules
@@ -229,6 +229,16 @@ match /insights_logs/{id} {
   allow update, delete: if false;
 }
 
+match /feedback/{id} {
+  allow create: if isSignedIn() &&
+                   request.resource.data.keys().hasOnly(['uid','text','createdAt']) &&
+                   request.resource.data.uid == request.auth.uid &&
+                   request.resource.data.text is string &&
+                   request.resource.data.createdAt is timestamp;
+  allow read: if isAdmin();
+  allow update, delete: if false;
+}
+
 match /{document=**} {
   allow read, write: if false;
 }

--- a/src/components/UserFeedback.tsx
+++ b/src/components/UserFeedback.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from '@/components/ui/form';
+import { submitFeedback } from '@/services/feedbackService';
+import { useToast } from '@/hooks/use-toast';
+import logger from '@/lib/logger';
+import * as Sentry from '@sentry/nextjs';
+
+const feedbackSchema = z.object({
+  text: z.string().min(3, { message: 'Digite pelo menos 3 caracteres.' }),
+});
+
+type FeedbackValues = z.infer<typeof feedbackSchema>;
+
+export default function UserFeedback() {
+  const { toast } = useToast();
+  const [loading, setLoading] = React.useState(false);
+
+  const form = useForm<FeedbackValues>({
+    resolver: zodResolver(feedbackSchema),
+    defaultValues: { text: '' },
+  });
+
+  async function onSubmit(data: FeedbackValues) {
+    setLoading(true);
+    try {
+      await submitFeedback(data.text);
+      toast({ title: 'Feedback enviado' });
+      form.reset();
+    } catch (err) {
+      Sentry.captureException(err);
+      logger.error({ action: 'submit_feedback_error', meta: { error: err } });
+      toast({ title: 'Erro ao enviar feedback', variant: 'destructive' });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="space-y-4"
+        role="form"
+      >
+        <FormField
+          control={form.control}
+          name="text"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Conte-nos sobre sua sessão</FormLabel>
+              <FormControl>
+                <Textarea
+                  {...field}
+                  placeholder="Deixe seu comentário..."
+                  rows={4}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button
+          type="submit"
+          className="bg-accent hover:bg-accent/90 text-accent-foreground"
+          disabled={loading}
+        >
+          Enviar
+        </Button>
+      </form>
+    </Form>
+  );
+}
+

--- a/src/lib/firestore-collections.ts
+++ b/src/lib/firestore-collections.ts
@@ -18,6 +18,7 @@ export const FIRESTORE_COLLECTIONS = {
   AUDIT_LOGS: 'auditLogs',
   INSIGHTS_LOGS: 'insights_logs',
   CLINICAL_DATA: 'clinicalTabs',
+  FEEDBACK: 'feedback',
 } as const;
 
 export type FirestoreCollectionKeys = keyof typeof FIRESTORE_COLLECTIONS;

--- a/src/services/feedbackService.ts
+++ b/src/services/feedbackService.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { addDoc, collection, serverTimestamp, type Firestore } from 'firebase/firestore';
+import { db, auth } from '@/lib/firebase';
+import { FIRESTORE_COLLECTIONS } from '@/lib/firestore-collections';
+
+export interface FeedbackEntry {
+  uid: string;
+  text: string;
+  createdAt: unknown;
+}
+
+export async function submitFeedback(
+  text: string,
+  firestore: Firestore = db,
+): Promise<string> {
+  const uid = auth.currentUser?.uid;
+  if (!uid) throw new Error('Usuário não autenticado');
+  const docRef = await addDoc(collection(firestore, FIRESTORE_COLLECTIONS.FEEDBACK), {
+    uid,
+    text,
+    createdAt: serverTimestamp(),
+  });
+  return docRef.id;
+}
+


### PR DESCRIPTION
## Summary
- allow storing feedback in Firestore
- expose submitFeedback service
- add `<UserFeedback />` component
- test rules and component
- update Firestore rules

## Testing
- `./run-tests.sh` *(fails: puppeteer download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6859f99b60c48324b42fe07df4178570