### PR TITLE
Fix Google Cloud Logging dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@genkit-ai/core": "^1.13.0",
         "@genkit-ai/googleai": "^1.13.0",
+        "@google-cloud/logging": "^11.2.0",
         "@google-cloud/secret-manager": "6.0.1",
         "@hookform/resolvers": "^5.1.1",
         "@radix-ui/react-accordion": "^1.2.11",
@@ -1679,6 +1680,26 @@
         "node": ">=18"
       }
     },
+    "node_modules/@google-cloud/common": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-5.0.2.tgz",
+      "integrity": "sha512-V7bmBKYQyu0eVG2BFejuUjlBt+zrya6vtsKdY+JxMM/dNntPF41vZ9+LhOshEUH01zOHEqBSvI7Dad7ZS6aUeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "^4.0.0",
+        "arrify": "^2.0.1",
+        "duplexify": "^4.1.1",
+        "extend": "^3.0.2",
+        "google-auth-library": "^9.0.0",
+        "html-entities": "^2.5.2",
+        "retry-request": "^7.0.0",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@google-cloud/firestore": {
       "version": "7.11.1",
       "license": "Apache-2.0",
@@ -1694,9 +1715,63 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@google-cloud/logging": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/logging/-/logging-11.2.0.tgz",
+      "integrity": "sha512-Ma94jvuoMpbgNniwtelOt8w82hxK62FuOXZonEv0Hyk3B+/YVuLG/SWNyY9yMso/RXnPEc1fP2qo9kDrjf/b2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/common": "^5.0.0",
+        "@google-cloud/paginator": "^5.0.0",
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "^4.0.0",
+        "@opentelemetry/api": "^1.7.0",
+        "arrify": "^2.0.1",
+        "dot-prop": "^6.0.0",
+        "eventid": "^2.0.0",
+        "extend": "^3.0.2",
+        "gcp-metadata": "^6.0.0",
+        "google-auth-library": "^9.0.0",
+        "google-gax": "^4.0.3",
+        "on-finished": "^2.3.0",
+        "pumpify": "^2.0.1",
+        "stream-events": "^1.0.5",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/logging/node_modules/dot-prop": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@google-cloud/logging/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@google-cloud/paginator": {
       "version": "5.0.2",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "arrify": "^2.0.0",
@@ -1716,7 +1791,6 @@
     },
     "node_modules/@google-cloud/projectify": {
       "version": "4.0.0",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14.0.0"
@@ -1724,7 +1798,6 @@
     },
     "node_modules/@google-cloud/promisify": {
       "version": "4.0.0",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -8152,7 +8225,6 @@
     },
     "node_modules/@types/long": {
       "version": "4.0.2",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/mime": {
@@ -9191,7 +9263,6 @@
     },
     "node_modules/arrify": {
       "version": "2.0.1",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12298,6 +12369,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/eventid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/eventid/-/eventid-2.0.1.tgz",
+      "integrity": "sha512-sPNTqiMokAvV048P2c9+foqVJzk49o6d4e0D/sq5jog3pw+4kBgyR0gaM1FM7Mx6Kzd9dztesh9oYz1LWWOpzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "uuid": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eventid/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "license": "MIT",
@@ -13767,7 +13859,6 @@
     },
     "node_modules/google-gax": {
       "version": "4.6.1",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.10.9",
@@ -13789,7 +13880,6 @@
     },
     "node_modules/google-gax/node_modules/node-fetch": {
       "version": "2.7.0",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -13808,12 +13898,10 @@
     },
     "node_modules/google-gax/node_modules/tr46": {
       "version": "0.0.3",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/google-gax/node_modules/uuid": {
       "version": "9.0.1",
-      "devOptional": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -13825,12 +13913,10 @@
     },
     "node_modules/google-gax/node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "devOptional": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/google-gax/node_modules/whatwg-url": {
       "version": "5.0.0",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -14204,8 +14290,7 @@
           "url": "https://patreon.com/mdevils"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -14839,7 +14924,6 @@
     },
     "node_modules/is-obj": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -19152,7 +19236,6 @@
     },
     "node_modules/proto3-json-serializer": {
       "version": "2.0.2",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "protobufjs": "^7.2.5"
@@ -19226,11 +19309,21 @@
     },
     "node_modules/pump": {
       "version": "3.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/pumpify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
+      "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+      "license": "MIT",
+      "dependencies": {
+        "duplexify": "^4.1.1",
+        "inherits": "^2.0.3",
+        "pump": "^3.0.0"
       }
     },
     "node_modules/punycode": {
@@ -20083,7 +20176,6 @@
     },
     "node_modules/retry-request": {
       "version": "7.0.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/request": "^2.48.8",
@@ -21736,7 +21828,6 @@
     },
     "node_modules/teeny-request": {
       "version": "9.0.0",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "http-proxy-agent": "^5.0.0",
@@ -21751,7 +21842,6 @@
     },
     "node_modules/teeny-request/node_modules/agent-base": {
       "version": "6.0.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -21762,7 +21852,6 @@
     },
     "node_modules/teeny-request/node_modules/http-proxy-agent": {
       "version": "5.0.0",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@tootallnate/once": "2",
@@ -21775,7 +21864,6 @@
     },
     "node_modules/teeny-request/node_modules/https-proxy-agent": {
       "version": "5.0.1",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -21787,7 +21875,6 @@
     },
     "node_modules/teeny-request/node_modules/node-fetch": {
       "version": "2.7.0",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -21806,12 +21893,10 @@
     },
     "node_modules/teeny-request/node_modules/tr46": {
       "version": "0.0.3",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/teeny-request/node_modules/uuid": {
       "version": "9.0.1",
-      "devOptional": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -21823,12 +21908,10 @@
     },
     "node_modules/teeny-request/node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "devOptional": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/teeny-request/node_modules/whatwg-url": {
       "version": "5.0.0",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@genkit-ai/core": "^1.13.0",
     "@genkit-ai/googleai": "^1.13.0",
     "@google-cloud/secret-manager": "6.0.1",
+    "@google-cloud/logging": "^11.2.0",
     "@hookform/resolvers": "^5.1.1",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.14",


### PR DESCRIPTION
## Summary
- add `@google-cloud/logging` dependency to support server logging

## Testing
- `npm install --package-lock-only --ignore-scripts`
- `npx jest --version` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a0eb1214c8324b97e4f8fbdce6b4c