### PR TITLE
Add group creation use case

### DIFF
--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,8 +1,4 @@
-import {
-  doc,
-  getDoc,
-  type Firestore,
-} from 'firebase/firestore';
+import { doc, getDoc, setDoc, type Firestore } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import { FIRESTORE_COLLECTIONS } from '@/lib/firestore-collections';
 import type { UserProfile } from '@/types/user';
@@ -35,5 +31,24 @@ export async function fetchUserProfile(
     Sentry.captureException(err);
     logger.error({ action: 'fetch_user_profile_error', meta: { error: err } });
     return null;
+  }
+}
+
+export async function assignRoleToUserInGroup(
+  groupId: string,
+  userId: string,
+  role: string,
+  firestore: Firestore = db
+): Promise<void> {
+  try {
+    const ref = doc(firestore, FIRESTORE_COLLECTIONS.GROUPS, groupId, 'members', userId);
+    await setDoc(ref, { role }, { merge: true });
+  } catch (err) {
+    Sentry.captureException(err);
+    logger.error({
+      action: 'assign_role_to_user_in_group_error',
+      meta: { groupId, userId, role, error: err },
+    });
+    throw err;
   }
 }

--- a/src/use-cases/create-group-with-leader.ts
+++ b/src/use-cases/create-group-with-leader.ts
@@ -1,0 +1,16 @@
+import { createGroup, type GroupInput } from '@/services/groupService';
+import { assignRoleToUserInGroup } from '@/services/userService';
+import * as Sentry from '@sentry/nextjs';
+import logger from '@/lib/logger';
+
+export async function createGroupWithLeader(data: GroupInput, leaderId: string): Promise<string> {
+  try {
+    const groupId = await createGroup(data);
+    await assignRoleToUserInGroup(groupId, leaderId, 'leader');
+    return groupId;
+  } catch (err) {
+    Sentry.captureException(err);
+    logger.error({ action: 'create_group_with_leader_error', meta: { error: err } });
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- add `create-group-with-leader` use case to centralize group creation logic
- extend `userService` with `assignRoleToUserInGroup`

## Testing
- `./run-tests.sh` *(fails: download failed, status 403)*

------
https://chatgpt.com/codex/tasks/task_e_685a0f9d65348324a2d2141c634cac83