### PR TITLE
Fix Firebase import path in user approvals page

### DIFF
--- a/src/app/(app)/user-approvals/page.tsx
+++ b/src/app/(app)/user-approvals/page.tsx
@@ -29,7 +29,7 @@ import {
   onSnapshot,
   Unsubscribe,
 } from 'firebase/firestore';
-import { app } from '@/services/firebase';
+import { app } from '@/lib/firebase';
 import {
   AlertDialog,
   AlertDialogAction,


### PR DESCRIPTION
## Summary
- correct the Firebase import path to use `@/lib/firebase`

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: blocked fetching browser binaries)*

------
https://chatgpt.com/codex/tasks/task_e_685a9dc9fab083248269c013718f1607