### PR TITLE
Enable Firestore persistence and add storage service

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -2,7 +2,7 @@
 import { initializeApp, getApps, getApp, type FirebaseApp } from 'firebase/app';
 import * as Sentry from '@sentry/nextjs';
 import { getAuth, connectAuthEmulator, type Auth } from 'firebase/auth';
-import { getFirestore, connectFirestoreEmulator, type Firestore } from 'firebase/firestore';
+import { getFirestore, connectFirestoreEmulator, enableIndexedDbPersistence, type Firestore } from 'firebase/firestore';
 import { getStorage, connectStorageEmulator, type FirebaseStorage } from 'firebase/storage';
 import { getMessaging, type Messaging } from 'firebase/messaging';
 import logger from '@/lib/logger';
@@ -40,6 +40,11 @@ const app: FirebaseApp = !getApps().length ? initializeApp(firebaseConfig) : get
 
 const auth: Auth = getAuth(app);
 const db: Firestore = getFirestore(app);
+if (typeof window !== 'undefined') {
+  enableIndexedDbPersistence(db).catch((err) => {
+    logger.warn({ action: 'firestore_persistence_error', meta: { error: err } });
+  });
+}
 const storage: FirebaseStorage = getStorage(app);
 let messaging: Messaging | null = null;
 if (typeof window !== 'undefined') {

--- a/src/services/storageService.ts
+++ b/src/services/storageService.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { ref, uploadBytes, getDownloadURL, type FirebaseStorage } from 'firebase/storage';
+import { storage } from '@/lib/firebase';
+import logger from '@/lib/logger';
+import * as Sentry from '@sentry/nextjs';
+
+export async function uploadFile(
+  path: string,
+  file: File,
+  cacheMaxAge = 86400,
+  storageInstance: FirebaseStorage = storage,
+): Promise<string> {
+  try {
+    const fileRef = ref(storageInstance, path);
+    await uploadBytes(fileRef, file, {
+      cacheControl: `public,max-age=${cacheMaxAge}`,
+    });
+    return await getDownloadURL(fileRef);
+  } catch (err) {
+    Sentry.captureException(err);
+    logger.error({ action: 'storage_upload_error', meta: { path, error: err } });
+    throw err;
+  }
+}
+
+export async function getFileUrl(
+  path: string,
+  storageInstance: FirebaseStorage = storage,
+): Promise<string> {
+  const fileRef = ref(storageInstance, path);
+  return getDownloadURL(fileRef);
+}


### PR DESCRIPTION
## Summary
- enable IndexedDB persistence for Firestore
- create storageService with upload helper that sets Cache-Control metadata

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f9e23bdc83248e736d145ff5999a