### PR TITLE
Integrate secret manager for admin credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Para obter `FIREBASE_CLIENT_EMAIL` e `FIREBASE_PRIVATE_KEY`:
 _No Console do Firebase -> Seu Projeto -> Configurações do Projeto -> Contas de serviço -> Gerar nova chave privada (isso fará o download de um arquivo JSON). O `client_email` e `private_key` estão neste arquivo._
 _Ao adicionar `FIREBASE_PRIVATE_KEY` ao seu arquivo `.env.local` ou variável de ambiente, certifique-se de formatar corretamente as quebras de linha (geralmente substituindo `\n` literais por novas linhas reais, ou envolvendo a chave em aspas duplas se o seu sistema `.env` suportar)._
 
+Para ambientes de produção, é recomendável armazenar `FIREBASE_CLIENT_EMAIL` e `FIREBASE_PRIVATE_KEY` no **Google Secret Manager**. O aplicativo irá buscar esses valores automaticamente na inicialização, facilitando a rotação de chaves e centralizando o controle de acesso.
+
 ### Variáveis de Configuração do Emulador (Desenvolvimento)
 
 - `NEXT_PUBLIC_FIREBASE_EMULATOR_HOST`: Define o host que o SDK do Firebase do lado do cliente usará para se conectar aos emuladores.

