### PR TITLE
Fix test script to handle emulators

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Plataforma web para gestão de clínicas de psicologia, com agenda integrada, pr
     - Você pode definir manualmente a senha chamando `setEncryptionPassword()` no início da aplicação ou configurando a variável de ambiente `ENCRYPTION_KEY`.
     - Sem essa senha, os dados sensíveis gravados no Firestore não poderão ser descriptografados.
 5.  **Inicie os Emuladores Firebase (em um terminal separado):**
+
     - É altamente recomendado usar os emuladores do Firebase para desenvolvimento local.
     - Se esta é a primeira vez, configure os emuladores: `firebase init emulators` (selecione Firestore, Storage, Functions).
     - Inicie os emuladores: `firebase emulators:start --project=demo-project`
@@ -62,8 +63,8 @@ Plataforma web para gestão de clínicas de psicologia, com agenda integrada, pr
 - `npm run genkit:dev` &mdash; executa os fluxos de IA em modo de desenvolvimento.
 - `npm run typecheck` &mdash; verifica os tipos TypeScript.
 - `npm run lint` &mdash; executa o ESLint.
-- `npm run test:all` &mdash; executa todos os testes com o Firebase Emulator em execução.
-- `./run-tests.sh` &mdash; script direto para rodar os testes (usado por `npm run test:all`).
+- `npm run test:all` &mdash; executa todos os testes iniciando automaticamente o Firebase Emulator.
+- `./run-tests.sh` &mdash; script opcional para rodar os testes manualmente.
 - `git p` &mdash; alias opcional para o comando acima.
 - `npm run build` &mdash; gera o build de produção.
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "typecheck": "tsc --noEmit",
     "test": "jest --config jest.config.js",
     "test:watch": "jest --watch --config jest.config.js",
-    "test:all": "jest --coverage --config jest.config.js",
+    "test:all": "./scripts/test.sh",
     "coverage": "jest --coverage",
     "test:rules": "jest tests/firestore.rules.test.ts",
     "test:a11y": "pa11y http://localhost:3000 --chrome --threshold 0 && pa11y http://localhost:3000/analytics --chrome --threshold 0",

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -2,8 +2,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(dirname "$0")"
-echo "📦 Instalando dependências via npm..."
-npm ci
+echo "📦 Verificando dependências..."
+if ! npx --no-install jest --version >/dev/null 2>&1; then
+  echo "📦 Instalando dependências via npm..."
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 PUPPETEER_SKIP_DOWNLOAD=1 npm ci
+fi
 
 echo "🔍 Verificando instalação do Jest..."
 if ! npx --no-install jest --version >/dev/null 2>&1; then
@@ -12,4 +15,5 @@ if ! npx --no-install jest --version >/dev/null 2>&1; then
 fi
 
 echo "🔥 Iniciando Firebase Emulator e executando testes..."
-npx firebase emulators:exec --project="${FIREBASE_PROJECT:-thalamus-dev}" --only firestore "npm run test:all -- --runInBand"
+PUPPETEER_SKIP_DOWNLOAD=1 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
+npx firebase emulators:exec --project="${FIREBASE_PROJECT:-thalamus-dev}" --only firestore,auth "npm run test:all -- --runInBand"


### PR DESCRIPTION
## Summary
- install deps only when needed in `run-tests.sh`
- start firestore and auth emulators by default
- avoid browser downloads during setup
- wire `npm run test:all` to call the script
- update README about running tests

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run typecheck`
- `npm run test:all` *(fails: download failed, status 403: Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6859fecd86248324bf24cd62cf09de00