### PR TITLE
Improve CI with caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,20 +17,24 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.11.0
+          cache: 'npm'
 
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
 
-      - name: Cache node_modules
-        uses: actions/cache@v3
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
       - name: Install dependencies
         run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
 
       - name: Audit dependencies
         run: npm audit --audit-level=high


### PR DESCRIPTION
## Summary
- use `actions/setup-node` npm caching
- cache Playwright browser binaries to speed up E2E tests

## Testing
- `npm ci` *(fails: ERROR: Failed to set up chrome v137.0.7151.119)*

------
https://chatgpt.com/codex/tasks/task_e_685a007565188324b8940fd57f4740b9