### PR TITLE
Add admin role validation to setUserRole API

### DIFF
--- a/src/app/api/admin/setUserRole/route.ts
+++ b/src/app/api/admin/setUserRole/route.ts
@@ -49,6 +49,11 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Proibido' }, { status: 403 });
     }
 
+    const requester = await adminAuth().getUser(decoded.uid);
+    if (requester.customClaims?.role !== 'admin') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+    }
+
     await adminAuth().setCustomUserClaims(uid, { role });
     return NextResponse.json({ success: true });
   } catch (e) {


### PR DESCRIPTION
## Summary
- enforce check for admin privileges in `/api/admin/setUserRole`

## Testing
- `npm run test:all` *(fails: download failed, status 403)*

------
https://chatgpt.com/codex/tasks/task_e_685a0e74dbe883249ac33e98f7894b70