### PR TITLE
Centralize user role strings

### DIFF
--- a/__tests__/audit-logs.test.ts
+++ b/__tests__/audit-logs.test.ts
@@ -1,6 +1,7 @@
 import { initializeTestEnvironment } from '@firebase/rules-unit-testing';
 import { readFileSync } from 'fs';
 import { Firestore, getDocs, collection } from 'firebase/firestore';
+import { USER_ROLES } from '@/constants/roles';
 import { saveSessionNote } from '../src/services/prontuarioService';
 import { createAppointment } from '../src/services/appointmentService';
 
@@ -26,7 +27,7 @@ beforeAll(async () => {
     },
   });
 
-  const auth = { uid: 'therapist1', role: 'Psychologist' };
+  const auth = { uid: 'therapist1', role: USER_ROLES.PSYCHOLOGIST } as const;
   const db = testEnv.authenticatedContext(auth.uid, auth).firestore();
 
   jest.doMock('../src/lib/firebase', () => ({
@@ -50,7 +51,7 @@ function getDb(auth: { uid: string; role: string }): Firestore {
 }
 
 test('audit log created for multiple actions', async () => {
-  const auth = { uid: 'therapist1', role: 'Psychologist' };
+  const auth = { uid: 'therapist1', role: USER_ROLES.PSYCHOLOGIST } as const;
   const db = getDb(auth);
   setEncryptionPassword('senha');
 

--- a/__tests__/clinical.service.test.ts
+++ b/__tests__/clinical.service.test.ts
@@ -1,6 +1,7 @@
 import { initializeTestEnvironment } from '@firebase/rules-unit-testing';
 import { readFileSync } from 'fs';
 import { Firestore } from 'firebase/firestore';
+import { USER_ROLES } from '@/constants/roles';
 
 let fetchClinicalData: any;
 let saveClinicalData: any;
@@ -21,7 +22,7 @@ beforeAll(async () => {
     },
   });
 
-  const auth = { uid: 'therapist1', role: 'Psychologist' };
+  const auth = { uid: 'therapist1', role: USER_ROLES.PSYCHOLOGIST } as const;
   const db = testEnv.authenticatedContext(auth.uid, auth).firestore();
 
   jest.doMock('../src/lib/firebase', () => ({
@@ -42,7 +43,7 @@ function getDb(auth: { uid: string; role: string }): Firestore {
 }
 
 test('salva e busca clinical data', async () => {
-  const auth = { uid: 'therapist1', role: 'Psychologist' };
+  const auth = { uid: 'therapist1', role: USER_ROLES.PSYCHOLOGIST } as const;
   const db = getDb(auth);
   const patientId = 'p1';
   const tabId = 't1';

--- a/__tests__/firestore-rules.test.ts
+++ b/__tests__/firestore-rules.test.ts
@@ -5,6 +5,7 @@ import {
 } from '@firebase/rules-unit-testing';
 import { Firestore } from 'firebase/firestore';
 import { readFileSync } from 'fs'; // <- ESSENCIAL!
+import { USER_ROLES } from '@/constants/roles';
 
 let testEnv: Awaited<ReturnType<typeof initializeTestEnvironment>>;
 
@@ -33,13 +34,13 @@ describe('Firestore security rules', () => {
   }
 
   test('admin user can read other user profile', async () => {
-    const auth = { sub: 'user-id', role: 'Admin' };
+    const auth = { sub: 'user-id', role: USER_ROLES.ADMIN } as const;
     const db = getAuthedDb(auth);
     await assertSucceeds(db.doc('users/otherUser').get());
   });
 
   test('authenticated user can create assessment', async () => {
-    const auth = { sub: 'therapist1', role: 'psychologist' };
+    const auth = { sub: 'therapist1', role: USER_ROLES.PSYCHOLOGIST } as const;
     const db = getAuthedDb(auth);
     await assertSucceeds(
       db.doc('assessments/testAssessment').set({
@@ -55,7 +56,7 @@ describe('Firestore security rules', () => {
 
   describe('Appointment Rules', () => {
     test('non participant cannot read appointment', async () => {
-      const psyAuth = { sub: 'psy1', role: 'Psychologist' };
+      const psyAuth = { sub: 'psy1', role: USER_ROLES.PSYCHOLOGIST } as const;
       const otherAuth = { uid: 'other' };
       const psyDb = getAuthedDb(psyAuth);
       const otherDb = testEnv.authenticatedContext(otherAuth.uid).firestore();
@@ -76,7 +77,7 @@ describe('Firestore security rules', () => {
     });
 
     test('psychologist can manage own appointment', async () => {
-      const psyAuth = { sub: 'psy2', role: 'Psychologist' };
+      const psyAuth = { sub: 'psy2', role: USER_ROLES.PSYCHOLOGIST } as const;
       const db = getAuthedDb(psyAuth);
       const docRef = db.collection('appointments').doc('apptManage');
 
@@ -86,7 +87,7 @@ describe('Firestore security rules', () => {
     });
 
     test('patient can read own appointment but cannot modify', async () => {
-      const psyAuth = { sub: 'psy3', role: 'Psychologist' };
+      const psyAuth = { sub: 'psy3', role: USER_ROLES.PSYCHOLOGIST } as const;
       const psyDb = getAuthedDb(psyAuth);
       const docRef = psyDb.collection('appointments').doc('apptPatient');
       await assertSucceeds(docRef.set({ psychologistId: psyAuth.sub, patientId: 'patRead' }));
@@ -102,7 +103,7 @@ describe('Firestore security rules', () => {
 
   describe('Audit Logs Rules', () => {
     test('authenticated user can create audit log', async () => {
-      const auth = { sub: 'userAudit', role: 'Psychologist' };
+      const auth = { sub: 'userAudit', role: USER_ROLES.PSYCHOLOGIST } as const;
       const db = getAuthedDb(auth);
       await assertSucceeds(
         db.collection('auditLogs').doc('log1').set({
@@ -118,7 +119,7 @@ describe('Firestore security rules', () => {
     });
 
     test('authenticated user cannot update audit log', async () => {
-      const auth = { sub: 'userAudit', role: 'Psychologist' };
+      const auth = { sub: 'userAudit', role: USER_ROLES.PSYCHOLOGIST } as const;
       const db = getAuthedDb(auth);
       const docRef = db.collection('auditLogs').doc('logUpdate');
       await assertSucceeds(docRef.set({ action: 'create', createdAt: '2024-01-01T00:00:00Z' }));
@@ -126,7 +127,7 @@ describe('Firestore security rules', () => {
     });
 
     test('authenticated user cannot delete audit log', async () => {
-      const auth = { sub: 'userAudit', role: 'Psychologist' };
+      const auth = { sub: 'userAudit', role: USER_ROLES.PSYCHOLOGIST } as const;
       const db = getAuthedDb(auth);
       const docRef = db.collection('auditLogs').doc('logDelete');
       await assertSucceeds(docRef.set({ action: 'create', createdAt: '2024-01-01T00:00:00Z' }));
@@ -136,8 +137,8 @@ describe('Firestore security rules', () => {
 
   describe('Chat Rules', () => {
     test('chat creation succeeds when all users exist', async () => {
-      const user1 = { sub: 'chatUser1', role: 'Psychologist' };
-      const user2 = { sub: 'chatUser2', role: 'Psychologist' };
+      const user1 = { sub: 'chatUser1', role: USER_ROLES.PSYCHOLOGIST } as const;
+      const user2 = { sub: 'chatUser2', role: USER_ROLES.PSYCHOLOGIST } as const;
       const db1 = getAuthedDb(user1);
       const db2 = getAuthedDb(user2);
 
@@ -145,13 +146,13 @@ describe('Firestore security rules', () => {
         db1
           .collection('users')
           .doc(user1.sub)
-          .set({ role: 'Psychologist', isApproved: true, name: 'U1', email: 'u1@test' })
+          .set({ role: USER_ROLES.PSYCHOLOGIST, isApproved: true, name: 'U1', email: 'u1@test' })
       );
       await assertSucceeds(
         db2
           .collection('users')
           .doc(user2.sub)
-          .set({ role: 'Psychologist', isApproved: true, name: 'U2', email: 'u2@test' })
+          .set({ role: USER_ROLES.PSYCHOLOGIST, isApproved: true, name: 'U2', email: 'u2@test' })
       );
 
       const chatRef = db1.collection('chats').doc('ok');
@@ -159,14 +160,14 @@ describe('Firestore security rules', () => {
     });
 
     test('chat creation fails if some user does not exist', async () => {
-      const user1 = { sub: 'chatUser3', role: 'Psychologist' };
+      const user1 = { sub: 'chatUser3', role: USER_ROLES.PSYCHOLOGIST } as const;
       const db1 = getAuthedDb(user1);
 
       await assertSucceeds(
         db1
           .collection('users')
           .doc(user1.sub)
-          .set({ role: 'Psychologist', isApproved: true, name: 'U3', email: 'u3@test' })
+          .set({ role: USER_ROLES.PSYCHOLOGIST, isApproved: true, name: 'U3', email: 'u3@test' })
       );
 
       const chatRef = db1.collection('chats').doc('fail');
@@ -176,7 +177,7 @@ describe('Firestore security rules', () => {
 
   describe('Feedback Rules', () => {
     test('authenticated user can create feedback', async () => {
-      const auth = { sub: 'userFb', role: 'Psychologist' };
+      const auth = { sub: 'userFb', role: USER_ROLES.PSYCHOLOGIST } as const;
       const db = getAuthedDb(auth);
       await assertSucceeds(
         db.collection('feedback').doc('fb1').set({
@@ -189,9 +190,7 @@ describe('Firestore security rules', () => {
 
     test('unauthenticated user cannot create feedback', async () => {
       const db = testEnv.unauthenticatedContext().firestore();
-      await assertFails(
-        db.collection('feedback').doc('fb2').set({ uid: 'x', text: 'no' })
-      );
+      await assertFails(db.collection('feedback').doc('fb2').set({ uid: 'x', text: 'no' }));
     });
   });
 });

--- a/__tests__/groups.service.test.ts
+++ b/__tests__/groups.service.test.ts
@@ -1,6 +1,7 @@
 import { initializeTestEnvironment } from '@firebase/rules-unit-testing';
 import { readFileSync } from 'fs';
 import { Firestore } from 'firebase/firestore';
+import { USER_ROLES } from '@/constants/roles';
 
 let createGroup: any;
 let fetchGroups: any;
@@ -23,7 +24,7 @@ beforeAll(async () => {
     },
   });
 
-  const auth = { uid: 'therapist1', role: 'Psychologist' };
+  const auth = { uid: 'therapist1', role: USER_ROLES.PSYCHOLOGIST } as const;
   const db = testEnv.authenticatedContext(auth.uid, auth).firestore();
 
   jest.doMock('../src/lib/firebase', () => ({
@@ -46,7 +47,7 @@ function getDb(auth: { uid: string; role: string }): Firestore {
 }
 
 test('create, update and delete group', async () => {
-  const auth = { uid: 'therapist1', role: 'Psychologist' };
+  const auth = { uid: 'therapist1', role: USER_ROLES.PSYCHOLOGIST } as const;
   const db = getDb(auth);
 
   const groupId = await createGroup(

--- a/__tests__/prontuario-flow.test.ts
+++ b/__tests__/prontuario-flow.test.ts
@@ -1,15 +1,16 @@
-import { initializeTestEnvironment } from '@firebase/rules-unit-testing'
-import { readFileSync } from 'fs'
-import { Firestore } from 'firebase/firestore'
-import { saveSessionNote, getSessionNotes } from '../src/services/prontuarioService'
-import { setEncryptionPassword } from '../src/lib/encryptionKey'
+import { initializeTestEnvironment } from '@firebase/rules-unit-testing';
+import { readFileSync } from 'fs';
+import { Firestore } from 'firebase/firestore';
+import { USER_ROLES } from '@/constants/roles';
+import { saveSessionNote, getSessionNotes } from '../src/services/prontuarioService';
+import { setEncryptionPassword } from '../src/lib/encryptionKey';
 
-let testEnv: Awaited<ReturnType<typeof initializeTestEnvironment>>
+let testEnv: Awaited<ReturnType<typeof initializeTestEnvironment>>;
 
 beforeAll(async () => {
-  const hostPort = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8085'
-  const [host, portStr] = hostPort.split(':')
-  const port = parseInt(portStr, 10)
+  const hostPort = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8085';
+  const [host, portStr] = hostPort.split(':');
+  const port = parseInt(portStr, 10);
 
   testEnv = await initializeTestEnvironment({
     projectId: 'demo-project',
@@ -18,25 +19,25 @@ beforeAll(async () => {
       port,
       rules: readFileSync('firestore.rules', 'utf8'),
     },
-  })
-})
+  });
+});
 
 afterAll(async () => {
-  if (testEnv) await testEnv.cleanup()
-})
+  if (testEnv) await testEnv.cleanup();
+});
 
 function getAuthedDb(auth: { sub: string; role: string }): Firestore {
-  return testEnv.authenticatedContext(auth.sub, auth).firestore()
+  return testEnv.authenticatedContext(auth.sub, auth).firestore();
 }
 
 test('save and retrieve encrypted session note', async () => {
-  const auth = { sub: 'therapist1', role: 'Psychologist' }
-  const db = getAuthedDb(auth)
-  setEncryptionPassword('senha-teste')
+  const auth = { sub: 'therapist1', role: USER_ROLES.PSYCHOLOGIST } as const;
+  const db = getAuthedDb(auth);
+  setEncryptionPassword('senha-teste');
 
-  const noteId = await saveSessionNote(db, 'patient1', 'conteudo sigiloso', auth.sub)
-  expect(noteId).toBeDefined()
+  const noteId = await saveSessionNote(db, 'patient1', 'conteudo sigiloso', auth.sub);
+  expect(noteId).toBeDefined();
 
-  const notes = await getSessionNotes(db, 'patient1')
-  expect(notes[0].summary).toBe('conteudo sigiloso')
-})
+  const notes = await getSessionNotes(db, 'patient1');
+  expect(notes[0].summary).toBe('conteudo sigiloso');
+});

--- a/__tests__/quickNoteService.test.ts
+++ b/__tests__/quickNoteService.test.ts
@@ -1,6 +1,7 @@
 import { initializeTestEnvironment } from '@firebase/rules-unit-testing';
 import { readFileSync } from 'fs';
 import { Firestore } from 'firebase/firestore';
+import { USER_ROLES } from '@/constants/roles';
 
 let createQuickNote: any;
 let getQuickNotes: any;
@@ -21,7 +22,7 @@ beforeAll(async () => {
     },
   });
 
-  const auth = { uid: 'therapist1', role: 'Psychologist' };
+  const auth = { uid: 'therapist1', role: USER_ROLES.PSYCHOLOGIST } as const;
   const db = testEnv.authenticatedContext(auth.uid, auth).firestore();
 
   jest.doMock('../src/lib/firebase', () => ({
@@ -42,7 +43,7 @@ function getDb(auth: { uid: string; role: string }): Firestore {
 }
 
 test('salva e carrega quick notes', async () => {
-  const auth = { uid: 'therapist1', role: 'Psychologist' };
+  const auth = { uid: 'therapist1', role: USER_ROLES.PSYCHOLOGIST } as const;
   const db = getDb(auth);
   const patientId = 'p1';
   const noteId = await createQuickNote(patientId, { text: 'olá' }, db);

--- a/__tests__/scheduler.test.ts
+++ b/__tests__/scheduler.test.ts
@@ -1,6 +1,7 @@
 import { initializeTestEnvironment } from '@firebase/rules-unit-testing';
 import { readFileSync } from 'fs';
 import { Firestore, doc, setDoc } from 'firebase/firestore';
+import { USER_ROLES } from '@/constants/roles';
 
 let checkScheduleConflict: any;
 let testEnv: Awaited<ReturnType<typeof initializeTestEnvironment>>;
@@ -19,7 +20,7 @@ beforeAll(async () => {
     },
   });
 
-  const auth = { uid: 'psy1', role: 'Psychologist' };
+  const auth = { uid: 'psy1', role: USER_ROLES.PSYCHOLOGIST } as const;
   const db = testEnv.authenticatedContext(auth.uid, auth).firestore();
 
   jest.doMock('../src/lib/firebase', () => ({
@@ -39,7 +40,7 @@ function getDb(auth: { uid: string; role: string }): Firestore {
 }
 
 test('detects conflict with existing appointment', async () => {
-  const auth = { uid: 'psy1', role: 'Psychologist' };
+  const auth = { uid: 'psy1', role: USER_ROLES.PSYCHOLOGIST } as const;
   const db = getDb(auth);
   await setDoc(doc(db, 'appointments/a1'), {
     psychologistId: auth.uid,
@@ -63,7 +64,7 @@ test('detects conflict with existing appointment', async () => {
 });
 
 test('block slot logic', async () => {
-  const auth = { uid: 'psy1', role: 'Psychologist' };
+  const auth = { uid: 'psy1', role: USER_ROLES.PSYCHOLOGIST } as const;
   const db = getDb(auth);
   await setDoc(doc(db, 'appointments/block1'), {
     psychologistId: auth.uid,
@@ -99,7 +100,7 @@ test('block slot logic', async () => {
 });
 
 test('detects conflict with group session', async () => {
-  const auth = { uid: 'psy1', role: 'Psychologist' };
+  const auth = { uid: 'psy1', role: USER_ROLES.PSYCHOLOGIST } as const;
   const db = getDb(auth);
   await setDoc(doc(db, 'groups/g1'), {
     psychologistId: auth.uid,

--- a/__tests__/use-auth.test.tsx
+++ b/__tests__/use-auth.test.tsx
@@ -1,27 +1,28 @@
-import { renderHook, act } from '@testing-library/react'
-import useAuth from '@/hooks/use-auth'
-import { getAuth, onAuthStateChanged, getIdTokenResult } from 'firebase/auth'
+import { renderHook, act } from '@testing-library/react';
+import useAuth from '@/hooks/use-auth';
+import { onAuthStateChanged, getIdTokenResult } from 'firebase/auth';
+import { USER_ROLES } from '@/constants/roles';
 
-type Callback = Parameters<typeof onAuthStateChanged>[1]
+type Callback = Parameters<typeof onAuthStateChanged>[1];
 
 jest.mock('firebase/auth', () => ({
   getAuth: jest.fn(),
   onAuthStateChanged: jest.fn(),
   getIdTokenResult: jest.fn(),
-}))
+}));
 
 describe('useAuth', () => {
   it('define usuário autenticado', async () => {
-    const user = { uid: '1', displayName: 'Alice', email: 'a@b.com', photoURL: null } as any
-    ;(onAuthStateChanged as jest.Mock).mockImplementation((_auth, cb: Callback) => {
-      cb(user)
-      return () => {}
-    })
-    ;(getIdTokenResult as jest.Mock).mockResolvedValue({ claims: { role: 'Admin' } })
+    const user = { uid: '1', displayName: 'Alice', email: 'a@b.com', photoURL: null } as any;
+    (onAuthStateChanged as jest.Mock).mockImplementation((_auth, cb: Callback) => {
+      cb(user);
+      return () => {};
+    });
+    (getIdTokenResult as jest.Mock).mockResolvedValue({ claims: { role: USER_ROLES.ADMIN } });
 
-    const { result } = renderHook(() => useAuth())
-    await act(async () => {})
-    expect(result.current.user?.uid).toBe('1')
-    expect(result.current.user?.role).toBe('Admin')
-  })
-})
+    const { result } = renderHook(() => useAuth());
+    await act(async () => {});
+    expect(result.current.user?.uid).toBe('1');
+    expect(result.current.user?.role).toBe(USER_ROLES.ADMIN);
+  });
+});

--- a/src/app/(app)/admin/metrics/page.tsx
+++ b/src/app/(app)/admin/metrics/page.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { checkUserRole } from '@/services/authRole';
+import { USER_ROLES } from '@/constants/roles';
 import {
   getTotalPatients,
   getSessionsThisMonth,
@@ -60,7 +61,7 @@ export default function AdminMetricsPage() {
   });
 
   useEffect(() => {
-    checkUserRole('Admin').then((ok) => {
+    checkUserRole(USER_ROLES.ADMIN).then((ok) => {
       if (!ok) router.replace('/');
     });
 

--- a/src/app/(app)/admin/roles/page.tsx
+++ b/src/app/(app)/admin/roles/page.tsx
@@ -13,16 +13,17 @@ import {
 } from '@/components/ui/select';
 import { useRouter } from 'next/navigation';
 import { checkUserRole } from '@/services/authRole';
+import { USER_ROLES, type UserRole } from '@/constants/roles';
 import { getAuth } from 'firebase/auth';
 
 export default function ManageRolesPage() {
   const router = useRouter();
   const [uid, setUid] = useState('');
-  const [role, setRole] = useState('Psychologist');
+  const [role, setRole] = useState<UserRole>(USER_ROLES.PSYCHOLOGIST);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    checkUserRole('Admin').then((ok) => {
+    checkUserRole(USER_ROLES.ADMIN).then((ok) => {
       if (!ok) router.replace('/');
     });
   }, [router]);
@@ -70,8 +71,8 @@ export default function ManageRolesPage() {
               <SelectValue placeholder="Papel" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="Admin">Administrador</SelectItem>
-              <SelectItem value="Psychologist">Psicólogo(a)</SelectItem>
+              <SelectItem value={USER_ROLES.ADMIN}>Administrador</SelectItem>
+              <SelectItem value={USER_ROLES.PSYCHOLOGIST}>Psicólogo(a)</SelectItem>
               <SelectItem value="Secretary">Secretário(a)</SelectItem>
             </SelectContent>
           </Select>

--- a/src/app/(app)/analytics/page.tsx
+++ b/src/app/(app)/analytics/page.tsx
@@ -33,6 +33,7 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import useAuth from '@/hooks/use-auth';
 import { checkUserRole } from '@/services/authRole';
+import { USER_ROLES, type UserRole } from '@/constants/roles';
 import { getTotalPatients, getSessionsThisMonth } from '@/services/metricsService';
 
 // --- Dynamic Component Imports ---
@@ -131,7 +132,7 @@ const getOccupancyBadgeVariant = (
 export default function AnalyticsHubPage() {
   const router = useRouter();
   const { user } = useAuth();
-  const userRole = user?.role as 'Admin' | 'Psychologist' | undefined;
+  const userRole = user?.role as UserRole | undefined;
 
   const [overallStats, setOverallStats] = useState<OverallStats>({
     activePatients: 0,
@@ -141,7 +142,7 @@ export default function AnalyticsHubPage() {
 
   useEffect(() => {
     // 1. Check user role for route protection
-    checkUserRole(['Admin', 'Psychologist']).then((isAuthorized) => {
+    checkUserRole([USER_ROLES.ADMIN, USER_ROLES.PSYCHOLOGIST]).then((isAuthorized) => {
       if (!isAuthorized) {
         router.replace('/');
       }
@@ -178,8 +179,8 @@ export default function AnalyticsHubPage() {
           <TabsTrigger value="clinicPerformance">Desempenho Clínica</TabsTrigger>
           <TabsTrigger value="clinicalAnalysis">Análise Clínica</TabsTrigger>
           <TabsTrigger value="platformUsage">Uso da Plataforma</TabsTrigger>
-          {userRole === 'Admin' && <TabsTrigger value="financial">Financeiro</TabsTrigger>}
-          {userRole === 'Psychologist' && (
+          {userRole === USER_ROLES.ADMIN && <TabsTrigger value="financial">Financeiro</TabsTrigger>}
+          {userRole === USER_ROLES.PSYCHOLOGIST && (
             <TabsTrigger value="myMetrics">Minhas Métricas</TabsTrigger>
           )}
         </TabsList>
@@ -256,7 +257,7 @@ export default function AnalyticsHubPage() {
 
         {/* Aba: Desempenho da Clínica */}
         <TabsContent value="clinicPerformance" className="mt-6 space-y-6">
-          {userRole === 'Admin' && (
+          {userRole === USER_ROLES.ADMIN && (
             <Card>
               <CardHeader>
                 <CardTitle className="font-headline text-xl flex items-center">
@@ -460,7 +461,7 @@ export default function AnalyticsHubPage() {
         </TabsContent>
 
         {/* Aba: Financeiro (Admin) */}
-        {userRole === 'Admin' && (
+        {userRole === USER_ROLES.ADMIN && (
           <TabsContent value="financial" className="mt-6 space-y-6">
             <Card>
               <CardHeader>
@@ -486,7 +487,7 @@ export default function AnalyticsHubPage() {
         )}
 
         {/* Aba: Minhas Métricas (Psicólogo) */}
-        {userRole === 'Psychologist' && (
+        {userRole === USER_ROLES.PSYCHOLOGIST && (
           <TabsContent value="myMetrics" className="mt-6 space-y-6">
             <Card>
               <CardHeader>

--- a/src/app/(app)/groups/[id]/page.tsx
+++ b/src/app/(app)/groups/[id]/page.tsx
@@ -28,12 +28,12 @@ import {
   Link as LinkIcon,
 } from 'lucide-react';
 import Link from 'next/link';
-import { useParams, useRouter } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { mockTherapeuticGroups } from '@/app/(app)/groups/page';
 import RequireRole from '@/components/RequireRole';
+import { USER_ROLES } from '@/constants/roles';
 import { format, parseISO } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
-import { Badge } from '@/components/ui/badge';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -58,8 +58,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
-import { Separator } from '@/components/ui/separator';
-import type { Participant, GroupResource, Group } from '@/types/group';
+import type { GroupResource, Group } from '@/types/group';
 
 const getInitials = (name: string) => {
   const names = name.split(' ');
@@ -178,7 +177,7 @@ export default function GroupDetailPage({ params }: { params: { id: string } }) 
         <Button variant="outline" size="sm" onClick={() => router.back()} className="mb-4 sm:mb-0">
           <ArrowLeft className="mr-2 h-4 w-4" /> Voltar
         </Button>
-        <RequireRole role="Admin">
+        <RequireRole role={USER_ROLES.ADMIN}>
           <div className="flex gap-2">
             <Button variant="outline" asChild>
               <Link
@@ -288,7 +287,7 @@ export default function GroupDetailPage({ params }: { params: { id: string } }) 
           )}
         </CardContent>
         <CardFooter>
-          <RequireRole role="Admin">
+          <RequireRole role={USER_ROLES.ADMIN}>
             <Button variant="outline" asChild>
               <Link
                 href={`/groups/edit/${currentGroup.id}?tab=participants`}
@@ -316,7 +315,7 @@ export default function GroupDetailPage({ params }: { params: { id: string } }) 
           </div>
         </CardContent>
         <CardFooter>
-          <RequireRole role="Admin">
+          <RequireRole role={USER_ROLES.ADMIN}>
             <Button variant="outline" asChild>
               <Link
                 href={`/groups/edit/${currentGroup.id}?tab=details`}
@@ -346,7 +345,7 @@ export default function GroupDetailPage({ params }: { params: { id: string } }) 
           </div>
         </CardContent>
         <CardFooter>
-          <RequireRole role="Admin">
+          <RequireRole role={USER_ROLES.ADMIN}>
             <Button variant="outline" asChild>
               <Link
                 href={`/groups/edit/${currentGroup.id}?tab=agenda`}
@@ -371,7 +370,7 @@ export default function GroupDetailPage({ params }: { params: { id: string } }) 
             </CardDescription>
           </div>
           <Dialog open={isAddResourceDialogOpen} onOpenChange={setIsAddResourceDialogOpen}>
-            <RequireRole role="Admin">
+            <RequireRole role={USER_ROLES.ADMIN}>
               <DialogTrigger asChild>
                 <Button
                   variant="outline"
@@ -490,7 +489,7 @@ export default function GroupDetailPage({ params }: { params: { id: string } }) 
                           <Download className="mr-1.5 h-3.5 w-3.5" /> Download
                         </Button>
                       )}
-                      <RequireRole role="Admin">
+                      <RequireRole role={USER_ROLES.ADMIN}>
                         <Button
                           variant="ghost"
                           size="icon"

--- a/src/app/(app)/groups/page.tsx
+++ b/src/app/(app)/groups/page.tsx
@@ -34,6 +34,7 @@ import { ptBR } from 'date-fns/locale';
 import type { GroupRecord } from '@/services/groupService';
 import { fetchGroups } from '@/services/groupService';
 import RequireRole from '@/components/RequireRole';
+import { USER_ROLES } from '@/constants/roles';
 
 export default function TherapeuticGroupsPage() {
   const [groups, setGroups] = useState<GroupRecord[]>([]);
@@ -64,7 +65,7 @@ export default function TherapeuticGroupsPage() {
           <Users className="h-7 w-7 text-primary" />
           <h1 className="text-3xl font-headline font-bold">Grupos Terapêuticos</h1>
         </div>
-        <RequireRole role="Admin">
+        <RequireRole role={USER_ROLES.ADMIN}>
           <Button variant="primary" asChild>
             <Link href="/groups/new" className="inline-flex items-center gap-2">
               <PlusCircle className="h-4 w-4" />
@@ -146,7 +147,7 @@ export default function TherapeuticGroupsPage() {
                                 </span>
                               </Link>
                             </DropdownMenuItem>
-                            <RequireRole role="Admin">
+                            <RequireRole role={USER_ROLES.ADMIN}>
                               <DropdownMenuItem asChild>
                                 <Link href={`/groups/edit/${group.id}`}>
                                   <span className="inline-flex items-center gap-2">
@@ -174,7 +175,7 @@ export default function TherapeuticGroupsPage() {
                 Nenhum grupo terapêutico encontrado
               </h3>
               <p className="mt-1 text-sm text-muted-foreground">Comece criando um novo grupo.</p>
-              <RequireRole role="Admin">
+              <RequireRole role={USER_ROLES.ADMIN}>
                 <Button
                   asChild
                   className="mt-4 bg-accent hover:bg-accent/90 text-accent-foreground"

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import ErrorBoundary from '@/components/layout/error-boundary';
 import { useRouter, usePathname } from 'next/navigation';
 import { checkUserRole } from '@/services/authRole';
+import { USER_ROLES } from '@/constants/roles';
 
 interface AppLayoutProps {
   children: React.ReactNode;
@@ -15,7 +16,7 @@ export default function AppLayout({ children }: AppLayoutProps) {
   const [authorized, setAuthorized] = useState(false);
 
   useEffect(() => {
-    checkUserRole(['Admin', 'Psychologist', 'Secretary']).then((ok) => {
+    checkUserRole([USER_ROLES.ADMIN, USER_ROLES.PSYCHOLOGIST, 'Secretary']).then((ok) => {
       if (!ok) {
         router.replace('/');
       } else {

--- a/src/app/(app)/patients/page.tsx
+++ b/src/app/(app)/patients/page.tsx
@@ -1,22 +1,22 @@
+'use client';
 
-"use client";
-
-import { Button } from "@/components/ui/button";
+import { Button } from '@/components/ui/button';
 import * as Sentry from '@sentry/nextjs';
 import logger from '@/lib/logger';
-import { Input } from "@/components/ui/input";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
-import { UserPlus, Search, Filter, Users } from "lucide-react";
-import Link from "next/link";
-import PatientListItem from "@/components/patients/patient-list-item";
-import type { Patient } from "@/types/patient";
-import { fetchPatients } from "@/services/patientService";
-import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
-import { checkUserRole } from "@/services/authRole";
-import EmptyState from "@/components/ui/empty-state";
-import PatientListItemSkeleton from "@/components/patients/patient-list-item-skeleton";
-import { APP_ROUTES } from "@/lib/routes";
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { UserPlus, Search, Filter, Users } from 'lucide-react';
+import Link from 'next/link';
+import PatientListItem from '@/components/patients/patient-list-item';
+import type { Patient } from '@/types/patient';
+import { fetchPatients } from '@/services/patientService';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { checkUserRole } from '@/services/authRole';
+import { USER_ROLES } from '@/constants/roles';
+import EmptyState from '@/components/ui/empty-state';
+import PatientListItemSkeleton from '@/components/patients/patient-list-item-skeleton';
+import { APP_ROUTES } from '@/lib/routes';
 
 export default function PatientsPage() {
   const router = useRouter();
@@ -24,8 +24,8 @@ export default function PatientsPage() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    checkUserRole(["Admin", "Psychologist", "Secretary"]).then((ok) => {
-      if (!ok) router.replace("/");
+    checkUserRole([USER_ROLES.ADMIN, USER_ROLES.PSYCHOLOGIST, 'Secretary']).then((ok) => {
+      if (!ok) router.replace('/');
     });
 
     async function load() {

--- a/src/app/(app)/tools/audit-trail/page.tsx
+++ b/src/app/(app)/tools/audit-trail/page.tsx
@@ -25,6 +25,7 @@ import { ptBR } from 'date-fns/locale';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { checkUserRole } from '@/services/authRole';
+import { USER_ROLES } from '@/constants/roles';
 
 const mockAuditLogs = [
   {
@@ -132,7 +133,7 @@ export default function AuditTrailPage() {
   const router = useRouter();
 
   useEffect(() => {
-    checkUserRole('Admin').then((ok) => {
+    checkUserRole(USER_ROLES.ADMIN).then((ok) => {
       if (!ok) router.replace('/');
     });
   }, [router]);

--- a/src/app/(app)/tools/backup/page.tsx
+++ b/src/app/(app)/tools/backup/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { checkUserRole } from '@/services/authRole';
+import { USER_ROLES } from '@/constants/roles';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import {
@@ -88,7 +89,7 @@ export default function BackupPage() {
   const [isManualBackupRunning, setIsManualBackupRunning] = useState(false);
 
   useEffect(() => {
-    checkUserRole('Admin').then((ok) => {
+    checkUserRole(USER_ROLES.ADMIN).then((ok) => {
       if (!ok) router.replace('/');
     });
   }, [router]);

--- a/src/app/(app)/user-approvals/page.tsx
+++ b/src/app/(app)/user-approvals/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { checkUserRole } from '@/services/authRole';
+import { USER_ROLES, type UserRole } from '@/constants/roles';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import {
@@ -58,7 +59,7 @@ export default function UserApprovalsPage() {
   const { toast } = useToast();
 
   useEffect(() => {
-    checkUserRole('Admin').then((ok) => {
+    checkUserRole(USER_ROLES.ADMIN).then((ok) => {
       if (!ok) {
         router.replace('/');
         return;
@@ -139,17 +140,17 @@ export default function UserApprovalsPage() {
     }
   };
 
-  const getRoleBadge = (role: string): 'secondary' | 'outline' | 'default' => {
-    if (role === 'Psychologist') return 'secondary';
-    if (role === 'Admin') return 'default';
+  const getRoleBadge = (role: UserRole | 'Secretary'): 'secondary' | 'outline' | 'default' => {
+    if (role === USER_ROLES.PSYCHOLOGIST) return 'secondary';
+    if (role === USER_ROLES.ADMIN) return 'default';
     return 'outline';
   };
 
-  const getRoleLabel = (role: string): string => {
+  const getRoleLabel = (role: UserRole | 'Secretary'): string => {
     const roleMap: Record<string, string> = {
-      Psychologist: 'Psicólogo(a)',
+      [USER_ROLES.PSYCHOLOGIST]: 'Psicólogo(a)',
       Secretary: 'Secretário(a)',
-      Admin: 'Administrador(a)',
+      [USER_ROLES.ADMIN]: 'Administrador(a)',
     };
     return roleMap[role] || role;
   };

--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -3,6 +3,7 @@ import StatsCard from '@/components/dashboard/stats-card';
 import { Clock } from 'lucide-react';
 import { firestoreAdmin } from '@/lib/firebaseAdmin';
 import { Timestamp } from 'firebase-admin/firestore';
+import { USER_ROLES } from '@/constants/roles';
 
 export const revalidate = 60;
 
@@ -46,7 +47,7 @@ export default async function AnalyticsPage() {
   const nameMap: Record<string, string> = {};
   usersSnap.forEach((doc) => {
     const data = doc.data();
-    if (data.role === 'Psychologist') {
+    if (data.role === USER_ROLES.PSYCHOLOGIST) {
       nameMap[doc.id] = data.name || doc.id;
     }
   });

--- a/src/app/api/admin/setUserRole/route.ts
+++ b/src/app/api/admin/setUserRole/route.ts
@@ -30,6 +30,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth as adminAuth } from 'firebase-admin';
 import * as Sentry from '@sentry/nextjs';
 import logger from '@/lib/logger';
+import { USER_ROLES } from '@/constants/roles';
 
 export async function POST(request: NextRequest) {
   try {
@@ -45,12 +46,12 @@ export async function POST(request: NextRequest) {
     }
 
     const decoded = await adminAuth().verifyIdToken(token);
-    if (decoded.role !== 'Admin') {
+    if (decoded.role !== USER_ROLES.ADMIN) {
       return NextResponse.json({ error: 'Proibido' }, { status: 403 });
     }
 
     const requester = await adminAuth().getUser(decoded.uid);
-    if (requester.customClaims?.role !== 'admin') {
+    if (requester.customClaims?.role !== USER_ROLES.ADMIN) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
     }
 

--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -27,9 +27,11 @@ import { NextResponse } from 'next/server';
 import * as Sentry from '@sentry/nextjs';
 import logger from '@/lib/logger';
 import { auth as adminAuth } from 'firebase-admin';
+import { USER_ROLES } from '@/constants/roles';
 import { firestoreAdmin } from '@/lib/firebaseAdmin';
 import { writeAuditLog } from '@/services/auditLogService';
 
+// eslint-disable-next-line no-undef
 const FIREBASE_API_KEY = process.env.NEXT_PUBLIC_FIREBASE_API_KEY;
 
 export async function POST(request: Request) {
@@ -65,11 +67,12 @@ export async function POST(request: Request) {
 
     const expiresIn = 60 * 60 * 24 * 5 * 1000; // 5 days
     await adminAuth().createSessionCookie(idToken, { expiresIn });
-    const role = userRecord.customClaims?.role || 'Psychologist';
+    const role = (userRecord.customClaims?.role as string | undefined) || USER_ROLES.PSYCHOLOGIST;
     const session = { user: { uid: localId, role } };
     const response = NextResponse.json({ token: idToken });
     response.cookies.set('session', JSON.stringify(session), {
       httpOnly: true,
+      // eslint-disable-next-line no-undef
       secure: process.env.NODE_ENV === 'production',
       maxAge: expiresIn / 1000,
       path: '/',

--- a/src/app/api/signup/route.ts
+++ b/src/app/api/signup/route.ts
@@ -26,6 +26,7 @@ import { NextResponse } from 'next/server';
 import { auth as adminAuth } from 'firebase-admin';
 import * as Sentry from '@sentry/nextjs';
 import logger from '@/lib/logger';
+import { USER_ROLES } from '@/constants/roles';
 
 export async function POST(request: Request) {
   try {
@@ -36,9 +37,9 @@ export async function POST(request: Request) {
     }
 
     const user = await adminAuth().createUser({ email, password });
-    await adminAuth().setCustomUserClaims(user.uid, { role: 'psychologist' });
+    await adminAuth().setCustomUserClaims(user.uid, { role: USER_ROLES.PSYCHOLOGIST });
 
-    return NextResponse.json({ uid: user.uid, role: 'psychologist' });
+    return NextResponse.json({ uid: user.uid, role: USER_ROLES.PSYCHOLOGIST });
   } catch (e) {
     Sentry.captureException(e);
     logger.error({ action: 'signup_api_error', meta: { error: e } });

--- a/src/components/RequireRole.tsx
+++ b/src/components/RequireRole.tsx
@@ -1,9 +1,10 @@
 'use client';
 import { ReactNode, useEffect, useState } from 'react';
 import { checkUserRole } from '@/services/authRole';
+import type { UserRole } from '@/constants/roles';
 
 interface RequireRoleProps {
-  role: string | string[];
+  role: UserRole | UserRole[];
   children: ReactNode;
 }
 

--- a/src/components/layout/sidebar-nav.tsx
+++ b/src/components/layout/sidebar-nav.tsx
@@ -37,7 +37,7 @@ import {
   SidebarGroupContent,
 } from '@/components/ui/sidebar';
 import { useSidebar } from '@/components/ui/sidebar';
-import type { UserRole } from '@/services/authRole';
+import { USER_ROLES, type UserRole } from '@/constants/roles';
 
 interface NavItem {
   href: string;
@@ -135,7 +135,7 @@ interface SidebarNavProps {
   userRole?: UserRole;
 }
 
-export default function SidebarNav({ currentPath, userRole = 'Admin' }: SidebarNavProps) {
+export default function SidebarNav({ currentPath, userRole = USER_ROLES.ADMIN }: SidebarNavProps) {
   const { state } = useSidebar();
 
   const renderNavItem = (
@@ -143,7 +143,7 @@ export default function SidebarNav({ currentPath, userRole = 'Admin' }: SidebarN
     index: number,
     isSubItem: boolean = false
   ): React.ReactElement | null => {
-    if (item.adminOnly && userRole !== 'Admin') return null;
+    if (item.adminOnly && userRole !== USER_ROLES.ADMIN) return null;
 
     const IconComponent = item.icon;
     const isActive =
@@ -165,7 +165,9 @@ export default function SidebarNav({ currentPath, userRole = 'Admin' }: SidebarN
     const ButtonComponent = isSubItem ? SidebarMenuSubButton : SidebarMenuButton;
 
     if (item.subItems?.length && state === 'expanded') {
-      const visibleSubItems = item.subItems.filter((sub) => !sub.adminOnly || userRole === 'Admin');
+      const visibleSubItems = item.subItems.filter(
+        (sub) => !sub.adminOnly || userRole === USER_ROLES.ADMIN
+      );
       if (visibleSubItems.length === 0) return null;
 
       return (
@@ -228,10 +230,10 @@ export default function SidebarNav({ currentPath, userRole = 'Admin' }: SidebarN
       const groupName = item.group || 'Geral';
       if (!acc[groupName]) acc[groupName] = [];
 
-      if (!item.adminOnly || userRole === 'Admin') {
+      if (!item.adminOnly || userRole === USER_ROLES.ADMIN) {
         if (item.subItems?.length) {
           const visibleSubItems = item.subItems.filter(
-            (sub) => !sub.adminOnly || userRole === 'Admin'
+            (sub) => !sub.adminOnly || userRole === USER_ROLES.ADMIN
           );
           if (visibleSubItems.length > 0 || (item.href && item.href !== '#')) {
             acc[groupName].push(item);

--- a/src/constants/roles.ts
+++ b/src/constants/roles.ts
@@ -1,0 +1,7 @@
+export const USER_ROLES = {
+  ADMIN: 'admin',
+  PSYCHOLOGIST: 'psychologist',
+  PATIENT: 'patient',
+} as const;
+
+export type UserRole = (typeof USER_ROLES)[keyof typeof USER_ROLES];

--- a/src/services/authRole.ts
+++ b/src/services/authRole.ts
@@ -1,11 +1,9 @@
-
 'use client';
 
 import { getAuth, getIdTokenResult } from 'firebase/auth';
 import * as Sentry from '@sentry/nextjs';
 import logger from '@/lib/logger';
-
-export type UserRole = 'Admin' | 'Psychologist' | 'Secretary';
+import type { UserRole } from '@/constants/roles';
 
 export async function getCurrentUserRole(): Promise<UserRole | null> {
   const auth = getAuth();
@@ -23,7 +21,7 @@ export async function getCurrentUserRole(): Promise<UserRole | null> {
   }
 }
 
-export async function checkUserRole(required: string | string[]): Promise<boolean> {
+export async function checkUserRole(required: UserRole | UserRole[]): Promise<boolean> {
   const expectedRoles = Array.isArray(required) ? required : [required];
   const currentRole = await getCurrentUserRole();
   if (!currentRole) return false;

--- a/src/services/metricsService.ts
+++ b/src/services/metricsService.ts
@@ -9,6 +9,7 @@ import {
 import { db } from '@/lib/firebase';
 import { FIRESTORE_COLLECTIONS } from '@/lib/firestore-collections';
 import { startOfMonth, endOfMonth } from 'date-fns';
+import { USER_ROLES } from '@/constants/roles';
 
 export async function getTotalPatients(firestore: Firestore = db): Promise<number> {
   const patientsColl = collection(firestore, FIRESTORE_COLLECTIONS.PATIENTS);
@@ -38,7 +39,11 @@ export async function getSessionsThisMonth(firestore: Firestore = db): Promise<n
 
 export async function getTotalPsychologists(firestore: Firestore = db): Promise<number> {
   const usersColl = collection(firestore, FIRESTORE_COLLECTIONS.USERS);
-  const q = query(usersColl, where('role', '==', 'Psychologist'), where('isApproved', '==', true));
+  const q = query(
+    usersColl,
+    where('role', '==', USER_ROLES.PSYCHOLOGIST),
+    where('isApproved', '==', true)
+  );
   const snapshot = await getCountFromServer(q);
   return snapshot.data().count;
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,4 +1,4 @@
-export type UserGender = "masculino" | "feminino" | "outro";
+export type UserGender = 'masculino' | 'feminino' | 'outro';
 
 export interface User {
   id: string;
@@ -16,7 +16,7 @@ export interface UserProfile {
   id: string;
   name: string;
   email: string;
-  role: 'Psychologist' | 'Admin' | 'Secretary';
+  role: import('@/constants/roles').UserRole | 'Secretary';
   gender?: UserGender;
   specialty?: string;
   phone?: string;


### PR DESCRIPTION
## Summary
- add `USER_ROLES` constants and `UserRole` type
- use role constants across components, pages and API routes
- update tests to rely on new constants

## Testing
- `./run-tests.sh` *(fails: download failed, status 403)*

------
https://chatgpt.com/codex/tasks/task_e_685a226100508324930544e52194b45a