### PR TITLE
Improve CI caching and unify security scans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,27 +17,41 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.11.0
-          cache: 'npm'
+
+      - name: Setup pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@latest --activate
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Cache pnpm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-
 
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-playwright-
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
 
       - name: Audit dependencies
-        run: npm audit --audit-level=high
+        run: pnpm audit --audit-level=high
 
       - name: Lint
         run: npm run lint

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -53,11 +53,18 @@ jobs:
       - run: npm ci
       - run: npm audit --audit-level=moderate
 
-  secret-scan:
-    name: Secret Scan
+  gitleaks-scan:
+    name: Gitleaks Scan
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: gitleaks/gitleaks-action@v2
         with:
           args: "--verbose --redact"
+
+  trufflehog-scan:
+    name: TruffleHog Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trufflesecurity/trufflehog@v3

--- a/README.md
+++ b/README.md
@@ -212,4 +212,4 @@ Erros genéricos como **"An unexpected Turbopack error occurred"** costumam esta
 
 - Utilizamos o [Snyk](https://snyk.io/) para inspeções de vulnerabilidades (workflow `security.yml`).
 - O [Dependabot](https://github.com/dependabot) atualiza dependências semanalmente.
-- Há também o workflow `security-scan.yml` que roda `npm audit --audit-level=moderate` todo mês.
+- O workflow `security.yml` também executa varreduras do **Gitleaks** e do **TruffleHog** periodicamente.


### PR DESCRIPTION
## Summary
- streamline security checks by adding Gitleaks and TruffleHog in `security.yml`
- enable pnpm and cache dependencies and Playwright binaries in CI
- document that `security.yml` now runs both secret scanners

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: failed to download Chrome due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685a0f7ebc288324ab8323727dc3ac53