### PR TITLE
Enable bundle analyzer and lazy load charts

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,9 @@
+import bundleAnalyzer from '@next/bundle-analyzer';
+
+const withBundleAnalyzer = bundleAnalyzer({
+  enabled: process.env.ANALYZE === 'true',
+});
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // typescript: {
@@ -25,4 +31,4 @@ const nextConfig = {
   ],
 };
 
-export default nextConfig;
+export default withBundleAnalyzer(nextConfig);

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
       "devDependencies": {
         "@eslint/js": "^9.2.0",
         "@firebase/rules-unit-testing": "^4.0.1",
+        "@next/bundle-analyzer": "^15.3.4",
         "@next/eslint-plugin-next": "^15.3.4",
         "@tailwindcss/postcss": "^4.1.10",
         "@testing-library/jest-dom": "^5.17.0",
@@ -891,6 +892,16 @@
       "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.2.0.tgz",
       "integrity": "sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==",
       "license": "MIT"
+    },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/@electric-sql/pglite": {
       "version": "0.3.3",
@@ -3553,6 +3564,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/@next/bundle-analyzer": {
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-15.3.4.tgz",
+      "integrity": "sha512-AN9H9S+4WaIIahyJBGe6arLj5kopvVZPLffAJsDhkbQPGqirYqaHhwO6vheytXtdq3xNjwJLpbmYNa5ZQnitSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webpack-bundle-analyzer": "4.10.1"
+      }
+    },
     "node_modules/@next/env": {
       "version": "14.2.30",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.30.tgz",
@@ -3567,6 +3588,66 @@
       "license": "MIT",
       "dependencies": {
         "fast-glob": "3.3.1"
+      }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.30",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.30.tgz",
+      "integrity": "sha512-EAqfOTb3bTGh9+ewpO/jC59uACadRHM6TSA9DdxJB/6gxOpyV+zrbqeXiFTDy9uV6bmipFDkfpAskeaDcO+7/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.30",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.30.tgz",
+      "integrity": "sha512-TyO7Wz1IKE2kGv8dwQ0bmPL3s44EKVencOqwIY69myoS3rdpO1NPg5xPM5ymKu7nfX4oYJrpMxv8G9iqLsnL4A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.30",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.30.tgz",
+      "integrity": "sha512-I5lg1fgPJ7I5dk6mr3qCH1hJYKJu1FsfKSiTKoYwcuUf53HWTrEkwmMI0t5ojFKeA6Vu+SfT2zVy5NS0QLXV4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.30",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.30.tgz",
+      "integrity": "sha512-8GkNA+sLclQyxgzCDs2/2GSwBc92QLMrmYAmoP2xehe5MUKBLB2cgo34Yu242L1siSkwQkiV4YLdCnjwc/Micw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
@@ -3596,6 +3677,51 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.30",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.30.tgz",
+      "integrity": "sha512-6MMHi2Qc1Gkq+4YLXAgbYslE1f9zMGBikKMdmQRHXjkGPot1JY3n5/Qrbg40Uvbi8//wYnydPnyvNhI1DMUW1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.30",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.30.tgz",
+      "integrity": "sha512-pVZMnFok5qEX4RT59mK2hEVtJX+XFfak+/rjHpyFh7juiT52r177bfFKhnlafm0UOSldhXjj32b+LZIOdswGTg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.30",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.30.tgz",
+      "integrity": "sha512-4KCo8hMZXMjpTzs3HOqOGYYwAXymXIy7PEPAXNEcEOyKqkjiDlECumrWziy+JEF0Oi4ILHGxzgQ3YiMGG2t/Lg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -5377,6 +5503,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@prisma/instrumentation": {
       "version": "6.8.2",
@@ -13071,6 +13204,13 @@
         "date-fns": "^3.0.0 || ^4.0.0"
       }
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -13431,6 +13571,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/duplexify": {
       "version": "4.1.3",
@@ -16382,6 +16529,22 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/handlebars": {
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
@@ -17401,6 +17564,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -20660,6 +20833,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -21399,6 +21582,16 @@
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.2.1"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/optionator": {
@@ -24228,6 +24421,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/skin-tone": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
@@ -26036,6 +26244,16 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
@@ -27018,6 +27236,44 @@
         }
       }
     },
