### PR TITLE
Add analyze script

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "dev:clean": "./scripts/clean.sh",
     "prepare:commit": "./scripts/prepare-commit.sh",
     "backup": "node scripts/backup.js",
+    "analyze": "ANALYZE=true pnpm build",
     "analyze-costs": "tsx scripts/analyze-costs.ts",
     "emulators": "firebase emulators:start --project=thalamus-dev",
     "emulators:export": "firebase emulators:export ./emulator-data",


### PR DESCRIPTION
## Summary
- add `analyze` script that runs the bundle analyzer

## Testing
- `npm ci` *(fails: npm registry access blocked)*
- `npm run lint` *(fails: lint errors)*
- `npm run typecheck` *(fails: type errors)*
- `timeout 5s npm run dev` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a22a8a78c832493e81645b711f840