### PR TITLE
Update Firebase Admin version in functions

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@sentry/node": "^9.30.0",
-    "firebase-admin": "^11.10.1",
+    "firebase-admin": "^12.0.0",
     "firebase-functions": "^4.4.1",
     "pino": "^9.7.0"
   },


### PR DESCRIPTION
## Summary
- fix Firebase Admin version mismatch in `functions/package.json`

## Testing
- `./run-tests.sh` *(fails: npm ci requires lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685a2f37d0608324966557ce32c8fe6e