### PR TITLE
Refactor clinical map page to server component

### DIFF
--- a/__tests__/clinical-map-loading.test.tsx
+++ b/__tests__/clinical-map-loading.test.tsx
@@ -1,12 +1,9 @@
 import { render, screen } from '@testing-library/react';
-import ClinicalMapFullscreenPage from '@/app/clinical-map/[patientId]/[tabId]/page';
+import ClinicalMapClient from '@/app/clinical-map/[patientId]/[tabId]/ClinicalMapClient';
 import { useClinicalStore } from '@/stores/clinicalStore';
 
-jest.mock('next/navigation', () => ({
-  useParams: () => ({ patientId: 'p1', tabId: 't1' }),
-}));
 
-describe('ClinicalMap page loading and error states', () => {
+describe('ClinicalMapClient loading and error states', () => {
   beforeEach(() => {
     useClinicalStore.setState({
       fetchClinicalData: jest.fn(),
@@ -14,18 +11,33 @@ describe('ClinicalMap page loading and error states', () => {
       tabs: [{ id: 't1', type: 'formulation', title: 'T1' }],
       isLoadingClinicalData: false,
       clinicalDataError: null,
+      formulationTabData: {},
     });
   });
 
   it('exibe spinner durante carregamento', () => {
     useClinicalStore.setState({ isLoadingClinicalData: true });
-    render(<ClinicalMapFullscreenPage />);
+    render(
+      <ClinicalMapClient
+        patientId="p1"
+        tabId="t1"
+        initialPatient={null}
+        initialMap={null}
+      />
+    );
     expect(screen.getByText(/carregando dados cl.nicos/i)).toBeInTheDocument();
   });
 
   it('exibe mensagem de erro se falhar', () => {
     useClinicalStore.setState({ clinicalDataError: 'Erro X' });
-    render(<ClinicalMapFullscreenPage />);
+    render(
+      <ClinicalMapClient
+        patientId="p1"
+        tabId="t1"
+        initialPatient={null}
+        initialMap={null}
+      />
+    );
     expect(screen.getByText(/erro ao carregar dados cl.nicos/i)).toBeInTheDocument();
     expect(screen.getByText('Erro X')).toBeInTheDocument();
   });

--- a/src/app/clinical-map/[patientId]/[tabId]/ClinicalMapClient.tsx
+++ b/src/app/clinical-map/[patientId]/[tabId]/ClinicalMapClient.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import { Loader2, AlertTriangle } from 'lucide-react';
+import FormulationMapWrapper from '@/components/clinical-formulation/FormulationMap';
+import { useClinicalStore } from '@/stores/clinicalStore';
+import type { Patient } from '@/types/patient';
+import type { TabSpecificFormulationData } from '@/types/clinicalTypes';
+
+interface ClinicalMapClientProps {
+  patientId: string;
+  tabId: string;
+  initialPatient: Patient | null;
+  initialMap: TabSpecificFormulationData | null;
+}
+
+export default function ClinicalMapClient({
+  patientId,
+  tabId,
+  initialPatient, // eslint-disable-line @typescript-eslint/no-unused-vars
+  initialMap,
+}: ClinicalMapClientProps) {
+  const {
+    setActiveTab,
+    fetchClinicalData,
+    isLoadingClinicalData,
+    clinicalDataError,
+    formulationTabData,
+  } = useClinicalStore((s) => ({
+    setActiveTab: s.setActiveTab,
+    fetchClinicalData: s.fetchClinicalData,
+    isLoadingClinicalData: s.isLoadingClinicalData,
+    clinicalDataError: s.clinicalDataError,
+    formulationTabData: s.formulationTabData,
+  }));
+
+  useEffect(() => {
+    if (patientId && tabId) {
+      setActiveTab(tabId);
+      if (!formulationTabData[tabId]) {
+        if (initialMap) {
+          useClinicalStore.setState((state) => ({
+            formulationTabData: { ...state.formulationTabData, [tabId]: initialMap },
+          }));
+        } else {
+          fetchClinicalData(patientId, tabId);
+        }
+      }
+    }
+  }, [patientId, tabId, initialMap, formulationTabData, setActiveTab, fetchClinicalData]);
+
+  if (isLoadingClinicalData) {
+    return (
+      <div className="h-screen w-screen flex items-center justify-center gap-2">
+        <Loader2 className="w-6 h-6 animate-spin" />
+        <span>Carregando dados clínicos...</span>
+      </div>
+    );
+  }
+
+  if (clinicalDataError) {
+    return (
+      <div className="h-screen w-screen flex flex-col items-center justify-center text-destructive space-y-2 text-center px-4">
+        <AlertTriangle className="h-8 w-8" />
+        <p className="text-sm font-medium">Erro ao carregar dados clínicos.</p>
+        <p className="text-xs">{clinicalDataError}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-screen w-screen overflow-hidden bg-background">
+      <FormulationMapWrapper />
+    </div>
+  );
+}

--- a/src/app/clinical-map/[patientId]/[tabId]/page.tsx
+++ b/src/app/clinical-map/[patientId]/[tabId]/page.tsx
@@ -1,69 +1,25 @@
-'use client';
+import ClinicalMapClient from './ClinicalMapClient';
+import { fetchPatient } from '@/services/patientService';
+import { fetchClinicalData } from '@/services/clinicalService';
+import type { Patient } from '@/types/patient';
+import type { TabSpecificFormulationData } from '@/types/clinicalTypes';
 
-import React, { useEffect } from 'react';
-import { useParams } from 'next/navigation';
-import { Loader2, AlertTriangle } from 'lucide-react';
-import FormulationMapWrapper from '@/components/clinical-formulation/FormulationMap';
-import { useClinicalStore } from '@/stores/clinicalStore';
-import { mockPatient } from '@/app/(app)/patients/[id]/page';
-
-// Helper to extract patientId and tabId. In a real app, you'd get this from route params
-// and ensure they are strings.
-function getRouteParams(defaultTabId: string | undefined): { patientId: string; tabId: string } {
-  const params = useParams();
-  const patientId = Array.isArray(params.patientId) ? params.patientId[0] : params.patientId;
-  const tabId = Array.isArray(params.tabId) ? params.tabId[0] : params.tabId;
-  return {
-    patientId: patientId || mockPatient.id,
-    tabId: tabId || defaultTabId || 'initialTab',
-  };
+interface PageProps {
+  params: { patientId: string; tabId: string };
 }
 
-export default function ClinicalMapFullscreenPage() {
-  const { setActiveTab, fetchClinicalData, tabs, isLoadingClinicalData, clinicalDataError } =
-    useClinicalStore((s) => ({
-      setActiveTab: s.setActiveTab,
-      fetchClinicalData: s.fetchClinicalData,
-      tabs: s.tabs,
-      isLoadingClinicalData: s.isLoadingClinicalData,
-      clinicalDataError: s.clinicalDataError,
-    }));
-  const { patientId, tabId } = getRouteParams(tabs[0]?.id);
+export default async function ClinicalMapFullscreenPage({ params }: PageProps) {
+  const { patientId, tabId } = params;
 
-  useEffect(() => {
-    if (patientId && tabId) {
-      // console.log(`Fullscreen: Setting active tab to ${tabId} for patient ${patientId}`);
-      setActiveTab(tabId);
-      fetchClinicalData(patientId, tabId);
-    }
-  }, [patientId, tabId, setActiveTab, fetchClinicalData]);
-
-  if (isLoadingClinicalData) {
-    return (
-      <div className="h-screen w-screen flex items-center justify-center gap-2">
-        <Loader2 className="w-6 h-6 animate-spin" />
-        <span>Carregando dados clínicos...</span>
-      </div>
-    );
-  }
-
-  if (clinicalDataError) {
-    return (
-      <div className="h-screen w-screen flex flex-col items-center justify-center text-destructive space-y-2 text-center px-4">
-        <AlertTriangle className="h-8 w-8" />
-        <p className="text-sm font-medium">Erro ao carregar dados clínicos.</p>
-        <p className="text-xs">{clinicalDataError}</p>
-      </div>
-    );
-  }
+  const patient: Patient | null = await fetchPatient(patientId);
+  const map: TabSpecificFormulationData | null = await fetchClinicalData(patientId, tabId);
 
   return (
-    <div className="h-screen w-screen overflow-hidden bg-background">
-      {/*
-        Pass patientId and tabId if FormulationMapWrapper needs them directly.
-        However, it should primarily rely on the activeTabId from the store.
-      */}
-      <FormulationMapWrapper />
-    </div>
+    <ClinicalMapClient
+      patientId={patientId}
+      tabId={tabId}
+      initialPatient={patient}
+      initialMap={map}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- fetch patient and clinical map on the server
- introduce new `ClinicalMapClient` to handle client-side state
- adjust loading test to render new client component

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run typecheck` *(fails: TS errors)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a0f44403483249f1736469f553ca6