### PR TITLE
Add onboarding modal

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -5,6 +5,8 @@ import ErrorBoundary from '@/components/layout/error-boundary';
 import { useRouter, usePathname } from 'next/navigation';
 import { checkUserRole } from '@/services/authRole';
 import { USER_ROLES } from '@/constants/roles';
+import { useFirstLoginStatus } from '@/hooks/use-first-login-status';
+import { WelcomeModal } from '@/components/onboarding/welcome-modal';
 
 interface AppLayoutProps {
   children: React.ReactNode;
@@ -14,6 +16,7 @@ export default function AppLayout({ children }: AppLayoutProps) {
   const router = useRouter();
   const pathname = usePathname();
   const [authorized, setAuthorized] = useState(false);
+  const { isFirstLogin, markOnboardingAsCompleted } = useFirstLoginStatus();
 
   useEffect(() => {
     checkUserRole([USER_ROLES.ADMIN, USER_ROLES.PSYCHOLOGIST, 'Secretary']).then((ok) => {
@@ -32,6 +35,10 @@ export default function AppLayout({ children }: AppLayoutProps) {
       <main className="flex-1 p-4 md:p-6 lg:p-8">
         <ErrorBoundary>{children}</ErrorBoundary>
       </main>
+      <WelcomeModal
+        isOpen={isFirstLogin}
+        onClose={markOnboardingAsCompleted}
+      />
     </div>
   );
 }

--- a/src/components/onboarding/welcome-modal.tsx
+++ b/src/components/onboarding/welcome-modal.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
+import { CheckCircle } from 'lucide-react'
+
+interface WelcomeModalProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function WelcomeModal({ isOpen, onClose }: WelcomeModalProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Bem-vindo(a) à Plataforma!</DialogTitle>
+          <DialogDescription>
+            Aqui estão alguns passos para você começar a usar todo o nosso potencial.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 py-4">
+          <h3 className="font-semibold">Seus Primeiros Passos:</h3>
+          <ul className="space-y-2">
+            <li className="flex items-center gap-2"><CheckCircle className="h-5 w-5 text-green-500" /> Crie seu primeiro paciente</li>
+            <li className="flex items-center gap-2"><CheckCircle className="h-5 w-5 text-green-500" /> Agende uma consulta na agenda</li>
+            <li className="flex items-center gap-2"><CheckCircle className="h-5 w-5 text-green-500" /> Explore o Mapa de Formulação Clínica</li>
+          </ul>
+        </div>
+        <Button onClick={onClose} className="w-full">Começar a Usar</Button>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/hooks/use-first-login-status.ts
+++ b/src/hooks/use-first-login-status.ts
@@ -1,0 +1,23 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+const ONBOARDING_KEY = 'bhc-onboarding-completed'
+
+export function useFirstLoginStatus() {
+  const [isFirstLogin, setIsFirstLogin] = useState(false)
+
+  useEffect(() => {
+    const hasCompletedOnboarding = localStorage.getItem(ONBOARDING_KEY)
+    if (!hasCompletedOnboarding) {
+      setIsFirstLogin(true)
+    }
+  }, [])
+
+  const markOnboardingAsCompleted = () => {
+    localStorage.setItem(ONBOARDING_KEY, 'true')
+    setIsFirstLogin(false)
+  }
+
+  return { isFirstLogin, markOnboardingAsCompleted }
+}


### PR DESCRIPTION
## Summary
- create welcome modal for first login
- add hook to manage first login status
- show modal from app layout

## Testing
- `npm run lint` *(fails: eslint-plugin-storybook missing)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a31dfaa4c83248dfb4dff6668001b