+    "node_modules/webpack-bundle-analyzer": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz",
+      "integrity": "sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "0.5.7",
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "commander": "^7.2.0",
+        "debounce": "^1.2.1",
+        "escape-string-regexp": "^4.0.0",
+        "gzip-size": "^6.0.0",
+        "html-escaper": "^2.0.2",
+        "is-plain-object": "^5.0.0",
+        "opener": "^1.5.2",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3",
+        "ws": "^7.3.1"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/webpack-sources": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
@@ -27745,111 +28001,6 @@
         "use-sync-external-store": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.30",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.30.tgz",
-      "integrity": "sha512-EAqfOTb3bTGh9+ewpO/jC59uACadRHM6TSA9DdxJB/6gxOpyV+zrbqeXiFTDy9uV6bmipFDkfpAskeaDcO+7/g==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.30",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.30.tgz",
-      "integrity": "sha512-TyO7Wz1IKE2kGv8dwQ0bmPL3s44EKVencOqwIY69myoS3rdpO1NPg5xPM5ymKu7nfX4oYJrpMxv8G9iqLsnL4A==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.30",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.30.tgz",
-      "integrity": "sha512-I5lg1fgPJ7I5dk6mr3qCH1hJYKJu1FsfKSiTKoYwcuUf53HWTrEkwmMI0t5ojFKeA6Vu+SfT2zVy5NS0QLXV4Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.30",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.30.tgz",
-      "integrity": "sha512-8GkNA+sLclQyxgzCDs2/2GSwBc92QLMrmYAmoP2xehe5MUKBLB2cgo34Yu242L1siSkwQkiV4YLdCnjwc/Micw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.30",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.30.tgz",
-      "integrity": "sha512-6MMHi2Qc1Gkq+4YLXAgbYslE1f9zMGBikKMdmQRHXjkGPot1JY3n5/Qrbg40Uvbi8//wYnydPnyvNhI1DMUW1g==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.30",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.30.tgz",
-      "integrity": "sha512-pVZMnFok5qEX4RT59mK2hEVtJX+XFfak+/rjHpyFh7juiT52r177bfFKhnlafm0UOSldhXjj32b+LZIOdswGTg==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.30",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.30.tgz",
-      "integrity": "sha512-4KCo8hMZXMjpTzs3HOqOGYYwAXymXIy7PEPAXNEcEOyKqkjiDlECumrWziy+JEF0Oi4ILHGxzgQ3YiMGG2t/Lg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
   "devDependencies": {
     "@eslint/js": "^9.2.0",
     "@firebase/rules-unit-testing": "^4.0.1",
+    "@next/bundle-analyzer": "^15.3.4",
     "@next/eslint-plugin-next": "^15.3.4",
     "@tailwindcss/postcss": "^4.1.10",
     "@testing-library/jest-dom": "^5.17.0",

--- a/src/components/dashboard/occupancy-chart.tsx
+++ b/src/components/dashboard/occupancy-chart.tsx
@@ -1,29 +1,57 @@
+'use client';
 
-"use client"
-
-import { Bar, BarChart, ResponsiveContainer, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from "recharts"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart"
+import React from 'react';
+import dynamic from 'next/dynamic';
+const BarChart = dynamic(
+  () => import('recharts').then((m) => m.BarChart as React.ComponentType<any>),
+  { ssr: false }
+);
+const Bar = dynamic(() => import('recharts').then((m) => m.Bar as React.ComponentType<any>), {
+  ssr: false,
+});
+const XAxis = dynamic(() => import('recharts').then((m) => m.XAxis as React.ComponentType<any>), {
+  ssr: false,
+});
+const YAxis = dynamic(() => import('recharts').then((m) => m.YAxis as React.ComponentType<any>), {
+  ssr: false,
+});
+const CartesianGrid = dynamic(
+  () => import('recharts').then((m) => m.CartesianGrid as React.ComponentType<any>),
+  { ssr: false }
+);
+const Legend = dynamic(() => import('recharts').then((m) => m.Legend as React.ComponentType<any>), {
+  ssr: false,
+});
+const ResponsiveContainer = dynamic(
+  () => import('recharts').then((m) => m.ResponsiveContainer as React.ComponentType<any>),
+  { ssr: false }
+);
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '@/components/ui/chart';
 
 const chartData = [
-  { month: "January", desktop: 186, mobile: 80 },
-  { month: "February", desktop: 305, mobile: 200 },
-  { month: "March", desktop: 237, mobile: 120 },
-  { month: "April", desktop: 73, mobile: 190 },
-  { month: "May", desktop: 209, mobile: 130 },
-  { month: "June", desktop: 214, mobile: 140 },
-]
+  { month: 'January', desktop: 186, mobile: 80 },
+  { month: 'February', desktop: 305, mobile: 200 },
+  { month: 'March', desktop: 237, mobile: 120 },
+  { month: 'April', desktop: 73, mobile: 190 },
+  { month: 'May', desktop: 209, mobile: 130 },
+  { month: 'June', desktop: 214, mobile: 140 },
+];
 
 const chartConfig = {
   desktop: {
-    label: "Booked Slots",
-    color: "hsl(var(--chart-1))",
+    label: 'Booked Slots',
+    color: 'hsl(var(--chart-1))',
   },
   mobile: {
-    label: "Available Slots",
-    color: "hsl(var(--chart-2))",
+    label: 'Available Slots',
+    color: 'hsl(var(--chart-2))',
   },
-} satisfies ChartConfig
+} satisfies ChartConfig;
 
 export function OccupancyChart({ data = chartData }: { data?: typeof chartData }) {
   if (!data || data.length === 0) {
@@ -39,7 +67,7 @@ export function OccupancyChart({ data = chartData }: { data?: typeof chartData }
     >
       <ResponsiveContainer width="100%" height="100%">
         <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" vertical={false} />
+          <CartesianGrid strokeDasharray="3 3" vertical={false} />
           <XAxis
             dataKey="month"
             tickLine={false}
@@ -47,20 +75,17 @@ export function OccupancyChart({ data = chartData }: { data?: typeof chartData }
             axisLine={false}
             // stroke="hsl(var(--muted-foreground))"
           />
-          <YAxis 
+          <YAxis
             tickLine={false}
             axisLine={false}
             // stroke="hsl(var(--muted-foreground))"
           />
-          <ChartTooltip
-            cursor={false}
-            content={<ChartTooltipContent indicator="dashed" />}
-          />
+          <ChartTooltip cursor={false} content={<ChartTooltipContent indicator="dashed" />} />
           <Legend />
           <Bar dataKey="desktop" fill="var(--color-desktop)" radius={4} />
           <Bar dataKey="mobile" fill="var(--color-mobile)" radius={4} />
         </BarChart>
       </ResponsiveContainer>
     </ChartContainer>
-  )
+  );
 }

--- a/src/components/dashboard/problem-distribution-chart.tsx
+++ b/src/components/dashboard/problem-distribution-chart.tsx
@@ -1,8 +1,24 @@
+'use client';
 
-"use client"
-
-import React from "react"; // Added React import
-import { Pie, PieChart, ResponsiveContainer, Cell, Label } from "recharts"
+import React from 'react';
+import dynamic from 'next/dynamic';
+const PieChart = dynamic(
+  () => import('recharts').then((m) => m.PieChart as React.ComponentType<any>),
+  { ssr: false }
+);
+const Pie = dynamic(() => import('recharts').then((m) => m.Pie as React.ComponentType<any>), {
+  ssr: false,
+});
+const Cell = dynamic(() => import('recharts').then((m) => m.Cell as React.ComponentType<any>), {
+  ssr: false,
+});
+const Label = dynamic(() => import('recharts').then((m) => m.Label as React.ComponentType<any>), {
+  ssr: false,
+});
+const ResponsiveContainer = dynamic(
+  () => import('recharts').then((m) => m.ResponsiveContainer as React.ComponentType<any>),
+  { ssr: false }
+);
 import {
   ChartConfig,
   ChartContainer,
@@ -10,41 +26,41 @@ import {
   ChartTooltipContent,
   ChartLegend,
   ChartLegendContent,
-} from "@/components/ui/chart"
+} from '@/components/ui/chart';
 
 const chartData = [
-  { problem: "Ansiedade", count: 275, fill: "var(--color-anxiety)" },
-  { problem: "Depressão", count: 200, fill: "var(--color-depression)" },
-  { problem: "Relacionamentos", count: 187, fill: "var(--color-relationships)" },
-  { problem: "Estresse", count: 173, fill: "var(--color-stress)" },
-  { problem: "Outros", count: 90, fill: "var(--color-others)" },
-]
+  { problem: 'Ansiedade', count: 275, fill: 'var(--color-anxiety)' },
+  { problem: 'Depressão', count: 200, fill: 'var(--color-depression)' },
+  { problem: 'Relacionamentos', count: 187, fill: 'var(--color-relationships)' },
+  { problem: 'Estresse', count: 173, fill: 'var(--color-stress)' },
+  { problem: 'Outros', count: 90, fill: 'var(--color-others)' },
+];
 
 const chartConfig = {
   count: {
-    label: "Casos",
+    label: 'Casos',
   },
   anxiety: {
-    label: "Ansiedade",
-    color: "hsl(var(--chart-1))",
+    label: 'Ansiedade',
+    color: 'hsl(var(--chart-1))',
   },
   depression: {
-    label: "Depressão",
-    color: "hsl(var(--chart-2))",
+    label: 'Depressão',
+    color: 'hsl(var(--chart-2))',
   },
   relationships: {
-    label: "Relacionamentos",
-    color: "hsl(var(--chart-3))",
+    label: 'Relacionamentos',
+    color: 'hsl(var(--chart-3))',
   },
   stress: {
-    label: "Estresse",
-    color: "hsl(var(--chart-4))",
+    label: 'Estresse',
+    color: 'hsl(var(--chart-4))',
   },
   others: {
-    label: "Outros",
-    color: "hsl(var(--chart-5))",
+    label: 'Outros',
+    color: 'hsl(var(--chart-5))',
   },
-} satisfies ChartConfig
+} satisfies ChartConfig;
 
 export function ProblemDistributionChart({ data = chartData }: { data?: typeof chartData }) {
   if (!data || data.length === 0) {
@@ -52,33 +68,21 @@ export function ProblemDistributionChart({ data = chartData }: { data?: typeof c
   }
 
   const totalCases = React.useMemo(() => {
-    return data.reduce((acc, curr) => acc + curr.count, 0)
-  }, [data])
+    return data.reduce((acc, curr) => acc + curr.count, 0);
+  }, [data]);
 
   return (
-    <ChartContainer
-      config={chartConfig}
-      className="mx-auto aspect-square max-h-[300px]"
-    >
+    <ChartContainer config={chartConfig} className="mx-auto aspect-square max-h-[300px]">
       <ResponsiveContainer width="100%" height="100%">
         <PieChart role="img" aria-label="Distribuição de problemas por tipo">
-          <ChartTooltip
-            cursor={false}
-            content={<ChartTooltipContent hideLabel />}
-          />
-          <Pie
-            data={data}
-            dataKey="count"
-            nameKey="problem"
-            innerRadius={60}
-            strokeWidth={5}
-          >
+          <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
+          <Pie data={data} dataKey="count" nameKey="problem" innerRadius={60} strokeWidth={5}>
             {data.map((entry) => (
               <Cell key={entry.problem} fill={entry.fill} />
             ))}
-             <Label
+            <Label
               content={({ viewBox }) => {
-                if (viewBox && "cx" in viewBox && "cy" in viewBox) {
+                if (viewBox && 'cx' in viewBox && 'cy' in viewBox) {
                   return (
                     <text
                       x={viewBox.cx}
@@ -101,15 +105,21 @@ export function ProblemDistributionChart({ data = chartData }: { data?: typeof c
                         Total Casos
                       </tspan>
                     </text>
-                  )
+                  );
                 }
               }}
             />
           </Pie>
-           <ChartLegend content={<ChartLegendContent nameKey="problem" className="text-xs flex-wrap justify-center gap-x-2 gap-y-1" />} />
+          <ChartLegend
+            content={
+              <ChartLegendContent
+                nameKey="problem"
+                className="text-xs flex-wrap justify-center gap-x-2 gap-y-1"
+              />
+            }
+          />
         </PieChart>
       </ResponsiveContainer>
     </ChartContainer>
-  )
+  );
 }
-

--- a/src/components/dashboard/sessions-trend-chart.tsx
+++ b/src/components/dashboard/sessions-trend-chart.tsx
@@ -1,22 +1,51 @@
+'use client';
 
-"use client"
-
-import { Line, LineChart, ResponsiveContainer, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from "recharts"
-import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart"
+import React from 'react';
+import dynamic from 'next/dynamic';
+const LineChart = dynamic(
+  () => import('recharts').then((m) => m.LineChart as React.ComponentType<any>),
+  { ssr: false }
+);
+const Line = dynamic(() => import('recharts').then((m) => m.Line as React.ComponentType<any>), {
+  ssr: false,
+});
+const XAxis = dynamic(() => import('recharts').then((m) => m.XAxis as React.ComponentType<any>), {
+  ssr: false,
+});
+const YAxis = dynamic(() => import('recharts').then((m) => m.YAxis as React.ComponentType<any>), {
+  ssr: false,
+});
+const CartesianGrid = dynamic(
+  () => import('recharts').then((m) => m.CartesianGrid as React.ComponentType<any>),
+  { ssr: false }
+);
+const Legend = dynamic(() => import('recharts').then((m) => m.Legend as React.ComponentType<any>), {
+  ssr: false,
+});
+const ResponsiveContainer = dynamic(
+  () => import('recharts').then((m) => m.ResponsiveContainer as React.ComponentType<any>),
+  { ssr: false }
+);
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '@/components/ui/chart';
 
 const chartData = [
-  { month: "Jan", sessions: 186 },
-  { month: "Fev", sessions: 305 },
-  { month: "Mar", sessions: 237 },
-  { month: "Abr", sessions: 273 },
-  { month: "Mai", sessions: 209 },
-  { month: "Jun", sessions: 314 },
+  { month: 'Jan', sessions: 186 },
+  { month: 'Fev', sessions: 305 },
+  { month: 'Mar', sessions: 237 },
+  { month: 'Abr', sessions: 273 },
+  { month: 'Mai', sessions: 209 },
+  { month: 'Jun', sessions: 314 },
 ];
 
 const chartConfig = {
   sessions: {
-    label: "Sessões",
-    color: "hsl(var(--chart-1))",
+    label: 'Sessões',
+    color: 'hsl(var(--chart-1))',
   },
 } satisfies ChartConfig;
 
@@ -56,10 +85,7 @@ export function SessionsTrendChart({ data = chartData }: { data?: typeof chartDa
             tickMargin={8}
             // stroke="hsl(var(--muted-foreground))"
           />
-          <ChartTooltip
-            cursor={true}
-            content={<ChartTooltipContent indicator="line" />}
-          />
+          <ChartTooltip cursor={true} content={<ChartTooltipContent indicator="line" />} />
           <Legend />
           <Line
             dataKey="sessions"
@@ -67,15 +93,15 @@ export function SessionsTrendChart({ data = chartData }: { data?: typeof chartDa
             stroke="var(--color-sessions)"
             strokeWidth={2}
             dot={{
-              fill: "var(--color-sessions)",
+              fill: 'var(--color-sessions)',
               r: 4,
             }}
             activeDot={{
-              r:6,
+              r: 6,
             }}
           />
         </LineChart>
       </ResponsiveContainer>
     </ChartContainer>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- add `@next/bundle-analyzer` plugin and wrap config
- dynamically import Recharts components
- format files with Prettier

## Testing
- `npm test` *(fails: connect ECONNREFUSED to emulator and missing Playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6859f9cbb8dc8324ba5fffe6af09ad10