### PR TITLE
Improve test script for offline env

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -2,6 +2,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(dirname "$0")"
+
+export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
+export PUPPETEER_SKIP_DOWNLOAD=1
+
 echo "📦 Instalando dependências via npm..."
 npm ci
 


### PR DESCRIPTION
## Summary
- set env vars in run-tests.sh to avoid browser downloads

## Testing
- `npm run test:all` *(fails: connect ECONNREFUSED 127.0.0.1:8084)*

------
https://chatgpt.com/codex/tasks/task_e_6859f85d70dc8324bb54a9daa264b26a