### PR TITLE
Modify verifyToken to check user existence

### DIFF
--- a/src/app/api/verifyToken/route.ts
+++ b/src/app/api/verifyToken/route.ts
@@ -33,11 +33,12 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    await adminAuth().verifyIdToken(token);
+    const decodedToken = await adminAuth().verifyIdToken(token);
+    await adminAuth().getUser(decodedToken.uid);
     return NextResponse.json({ ok: true });
   } catch (err) {
     Sentry.captureException(err);
     logger.error({ action: 'verify_token_error', meta: { error: err } });
-    return NextResponse.json({ error: 'Token inválido' }, { status: 401 });
+    return NextResponse.json({ valid: false, error: 'Invalid token' }, { status: 401 });
   }
 }


### PR DESCRIPTION
## Summary
- verify user existence by calling `auth().getUser(decodedToken.uid)`
- return a consistent error response for any token errors

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a892d77048324ba54407e6fe5c3d5