--- a/__tests__/secretManager.test.ts
+++ b/__tests__/secretManager.test.ts
@@ -1,0 +1,31 @@
+import { loadSecrets } from '../src/lib/secretManager';
+
+jest.mock('@google-cloud/secret-manager', () => {
+  return {
+    SecretManagerServiceClient: jest.fn(() => ({
+      accessSecretVersion: jest.fn(async ({ name }) => [
+        {
+          payload: { data: Buffer.from(name.includes('CLIENT_EMAIL') ? 'admin@test.com' : 'priv') },
+        },
+      ]),
+    })),
+  };
+});
+
+describe('loadSecrets', () => {
+  const origEnv = process.env;
+  beforeEach(() => {
+    process.env = { ...origEnv, FIREBASE_PROJECT_ID: 'demo' };
+    delete process.env.FIREBASE_CLIENT_EMAIL;
+    delete process.env.FIREBASE_PRIVATE_KEY;
+  });
+  afterAll(() => {
+    process.env = origEnv;
+  });
+
+  it('carrega variáveis do Secret Manager', async () => {
+    await loadSecrets(['FIREBASE_CLIENT_EMAIL', 'FIREBASE_PRIVATE_KEY']);
+    expect(process.env.FIREBASE_CLIENT_EMAIL).toBe('admin@test.com');
+    expect(process.env.FIREBASE_PRIVATE_KEY).toBe('priv');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@genkit-ai/core": "^1.13.0",
         "@genkit-ai/googleai": "^1.13.0",
+        "@google-cloud/secret-manager": "6.0.1",
         "@hookform/resolvers": "^5.1.1",
         "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-alert-dialog": "^1.1.14",
@@ -2047,6 +2048,199 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-6.0.1.tgz",
+      "integrity": "sha512-xvFzeqXZh7u6Pv1awJH/iOYudpvLXc45cCrjgsodWPm1SmYkXvLYtKfJLkEpkJGRMdteyfzGay4CueSZCVy8Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-gax": "^5.0.1-rc.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/@types/long": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-5.0.0.tgz",
+      "integrity": "sha512-eQs9RsucA/LNjnMoJvWG/nXa7Pot/RbBzilF/QRIU/xRl+0ApxrSUFsV5lmf01SvSlqMzJ7Zwxe440wmz2SJGA==",
+      "deprecated": "This is a stub types definition. long provides its own type definitions, so you do not need this installed.",
+      "license": "MIT",
+      "dependencies": {
+        "long": "*"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/gaxios": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.0.tgz",
+      "integrity": "sha512-y1Q0MX1Ba6eg67Zz92kW0MHHhdtWksYckQy1KJsI6P4UlDQ8cvdvpLEPslD/k7vFkdPppMESFGTvk7XpSiKj8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/gcp-metadata": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.0.tgz",
+      "integrity": "sha512-3PfRTzvT3Msu0Hy8Gf9ypxJvaClG2IB9pyH0r8QOmRBW5mUcrHgYpF4GYP+XulDbfhxEhBYtJtJJQb5S2wM+LA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/google-auth-library": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.1.0.tgz",
+      "integrity": "sha512-GspVjZj1RbyRWpQ9FbAXMKjFGzZwDKnUHi66JJ+tcjcu5/xYAP1pdlWotCuIkMwjfVsxxDvsGZXGLzRt72D0sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/google-gax": {
+      "version": "5.0.1-rc.1",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.1-rc.1.tgz",
+      "integrity": "sha512-kz3HlvYvmQVBcam2C7FOphE6xrhjrlbKrRpNxvWYAmVHi+SCeMReWcKp64WJXNL7clSYAgYer3gCKVTTF/+wPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.12.6",
+        "@grpc/proto-loader": "^0.7.13",
+        "@types/long": "^5.0.0",
+        "abort-controller": "^3.0.0",
+        "duplexify": "^4.1.3",
+        "google-auth-library": "^10.0.0-rc.1",
+        "google-logging-utils": "^1.1.1",
+        "node-fetch": "^3.3.2",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^3.0.0",
+        "protobufjs": "^7.5.0",
+        "retry-request": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/google-logging-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.1.tgz",
+      "integrity": "sha512-rcX58I7nqpu4mbKztFeOAObbomBbHU2oIb/d3tJfF3dizGSApqtSwYJigGCooHdnMyQBIw8BrWyK96w3YXgr6A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/gtoken": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/proto3-json-serializer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.0.tgz",
+      "integrity": "sha512-mHPIc7zaJc26HMpgX5J7vXjliYv4Rnn5ICUyINudz76iY4zFMQHTaQXrTFn0EoHnRsLD6BE+OuHhQHFUU93I9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "protobufjs": "^7.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/retry-request": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.0.tgz",
+      "integrity": "sha512-dJkZNmyV9C8WKUmbdj1xcvVlXBSvsUQCkg89TCK8rD72RdSn9A2jlXlS2VuYSTHoPJjJEfUHhjNYrlvuksF9cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/request": "^2.48.12",
+        "extend": "^3.0.2",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/teeny-request": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.0.tgz",
+      "integrity": "sha512-3ZnLvgWF29jikg1sAQ1g0o+lr5JX6sVgYvfUJazn7ZjJroDBUTWp44/+cFVX0bULjv4vci+rBD+oGVAkWqhUbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/teeny-request/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@google-cloud/storage": {
@@ -9036,7 +9230,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -9144,7 +9337,6 @@
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
       "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/connect": {
@@ -9701,7 +9893,6 @@
       "version": "2.48.12",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.12.tgz",
       "integrity": "sha512-G3sY+NpsA9jnwm0ixhAFQSJ3Q9JkpLZpJbI3GMv0mIAT0y3mRabYeINzal5WOChIiaTEGQYlHOKgkaM9EisWHw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/caseless": "*",
@@ -9714,7 +9905,6 @@
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.3.tgz",
       "integrity": "sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -9784,7 +9974,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/triple-beam": {
@@ -10330,7 +10519,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
@@ -13583,7 +13771,6 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
       "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.4.1",
@@ -13706,7 +13893,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -14517,7 +14703,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -21361,7 +21546,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -23348,7 +23532,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -24817,7 +25000,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
       "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "stubs": "^3.0.0"
@@ -24837,7 +25019,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
       "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/streamsearch": {
@@ -24866,7 +25047,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -25241,7 +25421,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/styled-jsx": {
@@ -27016,7 +27195,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "start:local": "./scripts/start.sh",
     "dev:clean": "./scripts/clean.sh",
     "prepare:commit": "./scripts/prepare-commit.sh",
-    "prepare": "husky install",
     "backup": "node scripts/backup.js",
     "analyze-costs": "tsx scripts/analyze-costs.ts",
     "emulators": "firebase emulators:start --project=thalamus-dev",
@@ -44,11 +43,13 @@
     "docker:functions:build": "docker build -t meu-app-func functions/ -f functions/Dockerfile.functions",
     "docker:up": "docker-compose up --build",
     "docker:down": "docker-compose down",
-    "sentry:release": "./scripts/sentry-release.sh"
+    "sentry:release": "./scripts/sentry-release.sh",
+    "prepare": "husky install"
   },
   "dependencies": {
     "@genkit-ai/core": "^1.13.0",
     "@genkit-ai/googleai": "^1.13.0",
+    "@google-cloud/secret-manager": "6.0.1",
     "@hookform/resolvers": "^5.1.1",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.14",

--- a/src/lib/firebaseAdmin.ts
+++ b/src/lib/firebaseAdmin.ts
@@ -1,4 +1,7 @@
 import admin from 'firebase-admin';
+import { loadSecrets } from './secretManager';
+
+await loadSecrets(['FIREBASE_CLIENT_EMAIL', 'FIREBASE_PRIVATE_KEY']);
 
 const app =
   admin.apps[0] ??

--- a/src/lib/secretManager.ts
+++ b/src/lib/secretManager.ts
@@ -1,0 +1,26 @@
+import type { AccessSecretVersionResponse } from '@google-cloud/secret-manager';
+let loaded = false;
+
+export async function loadSecrets(names: string[]): Promise<void> {
+  if (loaded) return;
+  loaded = true;
+  const { SecretManagerServiceClient } = await import('@google-cloud/secret-manager');
+  const client = new SecretManagerServiceClient();
+  const projectId = process.env.FIREBASE_PROJECT_ID;
+  if (!projectId) return;
+
+  await Promise.all(
+    names.map(async (name) => {
+      if (process.env[name]) return;
+      try {
+        const [version]: AccessSecretVersionResponse = await client.accessSecretVersion({
+          name: `projects/${projectId}/secrets/${name}/versions/latest`,
+        });
+        const value = version.payload?.data?.toString();
+        if (value) process.env[name] = value;
+      } catch (err) {
+        console.error(`Erro ao carregar segredo ${name}:`, err);
+      }
+    })
+  );
+}


### PR DESCRIPTION
## Summary
- fetch FIREBASE_PRIVATE_KEY and FIREBASE_CLIENT_EMAIL from Google Secret Manager
- use the helper in firebaseAdmin
- document using Secret Manager
- add dependency `@google-cloud/secret-manager`
- test secret loader

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run typecheck` *(fails: multiple TS errors)*
- `npm test` *(fails: Firebase auth errors and missing emulators)*

------
https://chatgpt.com/codex/tasks/task_e_685a0092db108324ba8abd60e5afafd0