### PR TITLE
Adiciona preconexões no head do layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head>
         <title>Thalamus - Plataforma de Gestão para Psicólogos</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link rel="preconnect" href="https://placehold.co" />
         {/* Removido: headLinks.map(...) */}
       </head>
       <body className="font-body antialiased"> {/* Estas classes dependem do Tailwind */}


### PR DESCRIPTION
## Summary
- adiciona `<link rel="preconnect" />` para domínios externos no layout raiz

## Testing
- `./run-tests.sh` *(falhou: `npm ci` não conseguiu instalar dependências)*

------
https://chatgpt.com/codex/tasks/task_e_685a8b3a6e6c83249262c7997abae5b1