### PR TITLE
Improve Firestore rules for patients and groups

### DIFF
--- a/__tests__/metrics.firestore.test.ts
+++ b/__tests__/metrics.firestore.test.ts
@@ -45,7 +45,7 @@ test('count patients and sessions', async () => {
   const auth = { uid: 'admin', role: USER_ROLES.ADMIN } as const;
   const db = getAuthedDb(auth);
 
-  await setDoc(doc(db, 'patients/p1'), { ownerId: 'admin', name: 'Test', email: 't@e.st' });
+  await setDoc(doc(db, 'patients/p1'), { ownerId: 'admin', psychologistId: 'admin', name: 'Test', email: 't@e.st' });
   await setDoc(doc(db, 'appointments/a1'), {
     startDate: Timestamp.fromDate(new Date()),
     status: 'Scheduled',

--- a/__tests__/patients.rules.test.ts
+++ b/__tests__/patients.rules.test.ts
@@ -39,6 +39,7 @@ describe('Patient Rules Tests', () => {
     await assertSucceeds(
       patientDoc.set({
         ownerId: auth.uid,
+        psychologistId: auth.uid,
         name: 'Test Patient',
         email: 'test@example.com',
         phoneEnc: encrypt('123', key),
@@ -52,7 +53,7 @@ describe('Patient Rules Tests', () => {
     const ownerDb = testEnv.authenticatedContext(ownerAuth.uid).firestore();
     const ownerDoc = ownerDb.collection('patients').doc('patient2');
     await assertSucceeds(
-      ownerDoc.set({ ownerId: ownerAuth.uid, name: 'Test Patient', email: 'a@b.c' })
+      ownerDoc.set({ ownerId: ownerAuth.uid, psychologistId: ownerAuth.uid, name: 'Test Patient', email: 'a@b.c' })
     );
 
     const otherAuth = { uid: 'user2' };
@@ -61,7 +62,7 @@ describe('Patient Rules Tests', () => {
 
     await assertFails(otherDoc.get());
     await assertFails(
-      otherDoc.set({ ownerId: otherAuth.uid, name: 'Should Fail', email: 'x@y.z' })
+      otherDoc.set({ ownerId: otherAuth.uid, psychologistId: otherAuth.uid, name: 'Should Fail', email: 'x@y.z' })
     );
   });
 
@@ -72,6 +73,6 @@ describe('Patient Rules Tests', () => {
       .collection('patients')
       .doc('patient3');
     await assertFails(patientDoc.get());
-    await assertFails(patientDoc.set({ ownerId: 'someone', name: 'Nope', email: 'n@o.pe' }));
+    await assertFails(patientDoc.set({ ownerId: 'someone', psychologistId: 'someone', name: 'Nope', email: 'n@o.pe' }));
   });
 });

--- a/firestore.rules
+++ b/firestore.rules
@@ -38,9 +38,10 @@ function validEncryptedField(field) {
 
 function validPatient() {
   return request.resource.data.keys().hasOnly([
-           'ownerId', 'name', 'birthdate', 'phoneEnc', 'addressEnc', 'identifierEnc', 'email', 'notes'
+           'ownerId', 'psychologistId', 'name', 'birthdate', 'phoneEnc', 'addressEnc', 'identifierEnc', 'email', 'notes'
          ]) &&
          request.resource.data.ownerId is string &&
+         request.resource.data.psychologistId is string &&
          request.resource.data.name is string &&
          request.resource.data.email is string &&
          (!('birthdate' in request.resource.data) || request.resource.data.birthdate is timestamp) &&
@@ -143,8 +144,15 @@ match /chats/{chatId} {
 
   match /patients/{id} {
     // Somente o psicólogo responsável pode criar e gerenciar seus pacientes
-    allow create: if (isPsychologist() && request.resource.data.ownerId == request.auth.uid && validPatient()) || isAdmin();
-    allow read, update, delete: if (isPsychologist() && request.auth.uid == resource.data.ownerId) || isAdmin();
+    allow create: if (isPsychologist() &&
+                     request.resource.data.ownerId == request.auth.uid &&
+                     request.resource.data.psychologistId == request.auth.uid &&
+                     validPatient()) || isAdmin();
+    allow update: if (isPsychologist() &&
+                     request.auth.uid == resource.data.ownerId &&
+                     request.resource.data.psychologistId == request.auth.uid &&
+                     validPatient()) || isAdmin();
+    allow read, delete: if (isPsychologist() && request.auth.uid == resource.data.ownerId) || isAdmin();
     allow list: if isPsychologist() || isAdmin();
   }
 
@@ -175,8 +183,12 @@ match /patients/{patientId}/clinicalTabs/{tabId} {
 
 match /groups/{id} {
   allow read: if isStaff();
-  allow create: if (isPsychologist() && request.auth.uid == request.resource.data.psychologistId) || isAdmin();
-  allow update, delete: if (isPsychologist() && request.auth.uid == resource.data.psychologistId) || isAdmin();
+  allow create: if ((isPsychologist() && request.auth.uid == request.resource.data.psychologistId) || isAdmin()) &&
+                   request.resource.data.leaderId == request.auth.uid &&
+                   request.resource.data.name is string && request.resource.data.name.size() > 0;
+  allow update, delete: if ((isPsychologist() && request.auth.uid == resource.data.psychologistId) || isAdmin()) &&
+                         request.resource.data.leaderId == request.auth.uid &&
+                         request.resource.data.name is string && request.resource.data.name.size() > 0;
 }
 
 match /tasks/{id} {

--- a/src/services/groupService.ts
+++ b/src/services/groupService.ts
@@ -77,7 +77,7 @@ export async function createGroup(
   if (!uid) throw new Error('Usuário não autenticado');
   const docRef = await addDoc(
     collection(firestore, FIRESTORE_COLLECTIONS.GROUPS),
-    { ...data, ownerId: uid },
+    { ...data, ownerId: uid, leaderId: uid },
   );
   await writeAuditLog(
     {


### PR DESCRIPTION
## Summary
- add validation for `psychologistId` in patient documents
- enforce leaderId and name checks on group writes
- update group creation service to set leaderId
- adjust tests for new rule expectations

## Testing
- `npm run lint` *(fails: require is not defined in ES module scope)*
- `npm run typecheck` *(fails: errors in src/tests/__mocks__/test-utils.ts)*
- `npm run test:all` *(fails: network access to firebase blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685a8b0c1fd0832481debb0e5890b940